### PR TITLE
Add GHA workflow job to build docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,53 @@ jobs:
           name: crud-bench
           path: crud-bench
 
+  docker-build-amd64:
+    name: Build Docker image
+    runs-on: [ runner-amd64-large-private ]
+    needs: build
+    continue-on-error: true
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: crud-bench
+          path: target/x86_64-unknown-linux-gnu/release/crud-bench
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        run: |
+          REGION=${{ secrets.REGISTRY_AWS_REGION }}
+          REGISTRY=${{ secrets.REGISTRY_AWS_ACCOUNT_ID }}.dkr.ecr.$REGION.amazonaws.com
+          aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $REGISTRY
+          echo "registry=$REGISTRY" >> $GITHUB_OUTPUT
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=${{ secrets.REGISTRY_AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.REGISTRY_AWS_REGION }}.amazonaws.com/docker-hub/moby/buildkit:buildx-stable-1
+
+      - name: Set docker tag
+        id: image
+        run: |
+          set -x
+          DOCKER_REPO=${{ steps.login-ecr.outputs.registry }}/crud-bench
+          DOCKER_TAG=amd64-$(git rev-parse --short "$GITHUB_SHA")
+          echo "docker-repo=$DOCKER_REPO" >> $GITHUB_OUTPUT
+          echo "docker-tag=$DOCKER_TAG" >> $GITHUB_OUTPUT
+
+      - name: Build Docker image
+        run: |
+          docker build --platform linux/amd64 -t ${{ steps.image.outputs.docker-repo }}:${{ steps.image.outputs.docker-tag }} .
+
+      - name: Push image to Amazon ECR
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          docker push ${{ steps.image.outputs.docker-repo }}:${{ steps.image.outputs.docker-tag }}
+
   benchmark:
     name: Benchmark ${{ matrix.description }}
     needs: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM cgr.dev/chainguard/glibc-dynamic:latest
+
+COPY target/x86_64-unknown-linux-gnu/release/crud-bench /crud-bench
+
+ENTRYPOINT ["/crud-bench"]


### PR DESCRIPTION
👋 Can I add a GHA workflow job to build the docker image (on pull request, for image build testing) and push it (on push to main) so the ease of internal use?