### PR TITLE
Make surrealkv cache size similar to surrealdb

### DIFF
--- a/src/surrealkv.rs
+++ b/src/surrealkv.rs
@@ -37,6 +37,8 @@ impl BenchmarkEngine<SurrealKVClient> for SurrealKVClientProvider {
 		opts.disk_persistence = true;
 		// Set the directory location
 		opts.dir = PathBuf::from(DATABASE_DIR);
+		// Set the cache size
+		opts.max_value_cache_size = 10000;
 		// Create the store
 		Ok(Self(Arc::new(Store::new(opts)?)))
 	}


### PR DESCRIPTION
Cap surrealkv `max_cache_size` to 10k elements, which is the default in surrealdb currently.