### PR TITLE
Ensure crud-bench for remote MySQL can run multiple times

### DIFF
--- a/src/mysql.rs
+++ b/src/mysql.rs
@@ -76,7 +76,7 @@ impl BenchmarkClient for MysqlClient {
 			.collect::<Vec<String>>()
 			.join(", ");
 		let stm =
-			format!("CREATE TABLE record ( id {id_type} PRIMARY KEY, {fields}) ENGINE=InnoDB;");
+			format!("DROP TABLE IF EXISTS record; CREATE TABLE record ( id {id_type} PRIMARY KEY, {fields}) ENGINE=InnoDB;");
 		self.conn.lock().await.query_drop(&stm).await?;
 		Ok(())
 	}


### PR DESCRIPTION
One-line fix to automatically drop the test table if exists before a benchmark on MySQL starts.

Without this, `crud-bench -d mysql` on the same DB fails due to duplicate records left by the previous benchmark run.

NOTES:

- This is analogous to [how we handle cleanup-before-benchmarking in our sqlite target today](https://github.com/surrealdb/crud-bench/blob/9f2ee1cd1505c75da077a2a9c2fc656a556347fd/src/sqlite.rs#L109)
- I've verified it to work manually, by running crud-bench with the `-d mysql` multiple times against the same DB instance


