### PR TITLE
Unify SurrealDB benchmark target and endpoints, and fix sync mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,19 @@ jobs:
           {"name":"batch_update_1000","operation":"UPDATE","batch_size":1000,"samples":100},
           {"name":"batch_delete_1000","operation":"DELETE","batch_size":1000,"samples":100}
         ]
+      CRUD_BENCH_SCANS: >-
+        [
+          {"name":"count_all","samples":1000,"projection":"COUNT"},
+          {"name":"limit_id","samples":100,"projection":"ID","limit":100,"expect":100},
+          {"name":"limit_all","samples":100,"projection":"FULL","limit":100,"expect":100},
+          {"name":"limit_start_id","samples":100,"projection":"ID","start":5000,"limit":100,"expect":100},
+          {"name":"limit_start_all","samples":100,"projection":"FULL","start":5000,"limit":100,"expect":100},
+          {"name":"where_field_integer_eq","samples":100,"projection":"FULL","condition":{"sql":"number = 21","mysql":"number = 21","neo4j":"r.number = 21","mongodb":{"number":{"$eq":21}},"arangodb":"r.number == 21","surrealdb":"number = 21"},"index":{"fields":["number"]}},
+          {"name":"where_field_integer_gte_lte","samples":100,"projection":"FULL","condition":{"sql":"number >= 18 AND number <= 21","mysql":"number >= 18 AND number <= 21","neo4j":"r.number >= 18 AND r.number <= 21","mongodb":{"number":{"$gte":18,"$lte":21}},"arangodb":"r.number >= 18 AND r.number <= 21","surrealdb":"number >= 18 AND number <= 21"},"index":{"fields":["number"]}},
+          {"name":"where_field_fulltext_single","samples":100,"projection":"FULL","limit":1000,"condition":{"sql":"to_tsvector('english', words) @@ to_tsquery('english', 'hello')","mysql":"MATCH(words) AGAINST('hello' IN NATURAL LANGUAGE MODE)","neo4j":"hello","mongodb":{"$text":{"$search":"hello"}},"surrealdb":"words @@ 'hello'"},"index":{"fields":["words"],"index_type":"fulltext"}},
+          {"name":"where_field_fulltext_multi_and","samples":100,"projection":"FULL","limit":1000,"condition":{"sql":"to_tsvector('english', words) @@ to_tsquery('english', 'hello & world')","mysql":"MATCH(words) AGAINST('+hello +world' IN NATURAL LANGUAGE MODE)","neo4j":"hello AND world","mongodb":{"$text":{"$search":"hello world"}},"surrealdb":"words @@ 'hello' AND words @@ 'world'"},"index":{"fields":["words"],"index_type":"fulltext"}},
+          {"name":"where_field_fulltext_multi_or","samples":100,"projection":"FULL","limit":1000,"condition":{"sql":"to_tsvector('english', words) @@ to_tsquery('english', 'foo | bar')","mysql":"MATCH(words) AGAINST('foo bar' IN NATURAL LANGUAGE MODE)","neo4j":"foo OR bar","mongodb":{"$text":{"$search":"foo bar"}},"surrealdb":"words @@ 'foo' OR words @@ 'bar'"},"index":{"fields":["words"],"index_type":"fulltext"}}
+        ]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,17 +315,20 @@ jobs:
             description: SQLite
           # SurrealDB + Memory
           - name: surrealdb-memory
-            database: surrealdb-memory
+            database: surrealdb
+            endpoint: -e server:memory
             enabled: true
             description: SurrealDB with in-memory storage
           # SurrealDB + RocksDB
           - name: surrealdb-rocksdb
-            database: surrealdb-rocksdb
+            database: surrealdb
+            endpoint: -e server:rocksdb
             enabled: true
             description: SurrealDB with RocksDB storage
           # SurrealDB + SurrealKV
           - name: surrealdb-surrealkv
-            database: surrealdb-surrealkv
+            database: surrealdb
+            endpoint: -e server:surrealkv
             enabled: false
             description: SurrealDB with SurrealKV storage
             skipped: SurrealDB with SurrealKV storage benchmark awaiting fixes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,9 +329,8 @@ jobs:
           - name: surrealdb-surrealkv
             database: surrealdb
             endpoint: -e server:surrealkv
-            enabled: false
+            enabled: true
             description: SurrealDB with SurrealKV storage
-            skipped: SurrealDB with SurrealKV storage benchmark awaiting fixes
           # SurrealDB Memory Engine
           - name: surrealdb-embedded-memory
             database: surrealdb
@@ -423,7 +422,7 @@ jobs:
           ulimit -u unlimited || true
           ulimit -l unlimited || true
 
-      - name: Run benchmarks (10,000 samples / 12 clients / 48 threads / key integer / random)
+      - name: Run benchmarks (10,000 samples / 12 clients / 4 threads / key integer / random)
         timeout-minutes: 5
         if: ${{ matrix.enabled && (success() || failure()) }}
         run: |
@@ -434,7 +433,7 @@ jobs:
           docker container prune --force &>/dev/null || true
           docker volume prune --all --force &>/dev/null || true
           # Run the benchmarks
-          ${{ github.workspace }}/artifacts/crud-bench -d ${{ matrix.database }} ${{ matrix.endpoint || '' }} -s 10000 -c 12 -t 48 -k integer -r -n integer-random
+          ${{ github.workspace }}/artifacts/crud-bench -d ${{ matrix.database }} ${{ matrix.endpoint || '' }} -s 10000 -c 12 -t 4 -k integer -r -n integer-random
           # Kill and remove any existing crud-bench container
           docker container kill crud-bench &>/dev/null || true
           docker container rm crud-bench &>/dev/null || true
@@ -445,7 +444,7 @@ jobs:
           DOCKER_PRE_ARGS: ${{ matrix.DOCKER_PRE_ARGS || '' }}
           DOCKER_POST_ARGS: ${{ matrix.DOCKER_POST_ARGS || '' }}
 
-      - name: Run benchmarks (10,000 samples / 12 clients / 48 threads / key string26 / random)
+      - name: Run benchmarks (10,000 samples / 12 clients / 4 threads / key string26 / random)
         timeout-minutes: 5
         if: ${{ matrix.enabled && (success() || failure()) }}
         run: |
@@ -456,7 +455,7 @@ jobs:
           docker container prune --force &>/dev/null || true
           docker volume prune --all --force &>/dev/null || true
           # Run the benchmarks
-          ${{ github.workspace }}/artifacts/crud-bench -d ${{ matrix.database }} ${{ matrix.endpoint || '' }} -s 10000 -c 12 -t 48 -k string26 -r -n string26-random
+          ${{ github.workspace }}/artifacts/crud-bench -d ${{ matrix.database }} ${{ matrix.endpoint || '' }} -s 10000 -c 12 -t 4 -k string26 -r -n string26-random
           # Kill and remove any existing crud-bench container
           docker container kill crud-bench &>/dev/null || true
           docker container rm crud-bench &>/dev/null || true
@@ -467,7 +466,7 @@ jobs:
           DOCKER_PRE_ARGS: ${{ matrix.DOCKER_PRE_ARGS || '' }}
           DOCKER_POST_ARGS: ${{ matrix.DOCKER_POST_ARGS || '' }}
 
-      - name: Run benchmarks (10,000 samples / 12 clients / 48 threads / key string90 / random)
+      - name: Run benchmarks (10,000 samples / 12 clients / 4 threads / key string90 / random)
         timeout-minutes: 5
         if: ${{ matrix.enabled && (success() || failure()) }}
         run: |
@@ -478,7 +477,7 @@ jobs:
           docker container prune --force &>/dev/null || true
           docker volume prune --all --force &>/dev/null || true
           # Run the benchmarks
-          ${{ github.workspace }}/artifacts/crud-bench -d ${{ matrix.database }} ${{ matrix.endpoint || '' }} -s 10000 -c 12 -t 48 -k string90 -r -n string90-random
+          ${{ github.workspace }}/artifacts/crud-bench -d ${{ matrix.database }} ${{ matrix.endpoint || '' }} -s 10000 -c 12 -t 4 -k string90 -r -n string90-random
           # Kill and remove any existing crud-bench container
           docker container kill crud-bench &>/dev/null || true
           docker container rm crud-bench &>/dev/null || true
@@ -489,7 +488,7 @@ jobs:
           DOCKER_PRE_ARGS: ${{ matrix.DOCKER_PRE_ARGS || '' }}
           DOCKER_POST_ARGS: ${{ matrix.DOCKER_POST_ARGS || '' }}
 
-      - name: Run benchmarks (10,000 samples / 12 clients / 48 threads / key string250 / random)
+      - name: Run benchmarks (10,000 samples / 12 clients / 4 threads / key string250 / random)
         timeout-minutes: 10
         if: ${{ matrix.enabled && (success() || failure()) }}
         run: |
@@ -500,7 +499,7 @@ jobs:
           docker container prune --force &>/dev/null || true
           docker volume prune --all --force &>/dev/null || true
           # Run the benchmarks
-          ${{ github.workspace }}/artifacts/crud-bench -d ${{ matrix.database }} ${{ matrix.endpoint || '' }} -s 10000 -c 12 -t 48 -k string250 -r -n string250-random
+          ${{ github.workspace }}/artifacts/crud-bench -d ${{ matrix.database }} ${{ matrix.endpoint || '' }} -s 10000 -c 12 -t 4 -k string250 -r -n string250-random
           # Kill and remove any existing crud-bench container
           docker container kill crud-bench &>/dev/null || true
           docker container rm crud-bench &>/dev/null || true
@@ -511,7 +510,7 @@ jobs:
           DOCKER_PRE_ARGS: ${{ matrix.DOCKER_PRE_ARGS || '' }}
           DOCKER_POST_ARGS: ${{ matrix.DOCKER_POST_ARGS || '' }}
 
-      - name: Run benchmarks (10,000 samples / 12 clients / 48 threads / key string506 / random)
+      - name: Run benchmarks (10,000 samples / 12 clients / 4 threads / key string506 / random)
         timeout-minutes: 10
         if: ${{ matrix.enabled && (success() || failure()) }}
         run: |
@@ -522,7 +521,7 @@ jobs:
           docker container prune --force &>/dev/null || true
           docker volume prune --all --force &>/dev/null || true
           # Run the benchmarks
-          ${{ github.workspace }}/artifacts/crud-bench -d ${{ matrix.database }} ${{ matrix.endpoint || '' }} -s 10000 -c 12 -t 48 -k string506 -r -n string506-random
+          ${{ github.workspace }}/artifacts/crud-bench -d ${{ matrix.database }} ${{ matrix.endpoint || '' }} -s 10000 -c 12 -t 4 -k string506 -r -n string506-random
           # Kill and remove any existing crud-bench container
           docker container kill crud-bench &>/dev/null || true
           docker container rm crud-bench &>/dev/null || true
@@ -533,7 +532,7 @@ jobs:
           DOCKER_PRE_ARGS: ${{ matrix.DOCKER_PRE_ARGS || '' }}
           DOCKER_POST_ARGS: ${{ matrix.DOCKER_POST_ARGS || '' }}
 
-      - name: Run benchmarks (10,000 samples / 12 clients / 48 threads / key string26 / random / 0.5KiB row and object size)
+      - name: Run benchmarks (10,000 samples / 12 clients / 4 threads / key string26 / random / 0.5KiB row and object size)
         timeout-minutes: 15
         if: ${{ matrix.enabled && (success() || failure()) }}
         run: |
@@ -544,7 +543,7 @@ jobs:
           docker container prune --force &>/dev/null || true
           docker volume prune --all --force &>/dev/null || true
           # Run the benchmarks
-          ${{ github.workspace }}/artifacts/crud-bench -d ${{ matrix.database }} ${{ matrix.endpoint || '' }} -s 10000 -c 12 -t 48 -k string26 -r -n string26-random-1k
+          ${{ github.workspace }}/artifacts/crud-bench -d ${{ matrix.database }} ${{ matrix.endpoint || '' }} -s 10000 -c 12 -t 4 -k string26 -r -n string26-random-1k
           # Kill and remove any existing crud-bench container
           docker container kill crud-bench &>/dev/null || true
           docker container rm crud-bench &>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Usage: crud-bench [OPTIONS] --database <DATABASE> --samples <SAMPLES>
 
 Options:
   -n, --name <NAME>                          An optional name for the test, used as a suffix for the JSON result file name
-  -d, --database <DATABASE>                  The database to benchmark [possible values: dry, map, arangodb, dragonfly, fjall, keydb, mdbx, lmdb, mongodb, mysql, neo4j, postgres, redb, redis, rocksdb, scylladb, slatedb, sqlite, surrealdb, surrealdb-memory, surrealdb-rocksdb, surrealdb-surrealkv, surrealkv, surrealmx]
+  -d, --database <DATABASE>                  The database to benchmark [possible values: dry, map, arangodb, dragonfly, fjall, keydb, mdbx, lmdb, mariadb, mongodb, mysql, neo4j, postgres, redb, redis, rocksdb, scylladb, slatedb, sqlite, surrealdb, surrealds, surrealkv, surrealmx]
   -i, --image <IMAGE>                        Specify a custom Docker image
   -p, --privileged                           Whether to run Docker in privileged mode
   -e, --endpoint <ENDPOINT>                  Specify a custom endpoint to connect to
@@ -457,41 +457,23 @@ SQLite is an embedded, relational, ACID-compliant, SQL-based database.
 cargo run -r -- -d sqlite -s 100000 -c 12 -t 24 -r
 ```
 
-### [SurrealDB](https://surrealdb.com) (in-memory storage engine)
+### [SurrealDB](https://surrealdb.com)
 
 ```bash
-cargo run -r -- -d surrealdb-memory -s 100000 -c 12 -t 24 -r
+cargo run -r -- -d surrealdb -s 100000 -c 12 -t 24 -r
 ```
 
-### [SurrealDB](https://surrealdb.com) (RocksDB storage engine)
+Specify a custom endpoint using `-e` or `--endpoint` to benchmark a custom deployment:
 
-```bash
-cargo run -r -- -d surrealdb-rocksdb -s 100000 -c 12 -t 24 -r
-```
-
-### [SurrealDB](https://surrealdb.com) (SurrealKV storage engine)
-
-```bash
-cargo run -r -- -d surrealdb-surrealkv -s 100000 -c 12 -t 24 -r
-```
-
-### [SurrealDB](https://surrealdb.com) embedded (in-memory storage engine)
-
-```bash
-cargo run -r -- -d surrealdb -e memory -s 100000 -c 12 -t 24 -r
-```
-
-### [SurrealDB](https://surrealdb.com) embedded (RocksDB storage engine)
-
-```bash
-cargo run -r -- -d surrealdb -e rocksdb:/tmp/db -s 100000 -c 12 -t 24 -r
-```
-
-### [SurrealDB](https://surrealdb.com) embedded (SurrealKV storage engine)
-
-```bash
-cargo run -r -- -d surrealdb -e surrealkv:/tmp/db -s 100000 -c 12 -t 24 -r
-```
+| Endpoint | Meaning |
+|----------|---------|
+| `server:memory` | Docker server with in-memory storage engine |
+| `server:rocksdb` | Docker server with RocksDB storage engine |
+| `server:surrealkv` | Docker server with SurrealKV storage engine |
+| `memory` | Embedded with in-memory storage engine. |
+| `rocksdb:<path>` (`rocksdb:/tmp/db`) | Embedded with RocksDB storage engine. |
+| `surrealkv:<path>` (`surrealkv:/tmp/db`) | Embedded with RocksDB storage engine. |
+| `ws://...`, `wss://...`, `http://...`, `https://...` | Remote server you manage yourself (no Docker started by crud-bench). |
 
 ### [SurrealKV](https://surrealkv.org)
 
@@ -527,7 +509,7 @@ cargo run -r -- -d surrealdb -e ws://127.0.0.1:8000 -s 100000 -c 12 -t 24 -r
 
 ## SurrealDB Authentication
 
-When benchmarking SurrealDB (including `surrealdb`, `surrealdb-memory`, `surrealdb-rocksdb`, `surrealdb-surrealkv`, and `surrealds`), you can configure authentication credentials using environment variables.
+When benchmarking SurrealDB (including `surrealdb`, and `surrealds`), you can configure authentication credentials using environment variables.
 
 ### Environment Variables
 
@@ -536,7 +518,7 @@ When benchmarking SurrealDB (including `surrealdb`, `surrealdb-memory`, `surreal
 
 These environment variables are used in two scenarios:
 
-1. **Docker Container Startup**: When crud-bench automatically starts a SurrealDB Docker container, it uses these credentials to configure the database server (applies to `surrealdb-memory`, `surrealdb-rocksdb`, and `surrealdb-surrealkv`)
+1. **Docker Container Startup**: When crud-bench automatically starts a SurrealDB Docker container (`-d surrealdb` with no endpoint, or with `-e server:rocksdb` / `-e server:memory` / `-e server:surrealkv`), it uses these credentials to configure the database server
 2. **Client Authentication**: When connecting to SurrealDB instances (both embedded and networked), the benchmark client uses these credentials to authenticate
 
 ### Usage Examples
@@ -544,7 +526,7 @@ These environment variables are used in two scenarios:
 **Using default credentials (root/root):**
 
 ```bash
-cargo run -r -- -d surrealdb-rocksdb -s 100000 -c 12 -t 24 -r
+cargo run -r -- -d surrealdb -s 100000 -c 12 -t 24 -r
 ```
 
 **Using custom credentials via environment variables:**
@@ -552,7 +534,7 @@ cargo run -r -- -d surrealdb-rocksdb -s 100000 -c 12 -t 24 -r
 ```bash
 export SURREALDB_USER=admin
 export SURREALDB_PASS=secure_password
-cargo run -r -- -d surrealdb-rocksdb -s 100000 -c 12 -t 24 -r
+cargo run -r -- -d surrealdb -s 100000 -c 12 -t 24 -r
 ```
 
 **One-line command with custom credentials:**

--- a/run.sh
+++ b/run.sh
@@ -127,7 +127,7 @@ EXAMPLES:
 AVAILABLE DATASTORES:
     arangodb, dragonfly, dry, fjall, keydb, lmdb, map, mdbx, mongodb,
     mysql, neo4j, postgres, redb, redis, rocksdb, sqlite,
-    surrealdb-memory, surrealdb-rocksdb, surrealdb-surrealkv,
+    surrealdb, surrealdb-memory, surrealdb-rocksdb, surrealdb-surrealkv,
     surrealdb-embedded-memory, surrealdb-embedded-rocksdb,
     surrealdb-embedded-surrealkv, surrealkv, surrealmx
 
@@ -316,9 +316,10 @@ redis|redis|networked|Redis|
 rocksdb|rocksdb|embedded|RocksDB|
 slatedb|slatedb|embedded|SlateDB|
 sqlite|sqlite|embedded|SQLite|
-surrealdb-memory|surrealdb-memory|networked|SurrealDB with in-memory storage|
-surrealdb-rocksdb|surrealdb-rocksdb|networked|SurrealDB with RocksDB storage|
-surrealdb-surrealkv|surrealdb-surrealkv|networked|SurrealDB with SurrealKV storage|
+surrealdb|surrealdb|networked|SurrealDB (server: RocksDB)|
+surrealdb-memory|surrealdb|networked|SurrealDB (server: memory)|-e server:memory
+surrealdb-rocksdb|surrealdb|networked|SurrealDB (server: RocksDB)|-e server:rocksdb
+surrealdb-surrealkv|surrealdb|networked|SurrealDB (server: SurrealKV)|-e server:surrealkv
 surrealdb-embedded-memory|surrealdb|embedded|SurrealDB embedded with in-memory storage|-e memory
 surrealdb-embedded-rocksdb|surrealdb|embedded|SurrealDB embedded with RocksDB storage|-e rocksdb:DATA_DIR
 surrealdb-embedded-surrealkv|surrealdb|embedded|SurrealDB embedded with SurrealKV storage|-e surrealkv:DATA_DIR

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -1,4 +1,3 @@
-use crate::database::Database;
 use crate::dialect::Dialect;
 use crate::engine::{BenchmarkClient, BenchmarkEngine, ScanContext};
 use crate::keyprovider::KeyProvider;
@@ -27,8 +26,6 @@ pub(crate) struct Benchmark {
 	/// Whether to run containers in privileged mode
 	pub(crate) privileged: bool,
 	/// The container image to use
-	pub(crate) database: Database,
-	/// The container image to use
 	pub(crate) image: Option<String>,
 	/// The server endpoint to connect to
 	pub(crate) endpoint: Option<String>,
@@ -51,7 +48,6 @@ impl Benchmark {
 	pub(crate) fn new(args: &Args) -> Self {
 		Self {
 			privileged: args.privileged,
-			database: args.database,
 			image: args.image.to_owned(),
 			endpoint: args.endpoint.to_owned(),
 			clients: args.clients,

--- a/src/database.rs
+++ b/src/database.rs
@@ -56,12 +56,6 @@ pub(crate) enum Database {
 	Sqlite,
 	#[cfg(feature = "surrealdb")]
 	Surrealdb,
-	#[cfg(feature = "surrealdb")]
-	SurrealdbMemory,
-	#[cfg(feature = "surrealdb")]
-	SurrealdbRocksdb,
-	#[cfg(feature = "surrealdb")]
-	SurrealdbSurrealkv,
 	#[cfg(feature = "surrealkv")]
 	Surrealkv,
 	#[cfg(feature = "surrealmx")]
@@ -79,6 +73,15 @@ pub(crate) enum Database {
 }
 
 impl Database {
+	/// Whether `start_docker` should run for this database when `endpoint` is set.
+	pub(crate) fn wants_docker(&self, endpoint: &Option<String>) -> bool {
+		match self {
+			#[cfg(feature = "surrealdb")]
+			Database::Surrealdb => crate::surrealdb::wants_docker(endpoint.as_deref()),
+			_ => endpoint.is_none(),
+		}
+	}
+
 	/// Start the Docker container if necessary
 	pub(crate) fn start_docker(&self, options: &Benchmark) -> Option<Container> {
 		// Get any pre-defined Docker configuration
@@ -104,11 +107,7 @@ impl Database {
 			#[cfg(feature = "scylladb")]
 			Self::Scylladb => crate::scylladb::docker(options),
 			#[cfg(feature = "surrealdb")]
-			Self::SurrealdbMemory => crate::surrealdb::docker(options),
-			#[cfg(feature = "surrealdb")]
-			Self::SurrealdbRocksdb => crate::surrealdb::docker(options),
-			#[cfg(feature = "surrealdb")]
-			Self::SurrealdbSurrealkv => crate::surrealdb::docker(options),
+			Self::Surrealdb => crate::surrealdb::docker(options),
 			#[allow(unreachable_patterns)]
 			_ => return None,
 		};
@@ -476,66 +475,6 @@ impl Database {
 					)
 					.await
 			}
-			#[cfg(feature = "surrealdb")]
-			Database::SurrealdbMemory => {
-				benchmark
-					.run::<_, SurrealDBDialect, _>(
-						crate::surrealdb::SurrealDBClientProvider::setup(
-							kt,
-							vp.columns(),
-							benchmark,
-						)
-						.await?,
-						kp,
-						vp,
-						scans,
-						batches,
-						database.clone(),
-						system.clone(),
-						metadata.clone(),
-					)
-					.await
-			}
-			#[cfg(feature = "surrealdb")]
-			Database::SurrealdbRocksdb => {
-				benchmark
-					.run::<_, SurrealDBDialect, _>(
-						crate::surrealdb::SurrealDBClientProvider::setup(
-							kt,
-							vp.columns(),
-							benchmark,
-						)
-						.await?,
-						kp,
-						vp,
-						scans,
-						batches,
-						database.clone(),
-						system.clone(),
-						metadata.clone(),
-					)
-					.await
-			}
-			#[cfg(feature = "surrealdb")]
-			Database::SurrealdbSurrealkv => {
-				benchmark
-					.run::<_, SurrealDBDialect, _>(
-						crate::surrealdb::SurrealDBClientProvider::setup(
-							kt,
-							vp.columns(),
-							benchmark,
-						)
-						.await?,
-						kp,
-						vp,
-						scans,
-						batches,
-						database.clone(),
-						system.clone(),
-						metadata.clone(),
-					)
-					.await
-			}
 			#[cfg(feature = "surrealkv")]
 			Database::Surrealkv => {
 				benchmark
@@ -624,12 +563,6 @@ impl Database {
 			Database::Surrealmx => "SurrealMX",
 			#[cfg(feature = "surrealdb")]
 			Database::Surrealdb => "SurrealDB",
-			#[cfg(feature = "surrealdb")]
-			Database::SurrealdbMemory => "SurrealDB (Memory)",
-			#[cfg(feature = "surrealdb")]
-			Database::SurrealdbRocksdb => "SurrealDB (RocksDB)",
-			#[cfg(feature = "surrealdb")]
-			Database::SurrealdbSurrealkv => "SurrealDB (SurrealKV)",
 			#[allow(unreachable_patterns)]
 			_ => "Unknown",
 		}

--- a/src/main.rs
+++ b/src/main.rs
@@ -290,13 +290,13 @@ fn run(args: Args) -> Result<()> {
 	}
 	// Prepare the benchmark
 	let mut benchmark = Benchmark::new(&args);
-	// If a Docker image is specified but the endpoint, spawn the container.
-	let container = if args.endpoint.is_some() {
-		// The endpoint is specified usually when you want the benchmark to run against a remote server.
-		// Not handling this results in crud-bench starting a container never used by the client and the benchmark.
-		None
-	} else {
+	// Check if we should spawn a Docker container
+	let container = if args.database.wants_docker(&args.endpoint) {
+		// Start the Docker container
 		args.database.start_docker(&benchmark)
+	} else {
+		// No Docker container needed
+		None
 	};
 	// Setup the asynchronous runtime
 	let runtime = runtime::Builder::new_multi_thread()

--- a/src/surrealdb.rs
+++ b/src/surrealdb.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "surrealdb")]
 
 use crate::benchmark::NOT_SUPPORTED_ERROR;
-use crate::database::Database;
 use crate::dialect::SurrealDBDialect;
 use crate::docker::DockerParams;
 use crate::engine::{BenchmarkClient, BenchmarkEngine, ScanContext};
@@ -21,6 +20,79 @@ use surrealdb::types::{RecordIdKey, SurrealValue, ToSql};
 use tokio::time::{sleep, timeout};
 
 const DEFAULT: &str = "ws://127.0.0.1:8000";
+
+/// Storage backend for Docker (`server:<backend>`).
+pub(crate) enum Docker {
+	Memory,
+	Rocksdb,
+	Surrealkv,
+}
+
+/// Connection mode derived from `--endpoint`.
+pub(crate) enum Endpoint {
+	/// `server:rocksdb` | `server:memory` | `server:surrealkv` (default when omitted: server:rocksdb)
+	Docker(Docker),
+	/// `rocksdb:…`, `surrealkv:…`, `memory`, `mem://`, `mem:…`
+	Embedded(String),
+	/// Remote SurrealDB (`ws` / `http` URL)
+	Remote(String),
+}
+
+/// `true` when crud-bench should start the SurrealDB Docker container.
+pub(crate) fn wants_docker(endpoint: Option<&str>) -> bool {
+	matches!(parse_endpoint(endpoint), Ok(Endpoint::Docker(_)))
+}
+
+pub(crate) fn parse_endpoint(opt: Option<&str>) -> Result<Endpoint> {
+	// If no endpoint is specified, use the default
+	let Some(raw) = opt else {
+		return Ok(Endpoint::Docker(Docker::Rocksdb));
+	};
+	// Trim whitespace from the endpoint
+	let s = raw.trim();
+	// If the endpoint is empty, use the default
+	if s.is_empty() {
+		return Ok(Endpoint::Docker(Docker::Rocksdb));
+	}
+	// If the endpoint is a remote endpoint, return it
+	if s.starts_with("ws://")
+		|| s.starts_with("wss://")
+		|| s.starts_with("http://")
+		|| s.starts_with("https://")
+	{
+		return Ok(Endpoint::Remote(s.to_string()));
+	}
+	// If the endpoint is a server backend, return it
+	if let Some(rest) = s.strip_prefix("server:") {
+		return match rest {
+			"rocksdb" => Ok(Endpoint::Docker(Docker::Rocksdb)),
+			"memory" => Ok(Endpoint::Docker(Docker::Memory)),
+			"surrealkv" => Ok(Endpoint::Docker(Docker::Surrealkv)),
+			_ => bail!(
+				"Invalid server backend {rest:?}. Expected server:rocksdb, server:memory, or server:surrealkv.",
+			),
+		};
+	}
+	// If the endpoint is a memory endpoint, return it
+	if s == "memory" {
+		return Ok(Endpoint::Embedded("mem://".to_string()));
+	}
+	// If the endpoint is a memory endpoint, return it
+	if s.starts_with("mem:") {
+		return Ok(Endpoint::Embedded(s.to_string()));
+	}
+	// If the endpoint is a rocksdb or surrealkv endpoint, return it
+	if s.starts_with("rocksdb:") || s.starts_with("surrealkv:") {
+		return Ok(Endpoint::Embedded(s.to_string()));
+	}
+	bail!(
+		"Invalid SurrealDB endpoint {:?}. Expected:\n\
+		 - server:rocksdb | server:memory | server:surrealkv (Docker)\n\
+		 - rocksdb:<path>[?args] | surrealkv:<path>[?args] | memory | mem:// | mem:<path>[?args] (embedded)\n\
+		 - ws://... | wss://... | http://... | https://... (remote)",
+		s
+	)
+}
 
 /// Calculate SurrealDB RocksDB specific memory allocation
 fn calculate_surrealdb_memory() -> u64 {
@@ -47,67 +119,54 @@ pub(super) fn surrealdb_password() -> String {
 }
 
 pub(crate) fn docker(options: &Benchmark) -> DockerParams {
+	// Parse the endpoint or use the default
+	let backend =
+		parse_endpoint(options.endpoint.as_deref()).unwrap_or(Endpoint::Docker(Docker::Rocksdb));
 	// Calculate memory allocation
 	let cache_gb = calculate_surrealdb_memory();
 	// Get credentials from environment variables or use defaults
 	let username = surrealdb_username();
 	let password = surrealdb_password();
+	// Configure the sync parameter
+	let sync = if options.sync {
+		"every"
+	} else {
+		"never"
+	};
 	// Return Docker parameters
-	match options.database {
-		Database::SurrealdbMemory => DockerParams {
+	match backend {
+		Endpoint::Embedded(_) | Endpoint::Remote(_) => {
+			unreachable!("docker() must only be called when wants_docker is true")
+		}
+		Endpoint::Docker(Docker::Memory) => DockerParams {
 			image: "surrealdb/surrealdb:nightly",
 			pre_args: "--ulimit nofile=65536:65536 -p 8000:8000 --user root".to_string(),
 			post_args: format!("start --user {username} --pass {password} memory"),
 		},
-		Database::SurrealdbRocksdb => DockerParams {
+		Endpoint::Docker(Docker::Rocksdb) => DockerParams {
 			image: "surrealdb/surrealdb:nightly",
 			pre_args: match options.optimised {
 				true => format!(
-					"--ulimit nofile=65536:65536 -p 8000:8000 -e SURREAL_SYNC_DATA={} -e SURREAL_ROCKSDB_BLOCK_CACHE_SIZE={cache_gb}GB --user root",
-					if options.sync {
-						"true"
-					} else {
-						"false"
-					}
+					"--ulimit nofile=65536:65536 -p 8000:8000 -e SURREAL_ROCKSDB_BLOCK_CACHE_SIZE={cache_gb}GB --user root",
 				),
-				false => format!(
-					"--ulimit nofile=65536:65536 -p 8000:8000 -e SURREAL_SYNC_DATA={} --user root",
-					if options.sync {
-						"true"
-					} else {
-						"false"
-					}
-				),
+				false => format!("--ulimit nofile=65536:65536 -p 8000:8000 --user root",),
 			},
 			post_args: format!(
-				"start --user {username} --pass {password} rocksdb:/data/crud-bench.db"
+				"start --user {username} --pass {password} rocksdb:/data/crud-bench.db?sync={sync}",
 			),
 		},
-		Database::SurrealdbSurrealkv => DockerParams {
+		Endpoint::Docker(Docker::Surrealkv) => DockerParams {
 			image: "surrealdb/surrealdb:nightly",
 			pre_args: match options.optimised {
 				true => format!(
-					"--ulimit nofile=65536:65536 -p 8000:8000 -e SURREAL_SYNC_DATA={} -e SURREAL_SURREALKV_MAX_VALUE_CACHE_SIZE={cache_gb}GB --user root",
-					if options.sync {
-						"true"
-					} else {
-						"false"
-					}
+					"--ulimit nofile=65536:65536 -p 8000:8000 -e SURREAL_SURREALKV_MAX_VALUE_CACHE_SIZE={cache_gb}GB --user root",
 				),
-				false => format!(
-					"--ulimit nofile=65536:65536 -p 8000:8000 -e SURREAL_SYNC_DATA={} --user root",
-					if options.sync {
-						"true"
-					} else {
-						"false"
-					}
-				),
+				false => format!("--ulimit nofile=65536:65536 -p 8000:8000 --user root",),
 			},
 			post_args: format!(
-				"start --user {username} --pass {password} surrealkv:/data/crud-bench.db"
+				"start --user {username} --pass {password} surrealkv:/data/crud-bench.db?sync={sync}",
 			),
 		},
-		_ => unreachable!(),
 	}
 }
 
@@ -133,8 +192,8 @@ pub(super) async fn initialise_db(endpoint: &str, root: Root) -> Result<Surreal<
 impl BenchmarkEngine<SurrealDBClient> for SurrealDBClientProvider {
 	/// Initiates a new datastore benchmarking engine
 	async fn setup(_: KeyType, _columns: Columns, options: &Benchmark) -> Result<Self> {
-		// Get the custom endpoint if specified
-		let endpoint = options.endpoint.as_deref().unwrap_or(DEFAULT).replace("memory", "mem://");
+		// Parse the benchmark engine endpoint
+		let mode = parse_endpoint(options.endpoint.as_deref())?;
 		// Define root user details from environment variables or use defaults
 		let username = surrealdb_username();
 		let password = surrealdb_password();
@@ -142,16 +201,28 @@ impl BenchmarkEngine<SurrealDBClient> for SurrealDBClientProvider {
 			username,
 			password,
 		};
-		// Setup the optional client
-		let client = match endpoint.split_once(':').unwrap().0 {
-			// We want to be able to create multiple connections
-			// when testing against an external server
-			"ws" | "wss" | "http" | "https" => None,
-			// When the database is embedded, create only
-			// one client to avoid sending queries to the
-			// wrong database
-			_ => Some(initialise_db(&endpoint, root.clone()).await?),
+		// Create the benchmark engine client
+		let (endpoint, client) = match mode {
+			Endpoint::Docker(_) => (DEFAULT.to_string(), None),
+			Endpoint::Remote(url) => (url, None),
+			Endpoint::Embedded(url) => {
+				// Configure the sync parameter
+				let sync = if options.sync {
+					"every"
+				} else {
+					"never"
+				};
+				// Configure the full endpoint URL
+				let full_url = if url.contains('?') {
+					format!("{url}&sync={sync}")
+				} else {
+					format!("{url}?sync={sync}")
+				};
+				let db = initialise_db(&full_url, root.clone()).await?;
+				(full_url, Some(db))
+			}
 		};
+		// Return the client provider
 		Ok(Self {
 			endpoint,
 			root,

--- a/src/surrealdb.rs
+++ b/src/surrealdb.rs
@@ -149,7 +149,7 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 				true => format!(
 					"--ulimit nofile=65536:65536 -p 8000:8000 -e SURREAL_ROCKSDB_BLOCK_CACHE_SIZE={cache_gb}GB --user root",
 				),
-				false => format!("--ulimit nofile=65536:65536 -p 8000:8000 --user root",),
+				false => "--ulimit nofile=65536:65536 -p 8000:8000 --user root".to_string(),
 			},
 			post_args: format!(
 				"start --user {username} --pass {password} rocksdb:/data/crud-bench.db?sync={sync}",
@@ -161,7 +161,7 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 				true => format!(
 					"--ulimit nofile=65536:65536 -p 8000:8000 -e SURREAL_SURREALKV_MAX_VALUE_CACHE_SIZE={cache_gb}GB --user root",
 				),
-				false => format!("--ulimit nofile=65536:65536 -p 8000:8000 --user root",),
+				false => "--ulimit nofile=65536:65536 -p 8000:8000 --user root".to_string(),
 			},
 			post_args: format!(
 				"start --user {username} --pass {password} surrealkv:/data/crud-bench.db?sync={sync}",

--- a/src/surrealdb.rs
+++ b/src/surrealdb.rs
@@ -402,10 +402,15 @@ impl BenchmarkClient for SurrealDBClient {
 						Ok(_) => return Ok(()),
 						Err(e) => {
 							let msg = e.to_string();
-							// Be permissive on the match to tolerate tiny wording changes
-							if msg.starts_with(
-								"The query was not executed due to a failed transaction.",
-							) {
+							// Be permissive on the match to tolerate tiny wording changes.
+							// We accept both the executor-level wrapper and the raw KV
+							// transaction conflict error, which surfaces directly when the
+							// failing statement is the only one in the query.
+							const RETRYABLE: &[&str] = &[
+								"This transaction can be retried",
+								"The query was not executed due to a failed transaction",
+							];
+							if RETRYABLE.iter().any(|p| msg.contains(p)) {
 								warn!("Retrying {sql} due to {msg}");
 								sleep(Duration::from_millis(500)).await;
 								continue;


### PR DESCRIPTION
- Single SurrealDB endpoint implementation with docker/embedded/remote endpoint parsing
- Ensures durable transaction writes are correctly configurable. Previously SurrealDB was always using sync writes, even when disabled in the benchmarking script.
