### PR TITLE
Switch workers to JoinSet, compact after BuildIndex, bump DDL timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,6 +780,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2564,7 +2573,6 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3901269ec6d4f6068d3f09e5f02f995bd076398dcd1dfec407cd230b02d11b"
 dependencies = [
- "earcutr",
  "float_next_after",
  "geo-types",
  "geographiclib-rs",
@@ -2576,7 +2584,6 @@ dependencies = [
  "rstar 0.12.2",
  "serde",
  "sif-itree",
- "spade",
 ]
 
 [[package]]
@@ -7031,9 +7038,8 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surrealdb"
-version = "3.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504a96b55e86ef8653a03b6b97e771f49c954e26bcc0308160b0134d94f334fd"
+version = "3.1.0-alpha"
+source = "git+https://github.com/surrealdb/surrealdb?branch=main#de35b0212e3fe37a645658d339040f26eb2118ce"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -7069,9 +7075,8 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-core"
-version = "3.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e6a7f248c958fd5000c4fab5759503663bf93c622be10a6d7bf7d2d676b8fc"
+version = "3.1.0-alpha"
+source = "git+https://github.com/surrealdb/surrealdb?branch=main#de35b0212e3fe37a645658d339040f26eb2118ce"
 dependencies = [
  "addr",
  "affinitypool",
@@ -7176,9 +7181,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-protocol"
-version = "0.8.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb37698e0493bcfac3229ecb6ec6894a3ad705a3a2087b1562eeb881b3db19d4"
+checksum = "f57065763bbd36486c449132252b3aac5a5e20f5669393ded0e967e8f8289ea2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7186,7 +7191,7 @@ dependencies = [
  "chrono",
  "flatbuffers",
  "futures",
- "geo 0.32.0",
+ "geo 0.31.0",
  "prost 0.14.3",
  "prost-types 0.14.3",
  "rust_decimal",
@@ -7210,12 +7215,13 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types"
-version = "3.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79e71d035367b933cf528c09b7ed186bc17dea58c66a1bca84d22f9abf167db"
+version = "3.1.0-alpha"
+source = "git+https://github.com/surrealdb/surrealdb?branch=main#de35b0212e3fe37a645658d339040f26eb2118ce"
 dependencies = [
  "anyhow",
+ "async-channel",
  "bytes",
+ "castaway",
  "chrono",
  "flatbuffers",
  "geo 0.32.0",
@@ -7224,22 +7230,26 @@ dependencies = [
  "papaya",
  "rand 0.8.6",
  "regex",
+ "reqwest 0.13.2",
  "rstest",
  "rust_decimal",
+ "semver",
  "serde",
  "serde_json",
  "surrealdb-protocol",
  "surrealdb-types-derive",
+ "tracing",
  "ulid",
+ "url",
  "uuid",
 ]
 
 [[package]]
 name = "surrealdb-types-derive"
-version = "3.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76abdbfc597e062daae5269251e18a84553f9090cfff423591f57c8c6765aa8"
+version = "3.1.0-alpha"
+source = "git+https://github.com/surrealdb/surrealdb?branch=main#de35b0212e3fe37a645658d339040f26eb2118ce"
 dependencies = [
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,9 @@ serde = { version = "1.0.228", features = ["derive"] }
 slatedb = { version = "0.10.1", features = ["snappy", "foyer"], optional = true }
 serde_json = "1.0.149"
 serial_test = "3.4.0"
-surrealdb = { version = "3.0.5", default-features = false, optional = true }
+# Temporary: use SurrealDB main; revert to crates.io for releases.
+# surrealdb = { version = "3.0.5", default-features = false, optional = true }
+surrealdb = { git = "https://github.com/surrealdb/surrealdb", branch = "main", default-features = false, optional = true }
 surrealkv = { version = "0.21.2", optional = true }
 surrealmx = { version = "0.18.0", optional = true }
 sysinfo = { version = "0.37.2", features = ["serde"] }

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -22,7 +22,7 @@ use futures::future::try_join_all;
 use hdrhistogram::Histogram;
 use indicatif::ProgressBar;
 use log::{debug, info};
-use tokio::task;
+use tokio::task::JoinSet;
 use tokio::time::Instant;
 
 use std::fmt::{Display, Formatter};
@@ -247,6 +247,8 @@ impl Benchmark {
 					)
 					.await?;
 				let (with_index, index_remove, indexed_write_results) = if index_build.is_some() {
+					// Compact the datastore so the indexed-scan phases benchmark a compacted index.
+					self.maybe_compact_datastore::<C, E>(&engine).await?;
 					// Same query shape using the new index
 					let with_index = self
 						.run_operation::<C, D>(
@@ -500,8 +502,6 @@ impl Benchmark {
 		}
 		let progress =
 			self.bench_ui.progress_bar(samples as u64, &progress_short_label(&operation));
-		// Get the total concurrent futures
-		let total = (self.clients * self.threads) as usize;
 		// Whether we have experienced an error
 		let error = Arc::new(AtomicBool::new(false));
 		// Wether the test should be skipped
@@ -510,8 +510,8 @@ impl Benchmark {
 		let current = Arc::new(AtomicU32::new(0));
 		// The total records processed so far
 		let complete = Arc::new(AtomicU32::new(0));
-		// Store the futures in a vector
-		let mut futures = Vec::with_capacity(total);
+		// Store the worker tasks in a join set so failures can stop the operation promptly.
+		let mut tasks = JoinSet::new();
 		// Measure the starting time
 		let metric = OperationMetric::new(self.pid, samples);
 		// Loop over the clients
@@ -527,7 +527,7 @@ impl Benchmark {
 				let vp = vp.clone();
 				let operation = operation.clone();
 				let operation_timeout = self.operation_timeout;
-				futures.push(task::spawn(async move {
+				tasks.spawn(async move {
 					match Self::operation_loop::<C, D>(
 						client,
 						samples,
@@ -551,32 +551,42 @@ impl Benchmark {
 						}
 						Ok(h) => Ok(Some(h)),
 					}
-				}));
+				});
 			}
 		}
-		// Wait for all the threads to complete
+		// Wait for the threads to complete, aborting the remaining tasks on the first failure.
 		let mut global_histogram = Histogram::new(3)?;
-		let join = try_join_all(futures).await;
+		while let Some(result) = tasks.join_next().await {
+			match result {
+				Ok(Ok(Some(histogram))) => {
+					global_histogram.add(histogram)?;
+				}
+				Ok(Ok(None)) => {}
+				Ok(Err(e)) => {
+					error.store(true, Ordering::Relaxed);
+					tasks.abort_all();
+					while tasks.join_next().await.is_some() {}
+					if let Some(ref pb) = progress {
+						pb.finish_and_clear();
+					}
+					return Err(e).with_context(|| format!("{operation} worker failed"));
+				}
+				Err(e) => {
+					error.store(true, Ordering::Relaxed);
+					tasks.abort_all();
+					while tasks.join_next().await.is_some() {}
+					if let Some(ref pb) = progress {
+						pb.finish_and_clear();
+					}
+					return Err(e).with_context(|| format!("{operation} task failed"));
+				}
+			}
+		}
 		// Finish the progress bar at 100% before tearing it down
 		if let Some(ref pb) = progress {
 			pb.set_position(samples as u64);
 			pb.finish_and_clear();
 		}
-		match join {
-			Ok(results) => {
-				// Merge per-worker HDR histograms into one distribution for this phase
-				for res in results {
-					if let Some(histogram) = res? {
-						global_histogram.add(histogram)?;
-					}
-				}
-			}
-			Err(e) => {
-				// Join error (e.g. worker panic): surface after marking failure
-				error.store(true, Ordering::Relaxed);
-				Err(e)?;
-			}
-		};
 		if error.load(Ordering::Relaxed) {
 			bail!("Task failure");
 		}
@@ -638,7 +648,7 @@ impl Benchmark {
 			// (e.g. a WebSocket reply that never lands because the
 			// connection was torn down without completing the
 			// matching oneshot) returns an error here instead of
-			// parking the worker task forever; `try_join_all` then
+			// parking the worker task forever; the operation `JoinSet` then
 			// short-circuits with the operation name in the error
 			// chain rather than hanging in `block_on`.
 			let time = Instant::now();

--- a/src/surrealdb.rs
+++ b/src/surrealdb.rs
@@ -582,10 +582,10 @@ impl BenchmarkClient for SurrealDBClient {
 		};
 		// Remove the index
 		let sql = format!("REMOVE INDEX IF EXISTS {name} ON TABLE record");
-		retry(sql, Duration::from_secs(120)).await?;
+		retry(sql, Duration::from_secs(300)).await?;
 		// Remove the analyzer
 		let sql = format!("REMOVE ANALYZER IF EXISTS {name}");
-		retry(sql, Duration::from_secs(60)).await?;
+		retry(sql, Duration::from_secs(180)).await?;
 		// All ok
 		Ok(())
 	}


### PR DESCRIPTION
## Summary

- Replace the per-phase `Vec<JoinHandle>` + `try_join_all` worker pool with `tokio::task::JoinSet`. The first worker error now triggers `abort_all` and surfaces with the operation name in the error chain, instead of letting the remaining workers run to completion before the error is observed.
- Call `maybe_compact_datastore` between `BuildIndex` and the indexed-scan phases so the freshly built index is compacted before being benchmarked. The call is gated by the existing `COMPACTION` env var, so it's a no-op when compaction is disabled.
- Bump the SurrealDB REMOVE INDEX retry timeout 120s → 300s and REMOVE ANALYZER 60s → 180s. These can run long on larger datasets when compaction is in flight, and the old limits were tripping.
- Track SurrealDB `main` temporarily for upcoming work (the comment block above the dep documents the revert-before-release expectation).

## Why

Long-running benchmark phases with many concurrent workers were taking a long time to fail when one worker errored — every other worker had to run to completion before `try_join_all` surfaced the error. `JoinSet::abort_all` makes that immediate, which keeps the operation timeout meaningful.

Separately, indexed-scan timings were noisier than they should be because the index hadn't fully compacted before scans started; running `maybe_compact_datastore` right after `BuildIndex` makes those phases comparable across runs.

## Test plan

- [x] `cargo check --features surrealdb` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --features surrealdb` clean
- [ ] **Manual smoke** — `COMPACTION=1 cargo run --release --features surrealdb -- -d surrealkv --samples 1000 --clients 1 --threads 1 <scan config with with_index>`; confirm a new `Compaction took …` line appears between `BuildIndex` and `Scan :: indexed`.
- [ ] **Worker-abort smoke** — point at a misconfigured endpoint and confirm the phase exits within seconds rather than running every worker to completion.

## Notes for reviewers

- The `surrealdb` dep is a git ref to `main`. Revert to the next published crates.io release before tagging crud-bench.
- The JoinSet refactor is a real semantic change to shutdown behavior — workers can now be cancelled mid-`await` via `abort_all` rather than only via the cooperative `error.load()` check + per-iteration timeout. If any adapter depends on a graceful tear-down per worker rather than abrupt cancellation, that adapter is worth a second look.