### PR TITLE
Do not spawn container if endpoint is specified

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -209,8 +209,6 @@ fn run(args: Args) -> Result<()> {
 				"CPUs: {} - Workers: {} - Clients: {} - Threads: {} - Samples: {} - Key: {:?} - Random: {}",
 				num_cpus::get(),
 				args.workers,
-
-
 				args.clients,
 				args.threads,
 				args.samples,


### PR DESCRIPTION
This prevented me from running `crud-bench` against all dbs not in containers, but `-d surrealdb`.

The usage is the same- you run something like:

```shell
crud-bench --database postgres --key integer --samples 10000 --random --show-sample --clients 1 --threads 1 --endpoint 'host=THE_HOST port=5432 dbname=test user=postgres password=postgres'
```

It just works now.

Previously, it failed when there was no docker setup. But the docker is unneeded because you point the endpoint to an external host.