### PR TITLE
Mariadb mysql fixes and improvements

### DIFF
--- a/src/mariadb.rs
+++ b/src/mariadb.rs
@@ -443,6 +443,7 @@ impl MariadbClient {
 	}
 
 	/// Helper function to execute a statement and verify the affected rows count
+	/// Retries on deadlock errors (MySQL/MariaDB error 1213)
 	async fn exec_and_verify(
 		&self,
 		stm: String,
@@ -450,19 +451,45 @@ impl MariadbClient {
 		expected_count: usize,
 		operation: &str,
 	) -> Result<()> {
-		let mut conn = self.conn.lock().await;
-		let result = conn.exec_iter(stm, params).await?;
-		let affected = result.affected_rows();
-		drop(result);
-		if affected != expected_count as u64 {
-			return Err(anyhow::anyhow!(
-				"{}: expected {} rows affected, got {}",
-				operation,
-				expected_count,
-				affected
-			));
+		const MAX_RETRIES: u32 = 5;
+		const INITIAL_BACKOFF_MS: u64 = 10;
+
+		let mut attempt = 0;
+		loop {
+			let mut conn = self.conn.lock().await;
+			match conn.exec_iter(&stm, params.clone()).await {
+				Ok(result) => {
+					let affected = result.affected_rows();
+					drop(result);
+					drop(conn);
+
+					if affected != expected_count as u64 {
+						return Err(anyhow::anyhow!(
+							"{}: expected {} rows affected, got {}",
+							operation,
+							expected_count,
+							affected
+						));
+					}
+					return Ok(());
+				}
+				Err(e) => {
+					drop(conn);
+
+					let error_msg = e.to_string();
+					let is_deadlock = error_msg.contains("1213") || error_msg.contains("Deadlock");
+
+					if is_deadlock && attempt < MAX_RETRIES {
+						attempt += 1;
+						let backoff_ms = INITIAL_BACKOFF_MS * (1 << (attempt - 1));
+						tokio::time::sleep(tokio::time::Duration::from_millis(backoff_ms)).await;
+						continue;
+					}
+
+					return Err(e.into());
+				}
+			}
 		}
-		Ok(())
 	}
 
 	async fn batch_create<T>(&self, key_vals: Vec<(T, Value)>) -> Result<()>

--- a/src/mariadb.rs
+++ b/src/mariadb.rs
@@ -42,6 +42,7 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 		image: "mariadb",
 		pre_args: "--ulimit nofile=65536:65536 -p 127.0.0.1:3306:3306 -e MARIADB_ROOT_PASSWORD=mariadb -e MARIADB_DATABASE=bench".to_string(),
 		post_args: match options.optimised {
+			// Optimised configuration
 			true => format!(
 				"--max-connections=1024 \
 				--innodb-buffer-pool-size={buffer_pool_gb}G \
@@ -64,6 +65,10 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 				--innodb-adaptive-hash-index=ON \
 				--innodb-use-native-aio=1 \
 				--innodb-doublewrite=OFF \
+				--log-bin=mariadb-bin \
+				--binlog-format=ROW \
+				--server-id=1 \
+				--binlog-row-image=MINIMAL \
 				--sync_binlog={} \
 				--innodb-flush-log-at-trx-commit={}",
 				if options.sync {
@@ -77,8 +82,13 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 					"0"
 				}
 			),
+			// Default configuration
 			false => format!(
 				"--max-connections=1024 \
+				--log-bin=mariadb-bin \
+				--binlog-format=ROW \
+				--server-id=1 \
+				--binlog-row-image=FULL \
 				--sync_binlog={} \
 				--innodb-flush-log-at-trx-commit={}",
 				if options.sync {

--- a/src/mariadb.rs
+++ b/src/mariadb.rs
@@ -512,7 +512,6 @@ impl MariadbClient {
 								serde_json::to_string(v).unwrap().as_bytes().to_vec(),
 							),
 						});
-
 					} else {
 						return Err(anyhow::anyhow!("Missing value for column {}", name));
 					}
@@ -590,8 +589,8 @@ impl MariadbClient {
 						),
 					});
 				} else {
-						return Err(anyhow::anyhow!("Missing value for column {}", name));
-					}
+					return Err(anyhow::anyhow!("Missing value for column {}", name));
+				}
 			}
 		}
 		for (key, _) in &key_vals {

--- a/src/mysql.rs
+++ b/src/mysql.rs
@@ -64,7 +64,6 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 				--join-buffer-size=32M \
 				--tmp-table-size=1G \
 				--max-heap-table-size=1G \
-				--query-cache-size=0 \
 				--log-bin=mysql-bin \
 				--binlog-format=ROW \
 				--server-id=1 \
@@ -443,6 +442,7 @@ impl MysqlClient {
 	}
 
 	/// Helper function to execute a statement and verify the affected rows count
+	/// Retries on deadlock errors (MySQL error 1213)
 	async fn exec_and_verify(
 		&self,
 		stm: String,
@@ -450,19 +450,45 @@ impl MysqlClient {
 		expected_count: usize,
 		operation: &str,
 	) -> Result<()> {
-		let mut conn = self.conn.lock().await;
-		let result = conn.exec_iter(stm, params).await?;
-		let affected = result.affected_rows();
-		drop(result);
-		if affected != expected_count as u64 {
-			return Err(anyhow::anyhow!(
-				"{}: expected {} rows affected, got {}",
-				operation,
-				expected_count,
-				affected
-			));
+		const MAX_RETRIES: u32 = 5;
+		const INITIAL_BACKOFF_MS: u64 = 10;
+
+		let mut attempt = 0;
+		loop {
+			let mut conn = self.conn.lock().await;
+			match conn.exec_iter(&stm, params.clone()).await {
+				Ok(result) => {
+					let affected = result.affected_rows();
+					drop(result);
+					drop(conn);
+
+					if affected != expected_count as u64 {
+						return Err(anyhow::anyhow!(
+							"{}: expected {} rows affected, got {}",
+							operation,
+							expected_count,
+							affected
+						));
+					}
+					return Ok(());
+				}
+				Err(e) => {
+					drop(conn);
+
+					let error_msg = e.to_string();
+					let is_deadlock = error_msg.contains("1213") || error_msg.contains("Deadlock");
+
+					if is_deadlock && attempt < MAX_RETRIES {
+						attempt += 1;
+						let backoff_ms = INITIAL_BACKOFF_MS * (1 << (attempt - 1));
+						tokio::time::sleep(tokio::time::Duration::from_millis(backoff_ms)).await;
+						continue;
+					}
+
+					return Err(e.into());
+				}
+			}
 		}
-		Ok(())
 	}
 
 	async fn batch_create<T>(&self, key_vals: Vec<(T, Value)>) -> Result<()>

--- a/src/mysql.rs
+++ b/src/mysql.rs
@@ -64,6 +64,10 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 				--tmp-table-size=1G \
 				--max-heap-table-size=1G \
 				--query-cache-size=0 \
+				--log-bin=mysql-bin \
+				--binlog-format=ROW \
+				--server-id=1 \
+				--binlog-row-image=MINIMAL \
 				--sync_binlog={} \
 				--innodb-flush-log-at-trx-commit={}",
 				if options.sync {
@@ -80,6 +84,10 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 			// Default configuration
 			false => format!(
 				"--max-connections=1024 \
+				--log-bin=mysql-bin \
+				--binlog-format=ROW \
+				--server-id=1 \
+				--binlog-row-image=FULL \
 				--sync_binlog={} \
 				--innodb-flush-log-at-trx-commit={}",
 				if options.sync {

--- a/src/mysql.rs
+++ b/src/mysql.rs
@@ -33,6 +33,8 @@ fn calculate_mysql_memory() -> (u64, u64, u64) {
 	(buffer_pool_gb, log_file_gb, buffer_pool_instances)
 }
 
+/// Returns the Docker parameters required to run a MySQL instance for benchmarking,
+/// with configuration optimized based on the provided benchmark options.
 pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 	// Calculate memory allocation
 	let (buffer_pool_gb, log_file_gb, buffer_pool_instances) = calculate_mysql_memory();
@@ -281,7 +283,6 @@ impl BenchmarkClient for MysqlClient {
 impl MysqlClient {
 	fn consume(&self, mut row: Row) -> Result<Value> {
 		let mut val: Map<String, Value> = Map::new();
-		//
 		for (i, c) in row.columns().iter().enumerate() {
 			val.insert(
 				c.name_str().to_string(),
@@ -432,6 +433,29 @@ impl MysqlClient {
 		}
 	}
 
+	/// Helper function to execute a statement and verify the affected rows count
+	async fn exec_and_verify(
+		&self,
+		stm: String,
+		params: Vec<mysql_async::Value>,
+		expected_count: usize,
+		operation: &str,
+	) -> Result<()> {
+		let mut conn = self.conn.lock().await;
+		let result = conn.exec_iter(stm, params).await?;
+		let affected = result.affected_rows();
+		drop(result);
+		if affected != expected_count as u64 {
+			return Err(anyhow::anyhow!(
+				"{}: expected {} rows affected, got {}",
+				operation,
+				expected_count,
+				affected
+			));
+		}
+		Ok(())
+	}
+
 	async fn batch_create<T>(&self, key_vals: Vec<(T, Value)>) -> Result<()>
 	where
 		T: ToValue + Sync,
@@ -439,6 +463,7 @@ impl MysqlClient {
 		if key_vals.is_empty() {
 			return Ok(());
 		}
+		let expected_count = key_vals.len();
 		let columns = self
 			.columns
 			.0
@@ -446,7 +471,7 @@ impl MysqlClient {
 			.map(|(name, _)| MySqlDialect::escape_field(name.clone()))
 			.collect::<Vec<String>>()
 			.join(", ");
-		let placeholders = (0..key_vals.len())
+		let placeholders = (0..expected_count)
 			.map(|_| {
 				let value_placeholders =
 					(0..self.columns.0.len()).map(|_| "?").collect::<Vec<_>>().join(", ");
@@ -478,12 +503,13 @@ impl MysqlClient {
 								serde_json::to_string(v).unwrap().as_bytes().to_vec(),
 							),
 						});
+					} else {
+						return Err(anyhow::anyhow!("Missing value for column {}", name));
 					}
 				}
 			}
 		}
-		let _: Vec<Row> = self.conn.lock().await.exec(stm, params).await?;
-		Ok(())
+		self.exec_and_verify(stm, params, expected_count, "batch_create").await
 	}
 
 	async fn batch_read<T>(&self, keys: Vec<T>) -> Result<()>
@@ -497,6 +523,7 @@ impl MysqlClient {
 		let stm = format!("SELECT * FROM record WHERE id IN ({placeholders})");
 		let params: Vec<mysql_async::Value> = keys.iter().map(|k| k.to_value()).collect();
 		let res: Vec<Row> = self.conn.lock().await.exec(stm, params).await?;
+		assert_eq!(res.len(), keys.len());
 		for row in res {
 			black_box(self.consume(row).unwrap());
 		}
@@ -510,6 +537,7 @@ impl MysqlClient {
 		if key_vals.is_empty() {
 			return Ok(());
 		}
+		let expected_count = key_vals.len();
 		let columns = self
 			.columns
 			.0
@@ -531,34 +559,35 @@ impl MysqlClient {
 		for (name, _) in &self.columns.0 {
 			for (key, val) in &key_vals {
 				params.push(key.to_value());
-				if let Value::Object(map) = val
-					&& let Some(v) = map.get(name)
-				{
-					params.push(match v {
-						Value::Null => mysql_async::Value::NULL,
-						Value::Bool(b) => mysql_async::Value::Int(*b as i64),
-						Value::Number(n) => {
-							if let Some(i) = n.as_i64() {
-								mysql_async::Value::Int(i)
-							} else if let Some(f) = n.as_f64() {
-								mysql_async::Value::Double(f)
-							} else {
-								mysql_async::Value::NULL
+				if let Value::Object(map) = val {
+					if let Some(v) = map.get(name) {
+						params.push(match v {
+							Value::Null => mysql_async::Value::NULL,
+							Value::Bool(b) => mysql_async::Value::Int(*b as i64),
+							Value::Number(n) => {
+								if let Some(i) = n.as_i64() {
+									mysql_async::Value::Int(i)
+								} else if let Some(f) = n.as_f64() {
+									mysql_async::Value::Double(f)
+								} else {
+									mysql_async::Value::NULL
+								}
 							}
-						}
-						Value::String(s) => mysql_async::Value::Bytes(s.as_bytes().to_vec()),
-						Value::Array(_) | Value::Object(_) => mysql_async::Value::Bytes(
-							serde_json::to_string(v).unwrap().as_bytes().to_vec(),
-						),
-					});
+							Value::String(s) => mysql_async::Value::Bytes(s.as_bytes().to_vec()),
+							Value::Array(_) | Value::Object(_) => mysql_async::Value::Bytes(
+								serde_json::to_string(v).unwrap().as_bytes().to_vec(),
+							),
+						});
+					} else {
+						return Err(anyhow::anyhow!("Missing value for column {}", name));
+					}
 				}
 			}
 		}
 		for (key, _) in &key_vals {
 			params.push(key.to_value());
 		}
-		let _: Vec<Row> = self.conn.lock().await.exec(stm, params).await?;
-		Ok(())
+		self.exec_and_verify(stm, params, expected_count, "batch_update").await
 	}
 
 	async fn batch_delete<T>(&self, keys: Vec<T>) -> Result<()>
@@ -568,10 +597,10 @@ impl MysqlClient {
 		if keys.is_empty() {
 			return Ok(());
 		}
+		let expected_count = keys.len();
 		let placeholders = keys.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
 		let stm = format!("DELETE FROM record WHERE id IN ({placeholders})");
 		let params: Vec<mysql_async::Value> = keys.iter().map(|k| k.to_value()).collect();
-		let _: Vec<Row> = self.conn.lock().await.exec(stm, params).await?;
-		Ok(())
+		self.exec_and_verify(stm, params, expected_count, "batch_delete").await
 	}
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the benchmarking support for MySQL and MariaDB backends. The main changes include enhanced Docker configurations for both databases, robust error handling and verification for batch operations, and stricter correctness checks to ensure expected results.

**Database Docker configuration enhancements:**

- Both `mysql` and `mariadb` Docker configurations now enable binary logging, set the binlog format to `ROW`, specify a `server-id`, and adjust `binlog-row-image` based on whether the configuration is optimized or default (MINIMAL for optimized, FULL for default). This ensures consistency and enables replication-related features. [[1]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecL64-R70) [[2]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecR87-R90) [[3]](diffhunk://#diff-34c20de6cfe746bbd8ccde8b122869b0b814101dd175fa08e8c87762448f8e42R68-R71) [[4]](diffhunk://#diff-34c20de6cfe746bbd8ccde8b122869b0b814101dd175fa08e8c87762448f8e42R85-R91)
- For MySQL, the Docker configuration now uses `innodb-redo-log-capacity` instead of the deprecated `innodb-log-file-size`, aligning with changes in MySQL 8.0.30+. [[1]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecL28-R41) [[2]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecL49-R52)

**Batch operation correctness and error handling:**

- Introduced a helper method `exec_and_verify` for both `MysqlClient` and `MariadbClient` to execute statements, verify the number of affected rows, and automatically retry on deadlock errors (error 1213), improving reliability of batch operations. [[1]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecR444-R509) [[2]](diffhunk://#diff-34c20de6cfe746bbd8ccde8b122869b0b814101dd175fa08e8c87762448f8e42R445-R510)
- Batch create, update, and delete methods now use `exec_and_verify` to ensure the expected number of rows are affected, and return errors if not. [[1]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecR541-R547) [[2]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecR575) [[3]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecR616-R625) [[4]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecR635-R639) [[5]](diffhunk://#diff-34c20de6cfe746bbd8ccde8b122869b0b814101dd175fa08e8c87762448f8e42R542-R548) [[6]](diffhunk://#diff-34c20de6cfe746bbd8ccde8b122869b0b814101dd175fa08e8c87762448f8e42R576) [[7]](diffhunk://#diff-34c20de6cfe746bbd8ccde8b122869b0b814101dd175fa08e8c87762448f8e42R618-R626) [[8]](diffhunk://#diff-34c20de6cfe746bbd8ccde8b122869b0b814101dd175fa08e8c87762448f8e42R636-R640)
- Batch methods now check for missing values for required columns and return errors if any are missing, preventing silent data inconsistencies. [[1]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecR541-R547) [[2]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecL534-R598) [[3]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecR616-R625) [[4]](diffhunk://#diff-34c20de6cfe746bbd8ccde8b122869b0b814101dd175fa08e8c87762448f8e42R542-R548) [[5]](diffhunk://#diff-34c20de6cfe746bbd8ccde8b122869b0b814101dd175fa08e8c87762448f8e42R618-R626)

**Correctness checks in batch reads:**

- Batch read methods now assert that the number of rows returned matches the number of keys requested, ensuring data consistency and surfacing unexpected issues early. [[1]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecR561) [[2]](diffhunk://#diff-34c20de6cfe746bbd8ccde8b122869b0b814101dd175fa08e8c87762448f8e42R562)

These changes collectively improve the reliability, correctness, and observability of the benchmarking framework for MySQL and MariaDB backends.

**References:**
- [[1]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecL64-R70) [[2]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecR87-R90) [[3]](diffhunk://#diff-34c20de6cfe746bbd8ccde8b122869b0b814101dd175fa08e8c87762448f8e42R68-R71) [[4]](diffhunk://#diff-34c20de6cfe746bbd8ccde8b122869b0b814101dd175fa08e8c87762448f8e42R85-R91) [[5]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecL28-R41) [[6]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecL49-R52) [[7]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecR444-R509) [[8]](diffhunk://#diff-34c20de6cfe746bbd8ccde8b122869b0b814101dd175fa08e8c87762448f8e42R445-R510) [[9]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecR541-R547) [[10]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecR575) [[11]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecR616-R625) [[12]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecR635-R639) [[13]](diffhunk://#diff-34c20de6cfe746bbd8ccde8b122869b0b814101dd175fa08e8c87762448f8e42R542-R548) [[14]](diffhunk://#diff-34c20de6cfe746bbd8ccde8b122869b0b814101dd175fa08e8c87762448f8e42R576) [[15]](diffhunk://#diff-34c20de6cfe746bbd8ccde8b122869b0b814101dd175fa08e8c87762448f8e42R618-R626) [[16]](diffhunk://#diff-34c20de6cfe746bbd8ccde8b122869b0b814101dd175fa08e8c87762448f8e42R636-R640) [[17]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecL534-R598) [[18]](diffhunk://#diff-b4dc5660e96c73b517fa71722ddda0199f679ec9c9d0cfa60f45334a4fc34cecR561) [[19]](diffhunk://#diff-34c20de6cfe746bbd8ccde8b122869b0b814101dd175fa08e8c87762448f8e42R562)