### PR TITLE
Ensure crud-bench for remote PostgreSQL can run multiple times

### DIFF
--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -78,7 +78,7 @@ impl BenchmarkClient for PostgresClient {
 			})
 			.collect::<Vec<String>>()
 			.join(", ");
-		let stm = format!("CREATE TABLE record ( id {id_type} PRIMARY KEY, {fields});");
+		let stm = format!("DROP TABLE IF EXISTS record; CREATE TABLE record ( id {id_type} PRIMARY KEY, {fields});");
 		self.client.batch_execute(&stm).await?;
 		Ok(())
 	}


### PR DESCRIPTION
One-line fix to automatically drop the test table if exists before a benchmark on PostgreSQL starts.

Without this, `crud-bench -d postgres` on the same DB fails due to duplicate records left by the previous benchmark run.

NOTES:

- This is analogous to https://github.com/surrealdb/crud-bench/pull/75
- I've manually verified it to work, by running crud-bench with the `-d postgres` multiple times against the same DB instance

