### PR TITLE
feat: batch CRUD benchmarks and SurrealDB bulk queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4399,6 +4399,7 @@ dependencies = [
  "rustls-native-certs 0.7.3",
  "rustls-pemfile",
  "serde",
+ "serde_json",
  "thiserror 1.0.69",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ mysql_async = { version = "0.36.2", default-features = false, features = [
     "rust_decimal",
     "time",
 ], optional = true }
-neo4rs = { version = "0.8.0", optional = true }
+neo4rs = { version = "0.8.0", optional = true, features = ["json"] }
 num_cpus = "1.17.0"
 pprof = { version = "0.15.0", features = ["flamegraph", "prost-codec"] }
 rand = "0.10.1"

--- a/src/arangodb.rs
+++ b/src/arangodb.rs
@@ -7,11 +7,12 @@ use crate::engine::{BenchmarkClient, BenchmarkEngine, ScanContext};
 use crate::valueprovider::Columns;
 use crate::{Benchmark, KeyType, Projection, Scan};
 use anyhow::{Result, bail};
+use arangors::aql::AqlQuery;
 use arangors::client::reqwest::ReqwestClient;
 use arangors::document::options::InsertOptions;
 use arangors::document::options::RemoveOptions;
 use arangors::{Collection, Connection, Database, GenericConnection};
-use serde_json::Value;
+use serde_json::{Value, json};
 use std::hint::black_box;
 use std::time::Duration;
 use tokio::sync::Mutex;
@@ -169,9 +170,151 @@ impl BenchmarkClient for ArangoDBClient {
 			_ => self.scan(scan).await,
 		}
 	}
+
+	async fn batch_create_u32(
+		&self,
+		key_vals: impl Iterator<Item = (u32, Value)> + Send,
+	) -> Result<()> {
+		match self.keytype {
+			KeyType::String506 => bail!(NOT_SUPPORTED_ERROR),
+			_ => {
+				let pairs = key_vals.map(|(k, v)| (k.to_string(), v)).collect::<Vec<_>>();
+				self.batch_create_pairs(pairs).await
+			}
+		}
+	}
+
+	async fn batch_create_string(
+		&self,
+		key_vals: impl Iterator<Item = (String, Value)> + Send,
+	) -> Result<()> {
+		match self.keytype {
+			KeyType::String506 => bail!(NOT_SUPPORTED_ERROR),
+			_ => self.batch_create_pairs(key_vals.collect()).await,
+		}
+	}
+
+	async fn batch_read_u32(&self, keys: impl Iterator<Item = u32> + Send) -> Result<()> {
+		match self.keytype {
+			KeyType::String506 => bail!(NOT_SUPPORTED_ERROR),
+			_ => {
+				let ks = keys.map(|k| k.to_string()).collect::<Vec<_>>();
+				self.batch_read_keys(ks).await
+			}
+		}
+	}
+
+	async fn batch_read_string(&self, keys: impl Iterator<Item = String> + Send) -> Result<()> {
+		match self.keytype {
+			KeyType::String506 => bail!(NOT_SUPPORTED_ERROR),
+			_ => self.batch_read_keys(keys.collect()).await,
+		}
+	}
+
+	async fn batch_update_u32(
+		&self,
+		key_vals: impl Iterator<Item = (u32, Value)> + Send,
+	) -> Result<()> {
+		match self.keytype {
+			KeyType::String506 => bail!(NOT_SUPPORTED_ERROR),
+			_ => {
+				let pairs = key_vals.map(|(k, v)| (k.to_string(), v)).collect::<Vec<_>>();
+				self.batch_update_pairs(pairs).await
+			}
+		}
+	}
+
+	async fn batch_update_string(
+		&self,
+		key_vals: impl Iterator<Item = (String, Value)> + Send,
+	) -> Result<()> {
+		match self.keytype {
+			KeyType::String506 => bail!(NOT_SUPPORTED_ERROR),
+			_ => self.batch_update_pairs(key_vals.collect()).await,
+		}
+	}
+
+	async fn batch_delete_u32(&self, keys: impl Iterator<Item = u32> + Send) -> Result<()> {
+		match self.keytype {
+			KeyType::String506 => bail!(NOT_SUPPORTED_ERROR),
+			_ => {
+				let ks = keys.map(|k| k.to_string()).collect::<Vec<_>>();
+				self.batch_delete_keys(ks).await
+			}
+		}
+	}
+
+	async fn batch_delete_string(&self, keys: impl Iterator<Item = String> + Send) -> Result<()> {
+		match self.keytype {
+			KeyType::String506 => bail!(NOT_SUPPORTED_ERROR),
+			_ => self.batch_delete_keys(keys.collect()).await,
+		}
+	}
 }
 
 impl ArangoDBClient {
+	async fn batch_create_pairs(&self, pairs: Vec<(String, Value)>) -> Result<()> {
+		if pairs.is_empty() {
+			return Ok(());
+		}
+		let docs: Vec<Value> =
+			pairs.into_iter().map(|(k, v)| Self::to_doc(k, v)).collect::<Result<Vec<_>>>()?;
+		let aql = AqlQuery::builder()
+			.query(
+				"FOR doc IN @docs INSERT doc INTO record OPTIONS { waitForSync: @sync } RETURN 1",
+			)
+			.bind_var("docs", Value::Array(docs))
+			.bind_var("sync", json!(self.sync))
+			.build();
+		let _: Vec<Value> = self.database.lock().await.aql_query(aql).await?;
+		Ok(())
+	}
+
+	async fn batch_read_keys(&self, keys: Vec<String>) -> Result<()> {
+		if keys.is_empty() {
+			return Ok(());
+		}
+		let aql = AqlQuery::builder()
+			.query("FOR k IN @keys LET d = DOCUMENT('record', k) FILTER d != null RETURN d")
+			.bind_var("keys", Value::Array(keys.into_iter().map(Value::String).collect()))
+			.build();
+		let res: Vec<Value> = self.database.lock().await.aql_query(aql).await?;
+		assert!(!res.is_empty());
+		Ok(())
+	}
+
+	async fn batch_update_pairs(&self, pairs: Vec<(String, Value)>) -> Result<()> {
+		if pairs.is_empty() {
+			return Ok(());
+		}
+		let docs: Vec<Value> =
+			pairs.into_iter().map(|(k, v)| Self::to_doc(k, v)).collect::<Result<Vec<_>>>()?;
+		let aql = AqlQuery::builder()
+			.query(
+				r#"FOR doc IN @docs INSERT doc INTO record OPTIONS { overwriteMode: "replace", waitForSync: @sync } RETURN 1"#,
+			)
+			.bind_var("docs", Value::Array(docs))
+			.bind_var("sync", json!(self.sync))
+			.build();
+		let _: Vec<Value> = self.database.lock().await.aql_query(aql).await?;
+		Ok(())
+	}
+
+	async fn batch_delete_keys(&self, keys: Vec<String>) -> Result<()> {
+		if keys.is_empty() {
+			return Ok(());
+		}
+		let aql = AqlQuery::builder()
+			.query(
+				"FOR k IN @keys REMOVE {_key: k} IN record OPTIONS { waitForSync: @sync } RETURN 1",
+			)
+			.bind_var("keys", Value::Array(keys.into_iter().map(Value::String).collect()))
+			.bind_var("sync", json!(self.sync))
+			.build();
+		let _: Vec<Value> = self.database.lock().await.aql_query(aql).await?;
+		Ok(())
+	}
+
 	fn to_doc(key: String, mut val: Value) -> Result<Value> {
 		let obj = val.as_object_mut().unwrap();
 		obj.insert("_key".to_string(), key.into());

--- a/src/dragonfly.rs
+++ b/src/dragonfly.rs
@@ -3,6 +3,7 @@
 use crate::benchmark::NOT_SUPPORTED_ERROR;
 use crate::docker::DockerParams;
 use crate::engine::{BenchmarkClient, BenchmarkEngine, ScanContext};
+use crate::util::redis_batch;
 use crate::valueprovider::Columns;
 use crate::{Benchmark, KeyType, Projection, Scan};
 use anyhow::{Result, bail};
@@ -114,6 +115,50 @@ impl BenchmarkClient for DragonflyClient {
 
 	async fn scan_string(&self, scan: &Scan, _ctx: ScanContext) -> Result<usize> {
 		self.scan_bytes(scan).await
+	}
+
+	async fn batch_create_u32(
+		&self,
+		key_vals: impl Iterator<Item = (u32, serde_json::Value)> + Send,
+	) -> Result<()> {
+		redis_batch::batch_create_u32(&self.conn_record, key_vals.collect()).await
+	}
+
+	async fn batch_create_string(
+		&self,
+		key_vals: impl Iterator<Item = (String, serde_json::Value)> + Send,
+	) -> Result<()> {
+		redis_batch::batch_create_string(&self.conn_record, key_vals.collect()).await
+	}
+
+	async fn batch_read_u32(&self, keys: impl Iterator<Item = u32> + Send) -> Result<()> {
+		redis_batch::batch_read_u32(&self.conn_record, keys.collect()).await
+	}
+
+	async fn batch_read_string(&self, keys: impl Iterator<Item = String> + Send) -> Result<()> {
+		redis_batch::batch_read_string(&self.conn_record, keys.collect()).await
+	}
+
+	async fn batch_update_u32(
+		&self,
+		key_vals: impl Iterator<Item = (u32, serde_json::Value)> + Send,
+	) -> Result<()> {
+		redis_batch::batch_update_u32(&self.conn_record, key_vals.collect()).await
+	}
+
+	async fn batch_update_string(
+		&self,
+		key_vals: impl Iterator<Item = (String, serde_json::Value)> + Send,
+	) -> Result<()> {
+		redis_batch::batch_update_string(&self.conn_record, key_vals.collect()).await
+	}
+
+	async fn batch_delete_u32(&self, keys: impl Iterator<Item = u32> + Send) -> Result<()> {
+		redis_batch::batch_delete_u32(&self.conn_record, keys.collect()).await
+	}
+
+	async fn batch_delete_string(&self, keys: impl Iterator<Item = String> + Send) -> Result<()> {
+		redis_batch::batch_delete_string(&self.conn_record, keys.collect()).await
 	}
 }
 

--- a/src/keydb.rs
+++ b/src/keydb.rs
@@ -3,6 +3,7 @@
 use crate::benchmark::NOT_SUPPORTED_ERROR;
 use crate::docker::DockerParams;
 use crate::engine::{BenchmarkClient, BenchmarkEngine, ScanContext};
+use crate::util::redis_batch;
 use crate::valueprovider::Columns;
 use crate::{Benchmark, KeyType, Projection, Scan};
 use anyhow::{Result, bail};
@@ -122,6 +123,50 @@ impl BenchmarkClient for KeydbClient {
 
 	async fn scan_string(&self, scan: &Scan, _ctx: ScanContext) -> Result<usize> {
 		self.scan_bytes(scan).await
+	}
+
+	async fn batch_create_u32(
+		&self,
+		key_vals: impl Iterator<Item = (u32, serde_json::Value)> + Send,
+	) -> Result<()> {
+		redis_batch::batch_create_u32(&self.conn_record, key_vals.collect()).await
+	}
+
+	async fn batch_create_string(
+		&self,
+		key_vals: impl Iterator<Item = (String, serde_json::Value)> + Send,
+	) -> Result<()> {
+		redis_batch::batch_create_string(&self.conn_record, key_vals.collect()).await
+	}
+
+	async fn batch_read_u32(&self, keys: impl Iterator<Item = u32> + Send) -> Result<()> {
+		redis_batch::batch_read_u32(&self.conn_record, keys.collect()).await
+	}
+
+	async fn batch_read_string(&self, keys: impl Iterator<Item = String> + Send) -> Result<()> {
+		redis_batch::batch_read_string(&self.conn_record, keys.collect()).await
+	}
+
+	async fn batch_update_u32(
+		&self,
+		key_vals: impl Iterator<Item = (u32, serde_json::Value)> + Send,
+	) -> Result<()> {
+		redis_batch::batch_update_u32(&self.conn_record, key_vals.collect()).await
+	}
+
+	async fn batch_update_string(
+		&self,
+		key_vals: impl Iterator<Item = (String, serde_json::Value)> + Send,
+	) -> Result<()> {
+		redis_batch::batch_update_string(&self.conn_record, key_vals.collect()).await
+	}
+
+	async fn batch_delete_u32(&self, keys: impl Iterator<Item = u32> + Send) -> Result<()> {
+		redis_batch::batch_delete_u32(&self.conn_record, keys.collect()).await
+	}
+
+	async fn batch_delete_string(&self, keys: impl Iterator<Item = String> + Send) -> Result<()> {
+		redis_batch::batch_delete_string(&self.conn_record, keys.collect()).await
 	}
 }
 

--- a/src/neo4j.rs
+++ b/src/neo4j.rs
@@ -6,12 +6,13 @@ use crate::docker::DockerParams;
 use crate::engine::{BenchmarkClient, BenchmarkEngine, ScanContext};
 use crate::valueprovider::Columns;
 use crate::{Benchmark, Index, KeyType, Projection, Scan};
-use anyhow::{Result, bail};
+use anyhow::{Result, anyhow, bail};
+use flatten_json_object::{ArrayFormatting, Flattener};
 use neo4rs::BoltType;
 use neo4rs::ConfigBuilder;
 use neo4rs::Graph;
 use neo4rs::query;
-use serde_json::Value;
+use serde_json::{Value, json};
 use std::hint::black_box;
 
 pub const DEFAULT: &str = "127.0.0.1:7687";
@@ -158,9 +159,196 @@ impl BenchmarkClient for Neo4jClient {
 	async fn scan_string(&self, scan: &Scan, ctx: ScanContext) -> Result<usize> {
 		self.scan(scan, ctx).await
 	}
+
+	async fn batch_create_u32(
+		&self,
+		key_vals: impl Iterator<Item = (u32, Value)> + Send,
+	) -> Result<()> {
+		let rows: Vec<Value> = key_vals
+			.map(|(k, v)| Self::flattened_row_with_id(json!(k), v))
+			.collect::<Result<Vec<_>>>()?;
+		if rows.is_empty() {
+			return Ok(());
+		}
+		let bolt =
+			BoltType::try_from(Value::Array(rows)).map_err(|e| anyhow!("neo4j BoltType: {e}"))?;
+		let mut res = self
+			.graph
+			.execute(
+				query("UNWIND $rows AS row CREATE (r:Record) SET r += row").param("rows", bolt),
+			)
+			.await?;
+		while res.next().await?.is_some() {}
+		Ok(())
+	}
+
+	async fn batch_create_string(
+		&self,
+		key_vals: impl Iterator<Item = (String, Value)> + Send,
+	) -> Result<()> {
+		let rows: Vec<Value> = key_vals
+			.map(|(k, v)| Self::flattened_row_with_id(Value::String(k), v))
+			.collect::<Result<Vec<_>>>()?;
+		if rows.is_empty() {
+			return Ok(());
+		}
+		let bolt =
+			BoltType::try_from(Value::Array(rows)).map_err(|e| anyhow!("neo4j BoltType: {e}"))?;
+		let mut res = self
+			.graph
+			.execute(
+				query("UNWIND $rows AS row CREATE (r:Record) SET r += row").param("rows", bolt),
+			)
+			.await?;
+		while res.next().await?.is_some() {}
+		Ok(())
+	}
+
+	async fn batch_read_u32(&self, keys: impl Iterator<Item = u32> + Send) -> Result<()> {
+		let ids: Vec<Value> = keys.map(|k| json!(k)).collect();
+		if ids.is_empty() {
+			return Ok(());
+		}
+		let bolt =
+			BoltType::try_from(Value::Array(ids)).map_err(|e| anyhow!("neo4j BoltType: {e}"))?;
+		let mut res = self
+			.graph
+			.execute(
+				query("UNWIND $ids AS id MATCH (r:Record { id: id }) RETURN r").param("ids", bolt),
+			)
+			.await?;
+		let mut n = 0;
+		while res.next().await?.is_some() {
+			n += 1;
+		}
+		assert!(n > 0);
+		Ok(())
+	}
+
+	async fn batch_read_string(&self, keys: impl Iterator<Item = String> + Send) -> Result<()> {
+		let ids: Vec<Value> = keys.map(Value::String).collect();
+		if ids.is_empty() {
+			return Ok(());
+		}
+		let bolt =
+			BoltType::try_from(Value::Array(ids)).map_err(|e| anyhow!("neo4j BoltType: {e}"))?;
+		let mut res = self
+			.graph
+			.execute(
+				query("UNWIND $ids AS id MATCH (r:Record { id: id }) RETURN r").param("ids", bolt),
+			)
+			.await?;
+		let mut n = 0;
+		while res.next().await?.is_some() {
+			n += 1;
+		}
+		assert!(n > 0);
+		Ok(())
+	}
+
+	async fn batch_update_u32(
+		&self,
+		key_vals: impl Iterator<Item = (u32, Value)> + Send,
+	) -> Result<()> {
+		let rows: Vec<Value> = key_vals
+			.map(|(k, v)| Self::flattened_row_with_id(json!(k), v))
+			.collect::<Result<Vec<_>>>()?;
+		if rows.is_empty() {
+			return Ok(());
+		}
+		let bolt =
+			BoltType::try_from(Value::Array(rows)).map_err(|e| anyhow!("neo4j BoltType: {e}"))?;
+		let mut res = self
+			.graph
+			.execute(
+				query(
+					"UNWIND $rows AS row MATCH (r:Record { id: row.id }) SET r += row RETURN r.id",
+				)
+				.param("rows", bolt),
+			)
+			.await?;
+		while res.next().await?.is_some() {}
+		Ok(())
+	}
+
+	async fn batch_update_string(
+		&self,
+		key_vals: impl Iterator<Item = (String, Value)> + Send,
+	) -> Result<()> {
+		let rows: Vec<Value> = key_vals
+			.map(|(k, v)| Self::flattened_row_with_id(Value::String(k), v))
+			.collect::<Result<Vec<_>>>()?;
+		if rows.is_empty() {
+			return Ok(());
+		}
+		let bolt =
+			BoltType::try_from(Value::Array(rows)).map_err(|e| anyhow!("neo4j BoltType: {e}"))?;
+		let mut res = self
+			.graph
+			.execute(
+				query(
+					"UNWIND $rows AS row MATCH (r:Record { id: row.id }) SET r += row RETURN r.id",
+				)
+				.param("rows", bolt),
+			)
+			.await?;
+		while res.next().await?.is_some() {}
+		Ok(())
+	}
+
+	async fn batch_delete_u32(&self, keys: impl Iterator<Item = u32> + Send) -> Result<()> {
+		let ids: Vec<Value> = keys.map(|k| json!(k)).collect();
+		if ids.is_empty() {
+			return Ok(());
+		}
+		let bolt =
+			BoltType::try_from(Value::Array(ids)).map_err(|e| anyhow!("neo4j BoltType: {e}"))?;
+		let mut res = self
+			.graph
+			.execute(
+				query("UNWIND $ids AS id MATCH (r:Record { id: id }) DETACH DELETE r")
+					.param("ids", bolt),
+			)
+			.await?;
+		while res.next().await?.is_some() {}
+		Ok(())
+	}
+
+	async fn batch_delete_string(&self, keys: impl Iterator<Item = String> + Send) -> Result<()> {
+		let ids: Vec<Value> = keys.map(Value::String).collect();
+		if ids.is_empty() {
+			return Ok(());
+		}
+		let bolt =
+			BoltType::try_from(Value::Array(ids)).map_err(|e| anyhow!("neo4j BoltType: {e}"))?;
+		let mut res = self
+			.graph
+			.execute(
+				query("UNWIND $ids AS id MATCH (r:Record { id: id }) DETACH DELETE r")
+					.param("ids", bolt),
+			)
+			.await?;
+		while res.next().await?.is_some() {}
+		Ok(())
+	}
 }
 
 impl Neo4jClient {
+	fn flattened_row_with_id(id: Value, val: Value) -> Result<Value> {
+		let val = Flattener::new()
+			.set_key_separator("_")
+			.set_array_formatting(ArrayFormatting::Surrounded {
+				start: "_".to_string(),
+				end: "".to_string(),
+			})
+			.set_preserve_empty_arrays(false)
+			.set_preserve_empty_objects(false)
+			.flatten(&val)?;
+		let mut m = val.as_object().cloned().ok_or_else(|| anyhow!("expected JSON object"))?;
+		m.insert("id".into(), id);
+		Ok(Value::Object(m))
+	}
+
 	async fn create<T>(&self, key: T, val: Value) -> Result<()>
 	where
 		T: Into<BoltType> + Sync,

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -3,6 +3,7 @@
 use crate::benchmark::NOT_SUPPORTED_ERROR;
 use crate::docker::DockerParams;
 use crate::engine::{BenchmarkClient, BenchmarkEngine, ScanContext};
+use crate::util::redis_batch;
 use crate::valueprovider::Columns;
 use crate::{Benchmark, KeyType, Projection, Scan};
 use anyhow::{Result, bail};
@@ -119,6 +120,50 @@ impl BenchmarkClient for RedisClient {
 
 	async fn scan_string(&self, scan: &Scan, _ctx: ScanContext) -> Result<usize> {
 		self.scan_bytes(scan).await
+	}
+
+	async fn batch_create_u32(
+		&self,
+		key_vals: impl Iterator<Item = (u32, serde_json::Value)> + Send,
+	) -> Result<()> {
+		redis_batch::batch_create_u32(&self.conn_record, key_vals.collect()).await
+	}
+
+	async fn batch_create_string(
+		&self,
+		key_vals: impl Iterator<Item = (String, serde_json::Value)> + Send,
+	) -> Result<()> {
+		redis_batch::batch_create_string(&self.conn_record, key_vals.collect()).await
+	}
+
+	async fn batch_read_u32(&self, keys: impl Iterator<Item = u32> + Send) -> Result<()> {
+		redis_batch::batch_read_u32(&self.conn_record, keys.collect()).await
+	}
+
+	async fn batch_read_string(&self, keys: impl Iterator<Item = String> + Send) -> Result<()> {
+		redis_batch::batch_read_string(&self.conn_record, keys.collect()).await
+	}
+
+	async fn batch_update_u32(
+		&self,
+		key_vals: impl Iterator<Item = (u32, serde_json::Value)> + Send,
+	) -> Result<()> {
+		redis_batch::batch_update_u32(&self.conn_record, key_vals.collect()).await
+	}
+
+	async fn batch_update_string(
+		&self,
+		key_vals: impl Iterator<Item = (String, serde_json::Value)> + Send,
+	) -> Result<()> {
+		redis_batch::batch_update_string(&self.conn_record, key_vals.collect()).await
+	}
+
+	async fn batch_delete_u32(&self, keys: impl Iterator<Item = u32> + Send) -> Result<()> {
+		redis_batch::batch_delete_u32(&self.conn_record, keys.collect()).await
+	}
+
+	async fn batch_delete_string(&self, keys: impl Iterator<Item = String> + Send) -> Result<()> {
+		redis_batch::batch_delete_string(&self.conn_record, keys.collect()).await
 	}
 }
 

--- a/src/surrealdb.rs
+++ b/src/surrealdb.rs
@@ -9,17 +9,18 @@ use crate::valueprovider::Columns;
 use crate::{Benchmark, Index, KeyType, Projection, Scan};
 use anyhow::{Result, bail};
 use log::{error, warn};
-use serde_json::Value;
+use serde_json::Value as Json;
 use std::env;
 use std::time::Duration;
 use surrealdb::Surreal;
 use surrealdb::engine::any::{Any, connect};
 use surrealdb::opt::auth::Root;
 use surrealdb::opt::{Config, Resource};
-use surrealdb::types::{RecordIdKey, SurrealValue, ToSql};
+use surrealdb::types::{Array, RecordId, RecordIdKey, SurrealValue, ToSql, Value};
 use tokio::time::{sleep, timeout};
 
 const DEFAULT: &str = "ws://127.0.0.1:8000";
+const TABLE: &str = "record";
 
 /// Wrap a SurrealDB result error so the failing SurrealQL surfaces in two
 /// places: a `log::error!` line emitted immediately (visible in the bench's
@@ -291,8 +292,8 @@ impl SurrealDBClient {
 #[derive(Debug, SurrealValue)]
 #[surreal(crate = "surrealdb::types")]
 struct Bindings<T: SurrealValue> {
-	content: Value,
-	key: T,
+	content: Json,
+	id: T,
 }
 
 impl BenchmarkClient for SurrealDBClient {
@@ -305,24 +306,19 @@ impl BenchmarkClient for SurrealDBClient {
 		// insert/create into the table attempts
 		// to set up the NS+DB+TB, and this causes
 		// 'resource busy' key conflict failures.
-		let surql = "
+		let sql = "
             REMOVE TABLE IF EXISTS record;
 			DEFINE TABLE record;
 		";
-		self.db
-			.query(surql)
-			.await
-			.map_err(log_sql_err(surql))?
-			.check()
-			.map_err(log_sql_err(surql))?;
+		self.db.query(sql).await.map_err(log_sql_err(sql))?.check().map_err(log_sql_err(sql))?;
 		Ok(())
 	}
 
 	async fn compact(&self) -> Result<()> {
 		// Issue a system compaction request
-		let surql = "ALTER SYSTEM COMPACT";
+		let sql = "ALTER SYSTEM COMPACT";
 		// Compact all databases and namespaces in SurrealDB
-		let response = self.db.query(surql).await.map_err(log_sql_err(surql))?;
+		let response = self.db.query(sql).await.map_err(log_sql_err(sql))?;
 		// Compaction only works on RocksDB storage engine
 		match response.check() {
 			Ok(_) => Ok(()),
@@ -330,17 +326,17 @@ impl BenchmarkClient for SurrealDBClient {
 				if e.to_string().contains("does not support compaction") {
 					Ok(())
 				} else {
-					Err(log_sql_err(surql)(e))
+					Err(log_sql_err(sql)(e))
 				}
 			}
 		}
 	}
 
-	async fn create_u32(&self, key: u32, val: Value) -> Result<()> {
-		self.create(key, val).await
+	async fn create_u32(&self, key: u32, val: Json) -> Result<()> {
+		self.create(key as i64, val).await
 	}
 
-	async fn create_string(&self, key: String, val: Value) -> Result<()> {
+	async fn create_string(&self, key: String, val: Json) -> Result<()> {
 		self.create(key, val).await
 	}
 
@@ -352,16 +348,16 @@ impl BenchmarkClient for SurrealDBClient {
 		self.read(key).await
 	}
 
-	async fn update_u32(&self, key: u32, val: Value) -> Result<()> {
-		self.update(key, val).await
+	async fn update_u32(&self, key: u32, val: Json) -> Result<()> {
+		self.update(key as i64, val).await
 	}
 
-	async fn update_string(&self, key: String, val: Value) -> Result<()> {
+	async fn update_string(&self, key: String, val: Json) -> Result<()> {
 		self.update(key, val).await
 	}
 
 	async fn delete_u32(&self, key: u32) -> Result<()> {
-		self.delete(key).await
+		self.delete(key as i64).await
 	}
 
 	async fn delete_string(&self, key: String) -> Result<()> {
@@ -515,19 +511,63 @@ impl BenchmarkClient for SurrealDBClient {
 	async fn scan_string(&self, scan: &Scan, ctx: ScanContext) -> Result<usize> {
 		self.scan(scan, ctx).await
 	}
+
+	async fn batch_create_u32(
+		&self,
+		key_vals: impl Iterator<Item = (u32, Json)> + Send,
+	) -> Result<()> {
+		self.batch_create(key_vals.map(|(k, v)| (k as i64, v))).await
+	}
+
+	async fn batch_create_string(
+		&self,
+		key_vals: impl Iterator<Item = (String, Json)> + Send,
+	) -> Result<()> {
+		self.batch_create(key_vals).await
+	}
+
+	async fn batch_read_u32(&self, keys: impl Iterator<Item = u32> + Send) -> Result<()> {
+		self.batch_read(keys.map(|k| k as i64)).await
+	}
+
+	async fn batch_read_string(&self, keys: impl Iterator<Item = String> + Send) -> Result<()> {
+		self.batch_read(keys).await
+	}
+
+	async fn batch_update_u32(
+		&self,
+		key_vals: impl Iterator<Item = (u32, Json)> + Send,
+	) -> Result<()> {
+		self.batch_update(key_vals.map(|(k, v)| (k as i64, v))).await
+	}
+
+	async fn batch_update_string(
+		&self,
+		key_vals: impl Iterator<Item = (String, Json)> + Send,
+	) -> Result<()> {
+		self.batch_update(key_vals).await
+	}
+
+	async fn batch_delete_u32(&self, keys: impl Iterator<Item = u32> + Send) -> Result<()> {
+		self.batch_delete(keys.map(|k| k as i64)).await
+	}
+
+	async fn batch_delete_string(&self, keys: impl Iterator<Item = String> + Send) -> Result<()> {
+		self.batch_delete(keys).await
+	}
 }
 
 impl SurrealDBClient {
-	async fn create<T>(&self, key: T, val: Value) -> Result<()>
+	async fn create<T>(&self, key: T, val: Json) -> Result<()>
 	where
-		T: SurrealValue + 'static,
+		T: Into<RecordIdKey>,
 	{
-		let sql = "CREATE type::record('record', $key) CONTENT $content RETURN NULL";
+		let sql = "CREATE $id CONTENT $content RETURN NULL";
 		let res = self
 			.db
 			.query(sql)
 			.bind(Bindings {
-				key,
+				id: Value::RecordId(RecordId::new(TABLE, key)),
 				content: val,
 			})
 			.await
@@ -547,16 +587,16 @@ impl SurrealDBClient {
 		Ok(())
 	}
 
-	async fn update<T>(&self, key: T, val: Value) -> Result<()>
+	async fn update<T>(&self, key: T, val: Json) -> Result<()>
 	where
-		T: SurrealValue + 'static,
+		T: Into<RecordIdKey>,
 	{
-		let sql = "UPDATE type::record('record', $key) CONTENT $content RETURN NULL";
+		let sql = "UPDATE $id CONTENT $content RETURN NULL";
 		let res = self
 			.db
 			.query(sql)
 			.bind(Bindings {
-				key,
+				id: Value::RecordId(RecordId::new(TABLE, key)),
 				content: val,
 			})
 			.await
@@ -569,13 +609,13 @@ impl SurrealDBClient {
 
 	async fn delete<T>(&self, key: T) -> Result<()>
 	where
-		T: SurrealValue + 'static,
+		T: Into<RecordIdKey>,
 	{
-		let sql = "DELETE type::record('record', $key) RETURN NULL";
+		let sql = "DELETE $id RETURN NULL";
 		let res = self
 			.db
 			.query(sql)
-			.bind(("key", key))
+			.bind(("id", Value::RecordId(RecordId::new(TABLE, key))))
 			.await
 			.map_err(log_sql_err(sql))?
 			.take::<surrealdb::types::Value>(0)
@@ -644,5 +684,110 @@ impl SurrealDBClient {
 				Ok(res.unwrap())
 			}
 		}
+	}
+
+	async fn batch_create<K>(&self, key_vals: impl Iterator<Item = (K, Json)> + Send) -> Result<()>
+	where
+		K: Into<RecordIdKey>,
+	{
+		// Construct the records
+		let rows: Vec<Value> = key_vals
+			.map(|(k, v)| {
+				let mut obj = match v.into_value() {
+					Value::Object(o) => o,
+					_ => panic!("Unexpected value type"),
+				};
+				obj.insert("id", Value::RecordId(RecordId::new(TABLE, k)));
+				Value::Object(obj)
+			})
+			.collect();
+		// Construct the SQL query
+		let sql = "INSERT $rows RETURN NONE";
+		// Execute the SQL query
+		self.db
+			.query(sql)
+			.bind(("rows", Value::Array(Array::from(rows))))
+			.await
+			.map_err(log_sql_err(sql))?
+			.check()
+			.map_err(log_sql_err(sql))?;
+		// All ok
+		Ok(())
+	}
+
+	async fn batch_read<K>(&self, keys: impl Iterator<Item = K> + Send) -> Result<()>
+	where
+		K: Into<RecordIdKey>,
+	{
+		// Construct the Record IDs
+		let ids: Vec<Value> = keys.map(|k| Value::RecordId(RecordId::new("record", k))).collect();
+		// Store the total Record IDs
+		let ids_len = ids.len();
+		// Construct the SQL query
+		let sql = "SELECT * FROM $ids";
+		// Execute the SQL query
+		let res: surrealdb::types::Value = self
+			.db
+			.query(sql)
+			.bind(("ids", Value::Array(Array::from(ids))))
+			.await
+			.map_err(log_sql_err(sql))?
+			.take(0)
+			.map_err(log_sql_err(sql))?;
+		// Check the response
+		let Some(arr) = res.as_array() else {
+			panic!("Unexpected response type");
+		};
+		assert_eq!(arr.len(), ids_len);
+		// All ok
+		Ok(())
+	}
+
+	async fn batch_update<K>(&self, key_vals: impl Iterator<Item = (K, Json)> + Send) -> Result<()>
+	where
+		K: Into<RecordIdKey>,
+	{
+		// Construct the records
+		let rows: Vec<Value> = key_vals
+			.map(|(k, v)| {
+				let mut obj = match v.into_value() {
+					Value::Object(o) => o,
+					_ => panic!("Unexpected value type"),
+				};
+				obj.insert("id", Value::RecordId(RecordId::new(TABLE, k)));
+				Value::Object(obj)
+			})
+			.collect();
+		// Construct the SQL query
+		let sql = "FOR $row IN $rows { UPDATE $row.id CONTENT $row RETURN NONE }";
+		// Execute the SQL query
+		self.db
+			.query(sql)
+			.bind(("rows", Value::Array(Array::from(rows))))
+			.await
+			.map_err(log_sql_err(sql))?
+			.check()
+			.map_err(log_sql_err(sql))?;
+		Ok(())
+	}
+
+	async fn batch_delete<K>(&self, keys: impl Iterator<Item = K> + Send) -> Result<()>
+	where
+		K: Into<RecordIdKey>,
+	{
+		// Construct the Record IDs
+		let ids: Vec<Value> = keys.map(|k| Value::RecordId(RecordId::new("record", k))).collect();
+		// Construct the SQL query
+		let sql = "DELETE $ids";
+		// Execute the SQL query
+		self.db
+			.query(sql)
+			.bind(("ids", Value::Array(Array::from(ids))))
+			.await
+			.map_err(log_sql_err(sql))?
+			.check()
+			.map_err(log_sql_err(sql))?;
+		// All ok
+		Ok(())
 	}
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,9 @@
+//! Shared helpers used across datastore backends.
+
 use std::time::Duration;
+
+#[cfg(any(feature = "redis", feature = "keydb", feature = "dragonfly"))]
+pub(crate) mod redis_batch;
 
 pub(crate) fn format_duration(duration: Duration) -> String {
 	let secs = duration.as_secs();

--- a/src/util/redis_batch.rs
+++ b/src/util/redis_batch.rs
@@ -1,0 +1,129 @@
+use anyhow::{Result, anyhow};
+use redis::aio::MultiplexedConnection;
+use serde_json::Value;
+use std::hint::black_box;
+use tokio::sync::Mutex;
+
+pub(crate) async fn batch_create_u32(
+	conn: &Mutex<MultiplexedConnection>,
+	key_vals: Vec<(u32, Value)>,
+) -> Result<()> {
+	if key_vals.is_empty() {
+		return Ok(());
+	}
+	let mut c = conn.lock().await;
+	let mut pipe = redis::pipe();
+	for (k, v) in key_vals {
+		let val = bincode::serde::encode_to_vec(&v, bincode::config::standard())?;
+		pipe.cmd("SET").arg(k).arg(val).ignore();
+	}
+	pipe.exec_async(&mut *c).await?;
+	Ok(())
+}
+
+pub(crate) async fn batch_create_string(
+	conn: &Mutex<MultiplexedConnection>,
+	key_vals: Vec<(String, Value)>,
+) -> Result<()> {
+	if key_vals.is_empty() {
+		return Ok(());
+	}
+	let mut c = conn.lock().await;
+	let mut pipe = redis::pipe();
+	for (k, v) in key_vals {
+		let val = bincode::serde::encode_to_vec(&v, bincode::config::standard())?;
+		pipe.cmd("SET").arg(k).arg(val).ignore();
+	}
+	pipe.exec_async(&mut *c).await?;
+	Ok(())
+}
+
+pub(crate) async fn batch_read_u32(
+	conn: &Mutex<MultiplexedConnection>,
+	keys: Vec<u32>,
+) -> Result<()> {
+	if keys.is_empty() {
+		return Ok(());
+	}
+	let mut c = conn.lock().await;
+	let mut pipe = redis::pipe();
+	for k in &keys {
+		pipe.cmd("GET").arg(k);
+	}
+	let vals: Vec<Option<Vec<u8>>> = pipe.query_async(&mut *c).await?;
+	assert_eq!(vals.len(), keys.len());
+	for v in vals {
+		let v = v.ok_or_else(|| anyhow!("missing key"))?;
+		assert!(!v.is_empty());
+		black_box(v);
+	}
+	Ok(())
+}
+
+pub(crate) async fn batch_read_string(
+	conn: &Mutex<MultiplexedConnection>,
+	keys: Vec<String>,
+) -> Result<()> {
+	if keys.is_empty() {
+		return Ok(());
+	}
+	let mut c = conn.lock().await;
+	let mut pipe = redis::pipe();
+	for k in &keys {
+		pipe.cmd("GET").arg(k);
+	}
+	let vals: Vec<Option<Vec<u8>>> = pipe.query_async(&mut *c).await?;
+	assert_eq!(vals.len(), keys.len());
+	for v in vals {
+		let v = v.ok_or_else(|| anyhow!("missing key"))?;
+		assert!(!v.is_empty());
+		black_box(v);
+	}
+	Ok(())
+}
+
+pub(crate) async fn batch_update_u32(
+	conn: &Mutex<MultiplexedConnection>,
+	key_vals: Vec<(u32, Value)>,
+) -> Result<()> {
+	batch_create_u32(conn, key_vals).await
+}
+
+pub(crate) async fn batch_update_string(
+	conn: &Mutex<MultiplexedConnection>,
+	key_vals: Vec<(String, Value)>,
+) -> Result<()> {
+	batch_create_string(conn, key_vals).await
+}
+
+pub(crate) async fn batch_delete_u32(
+	conn: &Mutex<MultiplexedConnection>,
+	keys: Vec<u32>,
+) -> Result<()> {
+	if keys.is_empty() {
+		return Ok(());
+	}
+	let mut c = conn.lock().await;
+	let mut pipe = redis::pipe();
+	for k in keys {
+		pipe.cmd("DEL").arg(k).ignore();
+	}
+	pipe.exec_async(&mut *c).await?;
+	Ok(())
+}
+
+pub(crate) async fn batch_delete_string(
+	conn: &Mutex<MultiplexedConnection>,
+	keys: Vec<String>,
+) -> Result<()> {
+	if keys.is_empty() {
+		return Ok(());
+	}
+	let mut c = conn.lock().await;
+	let mut pipe = redis::pipe();
+	for k in keys {
+		pipe.cmd("DEL").arg(k).ignore();
+	}
+	pipe.exec_async(&mut *c).await?;
+	Ok(())
+}


### PR DESCRIPTION
### What is the motivation?

Exercise bulk/batch database APIs in crud-bench so we can compare backends under realistic multi-record workloads, and wire SurrealDB to efficient SurrealQL batch patterns.

### What does this change do?

- **SurrealDB**: Implements `batch_*_u32` / `batch_*_string` via bulk SurrealQL (`INSERT`, `SELECT … INSIDE`, `FOR … UPDATE … CONTENT`, `DELETE … INSIDE`), building row objects with embedded record ids for creates/updates.
- **Redis ecosystem** (Redis, KeyDB, Dragonfly): Batch paths using pipelining (`util/redis_batch.rs`).
- **Neo4j & ArangoDB**: Batch operation implementations.
- **Utilities**: Split `src/util.rs` into `src/util/mod.rs` and shared helpers.

### What is your testing strategy?

Local `cargo check --features surrealdb`; rely on existing GitHub Actions CI for full matrix.

### Security considerations

No meaningful security surface change: benchmarking client code only, same credential/env patterns as before.

### Is this related to any issues?

No related issues.

### Have you read the Contributing Guidelines?

- [x] I have read the contributing guidelines.