### PR TITLE
Add configurable per-operation timeout (--operation-timeout)

### DIFF
--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -20,21 +20,6 @@ use tokio::time::Instant;
 
 const TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Per-operation timeout enforced inside [`Benchmark::operation_loop`].
-///
-/// A single benchmark operation that fails to complete within this budget
-/// returns an error so [`try_join_all`] can short-circuit instead of
-/// parking the whole bench process forever on one stuck worker. The
-/// timeout fires per *iteration* (one create / read / scan / batch
-/// call), not per worker task.
-///
-/// Sized for the worst-case scan returning a large result set on a
-/// CPU- and memory-constrained CI runner. A workload that legitimately
-/// exceeds this should raise the constant rather than rely on the
-/// previous unbounded behaviour, which silently turned a single hung
-/// reply into an infinite hang at `try_join_all`.
-const OPERATION_TIMEOUT: Duration = Duration::from_secs(300);
-
 pub(crate) const NOT_SUPPORTED_ERROR: &str = "NotSupported";
 
 pub(crate) struct Benchmark {
@@ -58,6 +43,8 @@ pub(crate) struct Benchmark {
 	pub(crate) persisted: bool,
 	/// Whether to enable optimised configurations
 	pub(crate) optimised: bool,
+	/// Per-operation timeout
+	pub(crate) operation_timeout: Duration,
 }
 impl Benchmark {
 	pub(crate) fn new(args: &Args) -> Self {
@@ -72,6 +59,7 @@ impl Benchmark {
 			pid: args.pid,
 			persisted: args.persisted,
 			optimised: args.optimised,
+			operation_timeout: Duration::from_secs(args.operation_timeout),
 		}
 	}
 
@@ -367,6 +355,7 @@ impl Benchmark {
 				let out = out.clone();
 				let vp = vp.clone();
 				let operation = operation.clone();
+				let operation_timeout = self.operation_timeout;
 				futures.push(task::spawn(async move {
 					match Self::operation_loop::<C, D>(
 						client,
@@ -375,6 +364,7 @@ impl Benchmark {
 						&current,
 						&complete,
 						operation,
+						operation_timeout,
 						(kp, vp, out),
 					)
 					.await
@@ -427,6 +417,7 @@ impl Benchmark {
 		Ok(Some(result))
 	}
 
+	#[allow(clippy::too_many_arguments)]
 	async fn operation_loop<C, D>(
 		client: Arc<C>,
 		samples: u32,
@@ -434,6 +425,7 @@ impl Benchmark {
 		current: &AtomicU32,
 		complete: &AtomicU32,
 		operation: BenchmarkOperation,
+		operation_timeout: Duration,
 		(mut kp, mut vp, mut out): (KeyProvider, ValueProvider, Terminal),
 	) -> Result<Histogram<u64>>
 	where
@@ -460,7 +452,7 @@ impl Benchmark {
 			// short-circuits with the operation name in the error
 			// chain rather than hanging in `block_on`.
 			let time = Instant::now();
-			tokio::time::timeout(OPERATION_TIMEOUT, async {
+			tokio::time::timeout(operation_timeout, async {
 				match &operation {
 					BenchmarkOperation::Create => {
 						let value = vp.generate_value::<D>();
@@ -493,7 +485,7 @@ impl Benchmark {
 			})
 			.await
 			.with_context(|| {
-				format!("{operation} did not complete within {OPERATION_TIMEOUT:?}")
+				format!("{operation} did not complete within {operation_timeout:?}")
 			})??;
 			// Get the completed sample number
 			let sample = complete.fetch_add(1, Ordering::Relaxed);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use crate::benchmark::Benchmark;
 use crate::database::Database;
 use crate::keyprovider::KeyProvider;
 use crate::valueprovider::ValueProvider;
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 use clap::{Parser, ValueEnum};
 use docker::Container;
 use serde::{Deserialize, Serialize};
@@ -488,7 +488,7 @@ fn run(args: Args) -> Result<()> {
 
 #[cfg(test)]
 mod test {
-	use crate::{Args, Database, KeyType, run};
+	use crate::{run, Args, Database, KeyType};
 	use anyhow::Result;
 	use serial_test::serial;
 
@@ -505,6 +505,7 @@ mod test {
 			threads: 2,
 			samples: 10000,
 			sync: false,
+			operation_timeout: 300,
 			persisted: false,
 			optimised: false,
 			random,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use crate::benchmark::Benchmark;
 use crate::database::Database;
 use crate::keyprovider::KeyProvider;
 use crate::valueprovider::ValueProvider;
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use clap::{Parser, ValueEnum};
 use docker::Container;
 use serde::{Deserialize, Serialize};
@@ -488,7 +488,7 @@ fn run(args: Args) -> Result<()> {
 
 #[cfg(test)]
 mod test {
-	use crate::{run, Args, Database, KeyType};
+	use crate::{Args, Database, KeyType, run};
 	use anyhow::Result;
 	use serial_test::serial;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,10 @@ pub(crate) struct Args {
 	#[arg(long, default_value = "false")]
 	pub(crate) sync: bool,
 
+	/// Per-operation timeout in seconds
+	#[arg(long, env = "CRUD_BENCH_OPERATION_TIMEOUT", default_value = "1800", value_parser=clap::value_parser!(u64).range(1..))]
+	pub(crate) operation_timeout: u64,
+
 	/// Whether to enable disk persistence for Redis-family databases
 	#[arg(long, default_value = "false")]
 	pub(crate) persisted: bool,


### PR DESCRIPTION
Follow up #229 

Replace the hardcoded 5 minute per-iteration operation timeout with a CLI flag so workloads can be tuned without recompiling.

**Changes**
- `--operation-timeout <seconds>` on the benchmark binary (clap, minimum 1).
- Default: **1800** seconds (30 minutes).
- The value is stored on `Args`, converted to `Duration` in `Benchmark::new`, and passed into `operation_loop` for each `tokio::time::timeout` around create/read/update/scan/index/batch calls.

**Rationale**
Per-iteration timeouts prevent a single stuck worker from blocking `try_join_all` indefinitely; making this configurable supports slow CI or large scans while keeping a safe default.