### PR TITLE
Fix SQLite JSON column re-escaping on read-modify-write cycles

### DIFF
--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -11,6 +11,7 @@ use crate::{Benchmark, Index, KeyType, Projection, Scan};
 use anyhow::{Result, anyhow, bail};
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
+use serde_json::Value as JsonValue;
 use std::borrow::Cow;
 use std::cmp::max;
 use std::hint::black_box;
@@ -45,6 +46,15 @@ fn sqlite_cell_to_bench(columns: &Columns, key: &str, value: Value) -> BenchValu
 			Ok(d) => BenchValue::Decimal(d),
 			Err(_) => BenchValue::String(s),
 		},
+		// JSON columns are stored as TEXT; parse back into structured [`BenchValue`]
+		// so subsequent writes don't re-escape the raw JSON string (which would grow
+		// the column on every read/write cycle and eventually trip `SQLITE_TOOBIG`).
+		(Some(ColumnType::Object), Value::Text(s)) | (Some(ColumnType::Array), Value::Text(s)) => {
+			match serde_json::from_str::<JsonValue>(&s) {
+				Ok(j) => BenchValue::from(j),
+				Err(_) => BenchValue::String(s),
+			}
+		}
 		(_, Value::Null) => BenchValue::Null,
 		(_, Value::Integer(int)) => BenchValue::Int(int),
 		(_, Value::Real(float)) => BenchValue::Float(float),


### PR DESCRIPTION
## Summary

The indexed combined-workload (scans + writes at 50% ratio) on the SQLite adapter
was aborting mid-run with:

```
Failure: Error("string or blob too big"): string or blob too big: Error code 18: String or BLOB exceeds size limit
```

Root cause: JSON-typed columns (`Object` / `Array`) are stored as `TEXT` in SQLite,
but `sqlite_cell_to_bench` had no explicit branch for them, so they fell through to
the generic `Value::Text(text) => BenchValue::String(text)` arm. Rows came back with
JSON columns wrapped in `BenchValue::String("{...}")` rather than parsed into
structured `Object`/`Array` values.

When those rows were written back via `bench_to_sqlite_param`:

```rust
(ColumnType::Object, _) | (ColumnType::Array, _) => {
    Ok(Box::new(serde_json::to_string(&v.to_json())?))
}
```

`v.to_json()` of a `BenchValue::String("{...}")` returns `JsonValue::String("{...}")`,
and `serde_json::to_string()` escapes that into a JSON string literal
(`"\"{\\\"foo\\\":\\\"bar\\\"}\""`). Each read-modify-write cycle multiplied the
column size by the escape factor. The compensating-swap legs in `workloads.rs` read
two rows per sample and write them back, so after enough iterations columns exceeded
`SQLITE_LIMIT_LENGTH` and SQLite raised `SQLITE_TOOBIG` (error 18). Only the SQLite
adapter was affected — Postgres/MySQL/MariaDB parse JSON columns via native typed paths.

This fix parses JSON text back into a structured `BenchValue` for `Object` / `Array`
columns in `sqlite_cell_to_bench`, mirroring the existing handling for
`Decimal` / `Uuid` / `DateTime`. Roundtripped JSON columns now write back with the
same serialised representation they were inserted with, so the column stays a
stable size and the indexed combined workload runs to completion.

## Test plan

- [x] `cargo build --release` is clean
- [ ] Re-run `CRUD_BENCH_CONFIG=config/bench.toml ./run.sh -d sqlite --no-build --optimised --elevated --sync -s 50000 -c 128 -t 48 --no-wait` and confirm the SQLite benchmark completes through every scan/combined-workload phase