### PR TITLE
Fix KeyDB --sync regression and tune Redis I/O threads

### DIFF
--- a/src/keydb.rs
+++ b/src/keydb.rs
@@ -18,8 +18,17 @@ pub const DEFAULT: &str = "redis://:root@127.0.0.1:6379/";
 pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 	// KeyDB's defining feature is multi-threading; without `--server-threads`
 	// it behaves like single-threaded Redis. Pin to the number of host CPU
-	// cores (capped at the practical KeyDB recommendation of 8).
-	let server_threads = num_cpus::get().clamp(2, 8);
+	// cores (capped at the practical KeyDB recommendation of 8). With
+	// `appendfsync always` (i.e. --sync) multiple I/O threads each take the
+	// AOF lock and fsync independently, which defeats the per-iteration
+	// fsync batching and is dramatically slower than single-threaded — so
+	// we drop back to one thread in that case.
+	let threading = if options.sync {
+		"--server-threads 1".to_string()
+	} else {
+		let n = num_cpus::get().clamp(2, 8);
+		format!("--server-threads {n} --server-thread-affinity true")
+	};
 	// Persistence: AOF on/off + sync flush. When persisted=true we also
 	// disable RDB explicitly so the default snapshot schedule doesn't
 	// contend with AOF writes during the benchmark.
@@ -40,10 +49,7 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 	DockerParams {
 		image: "eqalpha/keydb",
 		pre_args: "-p 127.0.0.1:6379:6379".to_string(),
-		post_args: format!(
-			"keydb-server --requirepass root --server-threads {server_threads} \
-			 --server-thread-affinity true {persistence} {memory}"
-		),
+		post_args: format!("keydb-server --requirepass root {threading} {persistence} {memory}"),
 	}
 }
 

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -16,9 +16,16 @@ use tokio::sync::Mutex;
 pub const DEFAULT: &str = "redis://:root@127.0.0.1:6379/";
 
 pub(crate) fn docker(options: &Benchmark) -> DockerParams {
-	// Redis 6+ supports `io-threads` for network I/O parallelism. The Redis
-	// docs recommend not exceeding 8 and leaving room for the main thread.
-	let io_threads = num_cpus::get().saturating_sub(1).clamp(2, 8);
+	// Redis 6+ supports `io-threads` for network I/O parallelism (command
+	// execution itself is still single-threaded). Docs recommend capping at
+	// 8 and leaving room for the main thread. With `appendfsync always`
+	// (i.e. --sync) the main thread is fsync-bound and the I/O threads sit
+	// idle, so we drop back to one thread in that case.
+	let io_threads = if options.sync {
+		1
+	} else {
+		num_cpus::get().saturating_sub(1).clamp(2, 8)
+	};
 	// Persistence: AOF on/off + sync flush. When persisted=true we also
 	// disable RDB explicitly so the default snapshot schedule doesn't
 	// contend with AOF writes during the benchmark.
@@ -41,7 +48,7 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 		pre_args: "-p 127.0.0.1:6379:6379".to_string(),
 		post_args: format!(
 			"redis-server --requirepass root --io-threads {io_threads} \
-			 --io-threads-do-reads yes {persistence} {memory}"
+			 {persistence} {memory}"
 		),
 	}
 }


### PR DESCRIPTION
## Summary

- KeyDB: `--persisted --optimised --sync` regressed from ~196s to ~32min after #237 enabled `--server-threads N --server-thread-affinity true`. With `appendfsync always`, each worker thread takes the AOF lock and fsyncs independently, defeating the per-event-loop fsync batching. Drop to `--server-threads 1` when `--sync` is set; keep multi-threading for the non-sync paths where it actually helps.
- Redis: command execution is single-threaded, so the same cliff doesn't apply, but with `appendfsync always` the main thread is fsync-bound and I/O threads sit idle — drop `--io-threads` to 1 in that case. Also remove `--io-threads-do-reads yes`; per Redis docs it rarely helps and adds thread-hop overhead on a loopback benchmark.

## Test plan

- [ ] `cargo check --features redis,keydb` (passes locally)
- [ ] Re-run `--persisted --optimised --sync` against KeyDB and confirm wall-clock returns to the pre-#237 baseline
- [ ] Sanity-check Redis `--sync` and non-sync runs for no regression