### PR TITLE
Fix log level for images not found locally

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -55,7 +55,13 @@ impl DockerContainer {
 		let output = command.output().unwrap();
 		let std_out = String::from_utf8(output.stdout).unwrap().trim().to_string();
 		if !output.stderr.is_empty() {
-			error!("{}", String::from_utf8(output.stderr).unwrap());
+			let message = String::from_utf8(output.stderr).unwrap();
+			let first_line = message.lines().next().unwrap().trim();
+			if first_line.starts_with("Unable to find image") && first_line.ends_with("locally") {
+				info!("{message}");
+			} else {
+				error!("{message}");
+			}
 		}
 		assert_eq!(output.status.code(), Some(0), "Docker command failure: {command:?}");
 		std_out


### PR DESCRIPTION
Seeing a red error message for images not found locally is unnecessarily alarming since the image will just be downloaded instead. Switched it to an `info` instead.