### PR TITLE
Move endpoint to `BenchmarkEngine::setup`

### DIFF
--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -24,7 +24,7 @@ pub(crate) const NOT_SUPPORTED_ERROR: &str = "NotSupported";
 
 pub(crate) struct Benchmark {
 	/// The server endpoint to connect to
-	endpoint: Option<String>,
+	pub(crate) endpoint: Option<String>,
 	/// The timeout for connecting to the server
 	timeout: Duration,
 	/// The number of clients to spawn
@@ -150,10 +150,8 @@ impl Benchmark {
 		while time.elapsed()? < self.timeout {
 			// Wait for a small amount of time
 			tokio::time::sleep(TIMEOUT).await;
-			// Get the specified endpoint
-			let endpoint = self.endpoint.to_owned();
 			// Attempt to create a client connection
-			if let Ok(v) = engine.create_client(endpoint).await {
+			if let Ok(v) = engine.create_client().await {
 				return Ok(v);
 			}
 		}
@@ -171,10 +169,8 @@ impl Benchmark {
 		for i in 0..self.clients {
 			// Log some information
 			info!("Creating client {}", i + 1);
-			// Get the specified endpoint
-			let endpoint = self.endpoint.to_owned();
 			// Create a new client connection
-			clients.push(engine.create_client(endpoint));
+			clients.push(engine.create_client());
 		}
 		// Wait for all the clients to connect
 		Ok(try_join_all(clients).await?.into_iter().map(Arc::new).collect())

--- a/src/database.rs
+++ b/src/database.rs
@@ -91,7 +91,8 @@ impl Database {
 			Database::Dry => {
 				benchmark
 					.run::<_, DefaultDialect, _>(
-						DryClientProvider::setup(kt, vp.columns()).await?,
+						DryClientProvider::setup(kt, vp.columns(), benchmark.endpoint.as_deref())
+							.await?,
 						kp,
 						vp,
 						scans,
@@ -101,7 +102,8 @@ impl Database {
 			Database::Map => {
 				benchmark
 					.run::<_, DefaultDialect, _>(
-						MapClientProvider::setup(kt, vp.columns()).await?,
+						MapClientProvider::setup(kt, vp.columns(), benchmark.endpoint.as_deref())
+							.await?,
 						kp,
 						vp,
 						scans,
@@ -112,7 +114,12 @@ impl Database {
 			Database::Dragonfly => {
 				benchmark
 					.run::<_, DefaultDialect, _>(
-						crate::dragonfly::DragonflyClientProvider::setup(kt, vp.columns()).await?,
+						crate::dragonfly::DragonflyClientProvider::setup(
+							kt,
+							vp.columns(),
+							benchmark.endpoint.as_deref(),
+						)
+						.await?,
 						kp,
 						vp,
 						scans,
@@ -123,7 +130,12 @@ impl Database {
 			Database::Redb => {
 				benchmark
 					.run::<_, DefaultDialect, _>(
-						crate::redb::ReDBClientProvider::setup(kt, vp.columns()).await?,
+						crate::redb::ReDBClientProvider::setup(
+							kt,
+							vp.columns(),
+							benchmark.endpoint.as_deref(),
+						)
+						.await?,
 						kp,
 						vp,
 						scans,
@@ -134,7 +146,12 @@ impl Database {
 			Database::Speedb => {
 				benchmark
 					.run::<_, DefaultDialect, _>(
-						crate::speedb::SpeeDBClientProvider::setup(kt, vp.columns()).await?,
+						crate::speedb::SpeeDBClientProvider::setup(
+							kt,
+							vp.columns(),
+							benchmark.endpoint.as_deref(),
+						)
+						.await?,
 						kp,
 						vp,
 						scans,
@@ -145,7 +162,12 @@ impl Database {
 			Database::Rocksdb => {
 				benchmark
 					.run::<_, DefaultDialect, _>(
-						crate::rocksdb::RocksDBClientProvider::setup(kt, vp.columns()).await?,
+						crate::rocksdb::RocksDBClientProvider::setup(
+							kt,
+							vp.columns(),
+							benchmark.endpoint.as_deref(),
+						)
+						.await?,
 						kp,
 						vp,
 						scans,
@@ -156,7 +178,12 @@ impl Database {
 			Database::Sqlite => {
 				benchmark
 					.run::<_, DefaultDialect, _>(
-						crate::sqlite::SqliteClientProvider::setup(kt, vp.columns()).await?,
+						crate::sqlite::SqliteClientProvider::setup(
+							kt,
+							vp.columns(),
+							benchmark.endpoint.as_deref(),
+						)
+						.await?,
 						kp,
 						vp,
 						scans,
@@ -167,7 +194,12 @@ impl Database {
 			Database::Surrealkv => {
 				benchmark
 					.run::<_, DefaultDialect, _>(
-						crate::surrealkv::SurrealKVClientProvider::setup(kt, vp.columns()).await?,
+						crate::surrealkv::SurrealKVClientProvider::setup(
+							kt,
+							vp.columns(),
+							benchmark.endpoint.as_deref(),
+						)
+						.await?,
 						kp,
 						vp,
 						scans,
@@ -178,7 +210,12 @@ impl Database {
 			Database::Surrealdb => {
 				benchmark
 					.run::<_, DefaultDialect, _>(
-						crate::surrealdb::SurrealDBClientProvider::setup(kt, vp.columns()).await?,
+						crate::surrealdb::SurrealDBClientProvider::setup(
+							kt,
+							vp.columns(),
+							benchmark.endpoint.as_deref(),
+						)
+						.await?,
 						kp,
 						vp,
 						scans,
@@ -189,7 +226,12 @@ impl Database {
 			Database::SurrealdbMemory => {
 				benchmark
 					.run::<_, DefaultDialect, _>(
-						crate::surrealdb::SurrealDBClientProvider::setup(kt, vp.columns()).await?,
+						crate::surrealdb::SurrealDBClientProvider::setup(
+							kt,
+							vp.columns(),
+							benchmark.endpoint.as_deref(),
+						)
+						.await?,
 						kp,
 						vp,
 						scans,
@@ -200,7 +242,12 @@ impl Database {
 			Database::SurrealdbRocksdb => {
 				benchmark
 					.run::<_, DefaultDialect, _>(
-						crate::surrealdb::SurrealDBClientProvider::setup(kt, vp.columns()).await?,
+						crate::surrealdb::SurrealDBClientProvider::setup(
+							kt,
+							vp.columns(),
+							benchmark.endpoint.as_deref(),
+						)
+						.await?,
 						kp,
 						vp,
 						scans,
@@ -211,7 +258,12 @@ impl Database {
 			Database::SurrealdbSurrealkv => {
 				benchmark
 					.run::<_, DefaultDialect, _>(
-						crate::surrealdb::SurrealDBClientProvider::setup(kt, vp.columns()).await?,
+						crate::surrealdb::SurrealDBClientProvider::setup(
+							kt,
+							vp.columns(),
+							benchmark.endpoint.as_deref(),
+						)
+						.await?,
 						kp,
 						vp,
 						scans,
@@ -222,7 +274,12 @@ impl Database {
 			Database::Scylladb => {
 				benchmark
 					.run::<_, AnsiSqlDialect, _>(
-						crate::scylladb::ScyllaDBClientProvider::setup(kt, vp.columns()).await?,
+						crate::scylladb::ScyllaDBClientProvider::setup(
+							kt,
+							vp.columns(),
+							benchmark.endpoint.as_deref(),
+						)
+						.await?,
 						kp,
 						vp,
 						scans,
@@ -233,7 +290,12 @@ impl Database {
 			Database::Mongodb => {
 				benchmark
 					.run::<_, DefaultDialect, _>(
-						crate::mongodb::MongoDBClientProvider::setup(kt, vp.columns()).await?,
+						crate::mongodb::MongoDBClientProvider::setup(
+							kt,
+							vp.columns(),
+							benchmark.endpoint.as_deref(),
+						)
+						.await?,
 						kp,
 						vp,
 						scans,
@@ -244,7 +306,12 @@ impl Database {
 			Database::Postgres => {
 				benchmark
 					.run::<_, AnsiSqlDialect, _>(
-						crate::postgres::PostgresClientProvider::setup(kt, vp.columns()).await?,
+						crate::postgres::PostgresClientProvider::setup(
+							kt,
+							vp.columns(),
+							benchmark.endpoint.as_deref(),
+						)
+						.await?,
 						kp,
 						vp,
 						scans,
@@ -255,7 +322,12 @@ impl Database {
 			Database::Redis => {
 				benchmark
 					.run::<_, DefaultDialect, _>(
-						crate::redis::RedisClientProvider::setup(kt, vp.columns()).await?,
+						crate::redis::RedisClientProvider::setup(
+							kt,
+							vp.columns(),
+							benchmark.endpoint.as_deref(),
+						)
+						.await?,
 						kp,
 						vp,
 						scans,
@@ -266,7 +338,12 @@ impl Database {
 			Database::Keydb => {
 				benchmark
 					.run::<_, DefaultDialect, _>(
-						crate::keydb::KeydbClientProvider::setup(kt, vp.columns()).await?,
+						crate::keydb::KeydbClientProvider::setup(
+							kt,
+							vp.columns(),
+							benchmark.endpoint.as_deref(),
+						)
+						.await?,
 						kp,
 						vp,
 						scans,

--- a/src/dragonfly.rs
+++ b/src/dragonfly.rs
@@ -16,16 +16,19 @@ pub(crate) const DRAGONFLY_DOCKER_PARAMS: DockerParams = DockerParams {
 	post_args: "--requirepass root",
 };
 
-pub(crate) struct DragonflyClientProvider {}
+pub(crate) struct DragonflyClientProvider {
+	url: String,
+}
 
 impl BenchmarkEngine<DragonflyClient> for DragonflyClientProvider {
-	async fn setup(_kt: KeyType, _columns: Columns) -> Result<Self> {
-		Ok(Self {})
+	async fn setup(_kt: KeyType, _columns: Columns, endpoint: Option<&str>) -> Result<Self> {
+		Ok(Self {
+			url: endpoint.unwrap_or("redis://:root@127.0.0.1:6379/").to_owned(),
+		})
 	}
 
-	async fn create_client(&self, endpoint: Option<String>) -> Result<DragonflyClient> {
-		let url = endpoint.unwrap_or("redis://:root@127.0.0.1:6379/".to_owned());
-		let client = Client::open(url)?;
+	async fn create_client(&self) -> Result<DragonflyClient> {
+		let client = Client::open(self.url.as_str())?;
 		let conn = Mutex::new(client.get_multiplexed_async_connection().await?);
 		Ok(DragonflyClient {
 			conn,

--- a/src/dry.rs
+++ b/src/dry.rs
@@ -8,11 +8,11 @@ use std::hint::black_box;
 pub(crate) struct DryClientProvider {}
 
 impl BenchmarkEngine<DryClient> for DryClientProvider {
-	async fn setup(_kt: KeyType, _columns: Columns) -> Result<Self> {
+	async fn setup(_kt: KeyType, _columns: Columns, _endpoint: Option<&str>) -> Result<Self> {
 		Ok(Self {})
 	}
 
-	async fn create_client(&self, _endpoint: Option<String>) -> Result<DryClient> {
+	async fn create_client(&self) -> Result<DryClient> {
 		Ok(DryClient {})
 	}
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -12,8 +12,8 @@ pub(crate) trait BenchmarkEngine<C>: Sized
 where
 	C: BenchmarkClient + Send,
 {
-	async fn setup(kt: KeyType, columns: Columns) -> Result<Self>;
-	async fn create_client(&self, endpoint: Option<String>) -> Result<C>;
+	async fn setup(kt: KeyType, columns: Columns, endpoint: Option<&str>) -> Result<Self>;
+	async fn create_client(&self) -> Result<C>;
 }
 
 /// A trait for a database benchmark implementation for

--- a/src/map.rs
+++ b/src/map.rs
@@ -30,11 +30,11 @@ impl From<KeyType> for MapDatabase {
 pub(crate) struct MapClientProvider(MapDatabase);
 
 impl BenchmarkEngine<MapClient> for MapClientProvider {
-	async fn setup(kt: KeyType, _columns: Columns) -> Result<Self> {
+	async fn setup(kt: KeyType, _columns: Columns, _endpoint: Option<&str>) -> Result<Self> {
 		Ok(Self(kt.into()))
 	}
 
-	async fn create_client(&self, _: Option<String>) -> Result<MapClient> {
+	async fn create_client(&self) -> Result<MapClient> {
 		Ok(MapClient(self.0.clone()))
 	}
 }

--- a/src/redb.rs
+++ b/src/redb.rs
@@ -13,14 +13,14 @@ const TABLE: TableDefinition<&[u8], Vec<u8>> = TableDefinition::new("test");
 pub(crate) struct ReDBClientProvider(Arc<Database>);
 
 impl BenchmarkEngine<ReDBClient> for ReDBClientProvider {
-	async fn setup(_kt: KeyType, _columns: Columns) -> Result<Self> {
+	async fn setup(_kt: KeyType, _columns: Columns, _endpoint: Option<&str>) -> Result<Self> {
 		// Cleanup the data directory
 		let _ = std::fs::remove_dir_all("redb");
 		// Create the store
 		Ok(Self(Arc::new(Database::create("redb")?)))
 	}
 
-	async fn create_client(&self, _: Option<String>) -> Result<ReDBClient> {
+	async fn create_client(&self) -> Result<ReDBClient> {
 		Ok(ReDBClient(self.0.clone()))
 	}
 }

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 pub(crate) struct RocksDBClientProvider(Arc<OptimisticTransactionDB>);
 
 impl BenchmarkEngine<RocksDBClient> for RocksDBClientProvider {
-	async fn setup(_kt: KeyType, _columns: Columns) -> Result<Self> {
+	async fn setup(_kt: KeyType, _columns: Columns, _endpoint: Option<&str>) -> Result<Self> {
 		// Cleanup the data directory
 		let _ = std::fs::remove_dir_all("rocksdb");
 		// Configure custom options
@@ -62,7 +62,7 @@ impl BenchmarkEngine<RocksDBClient> for RocksDBClientProvider {
 		Ok(Self(Arc::new(OptimisticTransactionDB::open(&opts, "rocksdb")?)))
 	}
 
-	async fn create_client(&self, _: Option<String>) -> Result<RocksDBClient> {
+	async fn create_client(&self) -> Result<RocksDBClient> {
 		Ok(RocksDBClient(self.0.clone()))
 	}
 }

--- a/src/scylladb.rs
+++ b/src/scylladb.rs
@@ -19,16 +19,16 @@ pub(crate) const SCYLLADB_DOCKER_PARAMS: DockerParams = DockerParams {
 	post_args: "",
 };
 
-pub(crate) struct ScyllaDBClientProvider(KeyType, Columns);
+pub(crate) struct ScyllaDBClientProvider(KeyType, Columns, String);
 
 impl BenchmarkEngine<ScylladbClient> for ScyllaDBClientProvider {
-	async fn setup(kt: KeyType, columns: Columns) -> Result<Self> {
-		Ok(ScyllaDBClientProvider(kt, columns))
+	async fn setup(kt: KeyType, columns: Columns, endpoint: Option<&str>) -> Result<Self> {
+		let node = endpoint.unwrap_or("127.0.0.1:9042").to_owned();
+		Ok(ScyllaDBClientProvider(kt, columns, node))
 	}
 
-	async fn create_client(&self, endpoint: Option<String>) -> Result<ScylladbClient> {
-		let node = endpoint.unwrap_or("127.0.0.1:9042".to_owned());
-		let session = SessionBuilder::new().known_node(node).build().await?;
+	async fn create_client(&self) -> Result<ScylladbClient> {
+		let session = SessionBuilder::new().known_node(&self.2).build().await?;
 		Ok(ScylladbClient {
 			session,
 			kt: self.0,

--- a/src/speedb.rs
+++ b/src/speedb.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 pub(crate) struct SpeeDBClientProvider(Arc<OptimisticTransactionDB>);
 
 impl BenchmarkEngine<SpeeDBClient> for SpeeDBClientProvider {
-	async fn setup(_kt: KeyType, _columns: Columns) -> Result<Self> {
+	async fn setup(_kt: KeyType, _columns: Columns, _endpoint: Option<&str>) -> Result<Self> {
 		// Cleanup the data directory
 		let _ = std::fs::remove_dir_all("speedb");
 		// Configure custom options
@@ -61,7 +61,7 @@ impl BenchmarkEngine<SpeeDBClient> for SpeeDBClientProvider {
 		// Create the store
 		Ok(Self(Arc::new(OptimisticTransactionDB::open(&opts, "speedb")?)))
 	}
-	async fn create_client(&self, _: Option<String>) -> Result<SpeeDBClient> {
+	async fn create_client(&self) -> Result<SpeeDBClient> {
 		Ok(SpeeDBClient(self.0.clone()))
 	}
 }

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -21,7 +21,7 @@ pub(crate) struct SqliteClientProvider {
 }
 
 impl BenchmarkEngine<SqliteClient> for SqliteClientProvider {
-	async fn setup(kt: KeyType, columns: Columns) -> Result<Self> {
+	async fn setup(kt: KeyType, columns: Columns, _endpoint: Option<&str>) -> Result<Self> {
 		// Remove the database directory
 		tokio::fs::remove_dir_all(DATABASE_DIR).await.ok();
 		// Recreate the database directory
@@ -38,7 +38,7 @@ impl BenchmarkEngine<SqliteClient> for SqliteClientProvider {
 		})
 	}
 
-	async fn create_client(&self, _endpoint: Option<String>) -> Result<SqliteClient> {
+	async fn create_client(&self) -> Result<SqliteClient> {
 		Ok(SqliteClient {
 			conn: self.conn.clone(),
 			kt: self.kt,

--- a/src/surrealkv.rs
+++ b/src/surrealkv.rs
@@ -17,7 +17,7 @@ use surrealkv::Store;
 pub(crate) struct SurrealKVClientProvider(Arc<Store>);
 
 impl BenchmarkEngine<SurrealKVClient> for SurrealKVClientProvider {
-	async fn setup(_: KeyType, _columns: Columns) -> Result<Self> {
+	async fn setup(_: KeyType, _columns: Columns, _endpoint: Option<&str>) -> Result<Self> {
 		// Cleanup the data directory
 		let _ = std::fs::remove_dir_all("surrealkv");
 		// Configure custom options
@@ -32,7 +32,7 @@ impl BenchmarkEngine<SurrealKVClient> for SurrealKVClientProvider {
 		Ok(Self(Arc::new(Store::new(opts)?)))
 	}
 
-	async fn create_client(&self, _: Option<String>) -> Result<SurrealKVClient> {
+	async fn create_client(&self) -> Result<SurrealKVClient> {
 		Ok(SurrealKVClient {
 			db: self.0.clone(),
 		})


### PR DESCRIPTION
This helps reduce allocations when creating clients and it makes it easier to setup some database clients.