### PR TITLE
Retry SurrealDB DML on transaction conflict in concurrent scan workloads

### DIFF
--- a/src/surrealdb.rs
+++ b/src/surrealdb.rs
@@ -216,6 +216,49 @@ where
 	}
 }
 
+/// Substrings that identify a SurrealDB error as a retryable transaction
+/// conflict. The first wraps a per-statement KV conflict ("This transaction
+/// can be retried"); the second is the executor wrapper emitted when a
+/// transaction-scoped statement aborts the surrounding query.
+const RETRYABLE_CONFLICT_MARKERS: &[&str] =
+	&["This transaction can be retried", "The query was not executed due to a failed transaction"];
+
+fn is_retryable_conflict<E: std::fmt::Display>(e: &E) -> bool {
+	let msg = e.to_string();
+	RETRYABLE_CONFLICT_MARKERS.iter().any(|p| msg.contains(p))
+}
+
+/// Run a single DML statement, retrying with bounded exponential backoff on
+/// SurrealDB optimistic-concurrency conflicts. RocksDB surfaces concurrent
+/// writes on the same keys as a "Resource busy" status that the kvs layer
+/// maps to a `TransactionConflict` error — explicitly marked retryable by
+/// SurrealDB but not auto-retried at the commit path. Crud-bench's
+/// scan-with-writes phases generate this contention by design; without
+/// application-level retry, a single conflict aborts the whole benchmark
+/// run. The retry budget is small so genuine failures still surface.
+async fn run_dml_with_retry<F, Fut>(sql: &str, mut op: F) -> Result<()>
+where
+	F: FnMut() -> Fut,
+	Fut: std::future::Future<Output = std::result::Result<(), surrealdb::Error>>,
+{
+	const MAX_RETRIES: u32 = 16;
+	const MAX_DELAY: Duration = Duration::from_millis(100);
+	let mut delay = Duration::from_millis(1);
+	let mut attempts = 0u32;
+	loop {
+		match op().await {
+			Ok(()) => return Ok(()),
+			Err(e) if is_retryable_conflict(&e) && attempts < MAX_RETRIES => {
+				attempts += 1;
+				warn!("Retrying {sql} due to transaction conflict (attempt {attempts}): {e}");
+				sleep(delay).await;
+				delay = (delay * 2).min(MAX_DELAY);
+			}
+			Err(e) => return Err(log_sql_err(sql)(e)),
+		}
+	}
+}
+
 /// Storage backend for Docker (`server:<backend>`).
 pub(crate) enum Docker {
 	Memory,
@@ -824,19 +867,21 @@ impl SurrealDBClient {
 	{
 		let sql = "CREATE $id CONTENT $content RETURN NULL";
 		let content = bench_to_surreal_value(val);
-		let res = self
-			.db
-			.query(sql)
-			.bind(Bindings {
-				id: Value::RecordId(RecordId::new(TABLE, key)),
-				content,
-			})
-			.await
-			.map_err(log_sql_err(sql))?
-			.take::<surrealdb::types::Value>(0)
-			.map_err(log_sql_err(sql))?;
-		assert!(!res.is_none());
-		Ok(())
+		let id = Value::RecordId(RecordId::new(TABLE, key));
+		run_dml_with_retry(sql, || async {
+			let res = self
+				.db
+				.query(sql)
+				.bind(Bindings {
+					id: id.clone(),
+					content: content.clone(),
+				})
+				.await?
+				.take::<surrealdb::types::Value>(0)?;
+			assert!(!res.is_none());
+			Ok(())
+		})
+		.await
 	}
 
 	async fn read<T>(&self, key: T) -> Result<Row>
@@ -863,19 +908,21 @@ impl SurrealDBClient {
 		if let Value::Object(ref mut obj) = content {
 			obj.remove("id");
 		}
-		let res = self
-			.db
-			.query(sql)
-			.bind(Bindings {
-				id: Value::RecordId(RecordId::new(TABLE, key)),
-				content,
-			})
-			.await
-			.map_err(log_sql_err(sql))?
-			.take::<surrealdb::types::Value>(0)
-			.map_err(log_sql_err(sql))?;
-		assert!(!res.is_none());
-		Ok(())
+		let id = Value::RecordId(RecordId::new(TABLE, key));
+		run_dml_with_retry(sql, || async {
+			let res = self
+				.db
+				.query(sql)
+				.bind(Bindings {
+					id: id.clone(),
+					content: content.clone(),
+				})
+				.await?
+				.take::<surrealdb::types::Value>(0)?;
+			assert!(!res.is_none());
+			Ok(())
+		})
+		.await
 	}
 
 	async fn delete<T>(&self, key: T) -> Result<()>
@@ -883,16 +930,18 @@ impl SurrealDBClient {
 		T: Into<RecordIdKey>,
 	{
 		let sql = "DELETE $id RETURN NULL";
-		let res = self
-			.db
-			.query(sql)
-			.bind(("id", Value::RecordId(RecordId::new(TABLE, key))))
-			.await
-			.map_err(log_sql_err(sql))?
-			.take::<surrealdb::types::Value>(0)
-			.map_err(log_sql_err(sql))?;
-		assert!(!res.is_none());
-		Ok(())
+		let id = Value::RecordId(RecordId::new(TABLE, key));
+		run_dml_with_retry(sql, || async {
+			let res = self
+				.db
+				.query(sql)
+				.bind(("id", id.clone()))
+				.await?
+				.take::<surrealdb::types::Value>(0)?;
+			assert!(!res.is_none());
+			Ok(())
+		})
+		.await
 	}
 
 	async fn knn_scan(&self, scan: &Scan, query: &[f32]) -> Result<usize> {
@@ -1038,16 +1087,12 @@ impl SurrealDBClient {
 			.collect();
 		// Construct the SQL query
 		let sql = "INSERT $rows RETURN NONE";
-		// Execute the SQL query
-		self.db
-			.query(sql)
-			.bind(("rows", Value::Array(Array::from(rows))))
-			.await
-			.map_err(log_sql_err(sql))?
-			.check()
-			.map_err(log_sql_err(sql))?;
-		// All ok
-		Ok(())
+		let rows = Value::Array(Array::from(rows));
+		run_dml_with_retry(sql, || async {
+			self.db.query(sql).bind(("rows", rows.clone())).await?.check()?;
+			Ok(())
+		})
+		.await
 	}
 
 	async fn batch_read<K>(&self, keys: impl Iterator<Item = K> + Send) -> Result<()>
@@ -1098,15 +1143,12 @@ impl SurrealDBClient {
 			.collect();
 		// Construct the SQL query
 		let sql = "FOR $row IN $rows { UPDATE $row.id CONTENT $row RETURN NONE }";
-		// Execute the SQL query
-		self.db
-			.query(sql)
-			.bind(("rows", Value::Array(Array::from(rows))))
-			.await
-			.map_err(log_sql_err(sql))?
-			.check()
-			.map_err(log_sql_err(sql))?;
-		Ok(())
+		let rows = Value::Array(Array::from(rows));
+		run_dml_with_retry(sql, || async {
+			self.db.query(sql).bind(("rows", rows.clone())).await?.check()?;
+			Ok(())
+		})
+		.await
 	}
 
 	async fn batch_delete<K>(&self, keys: impl Iterator<Item = K> + Send) -> Result<()>
@@ -1117,15 +1159,11 @@ impl SurrealDBClient {
 		let ids: Vec<Value> = keys.map(|k| Value::RecordId(RecordId::new("record", k))).collect();
 		// Construct the SQL query
 		let sql = "DELETE $ids";
-		// Execute the SQL query
-		self.db
-			.query(sql)
-			.bind(("ids", Value::Array(Array::from(ids))))
-			.await
-			.map_err(log_sql_err(sql))?
-			.check()
-			.map_err(log_sql_err(sql))?;
-		// All ok
-		Ok(())
+		let ids = Value::Array(Array::from(ids));
+		run_dml_with_retry(sql, || async {
+			self.db.query(sql).bind(("ids", ids.clone())).await?.check()?;
+			Ok(())
+		})
+		.await
 	}
 }


### PR DESCRIPTION
## Summary

- During the `Scan · where_field_integer_eq` phase (combined scan + concurrent writes at 15%/50% ratios), the SurrealDB embedded RocksDB backend aborts the entire benchmark run with `Transaction conflict: Resource busy: . This transaction can be retried`.
- The error is explicitly retryable on the SurrealDB side, but the SDK does not auto-retry at the commit path — retry is the application's responsibility. Crud-bench already establishes that pattern for `REMOVE INDEX` in `drop_index` (substring-matching on the same markers, with a sleep-and-loop).
- This PR adds the same bounded retry-with-backoff to the six DML adapters in `src/surrealdb.rs` (`create`, `update`, `delete`, and their batch counterparts), so a single optimistic-concurrency conflict no longer kills the run.

## Why this isn't a SurrealDB bug

Two independent runs reproduce the same `Scan · where_field_integer_eq` failure on different branches and different concurrency settings:
- `surrealdb-private@caa9ffccc` (perf branch), 100K samples, `-c 128 -t 48` — fails at no-index ratio-15% phase.
- `surrealdb-private@dfeaf21d3` (main), 1M samples, `-c 12 -t 1` — fails at indexed ratio-50% phase.

Same error class, same scan id, different phases. The behaviour is workload-induced, not branch-specific. The SurrealDB `TransactionConflict` variant returns `is_retryable() == true` precisely so callers can loop on it.

## What this PR changes

- New private helpers in `src/surrealdb.rs`:
  - `RETRYABLE_CONFLICT_MARKERS` — the two substrings (`"This transaction can be retried"` and `"The query was not executed due to a failed transaction"`) already used in `drop_index`.
  - `is_retryable_conflict(&e)` — substring match over a `Display` error.
  - `run_dml_with_retry(sql, op)` — bounded exponential backoff (1ms start, 100ms cap, 16 attempts) around an `op` closure that performs the full bind+await+take/check pipeline. Logs each retry via `warn!` so the bench's stderr captures contention without going silent.
- `create`, `update`, `delete`, `batch_create`, `batch_update`, `batch_delete` rewrapped to use the helper. Bindings are pre-built outside the loop and cloned per attempt (Surreal `Value` is `Clone`).
- No change to read paths or scan paths — they don't generate write conflicts in RocksDB's optimistic mode.
- The existing `drop_index` retry block is unchanged: it has its own outer `tokio::time::timeout` and a longer cooldown that suits DDL semantics, and refactoring it would be unrelated to this fix.

## Companion change in surrealdb-private

The bench's stderr line included a malformed segment — `"Resource busy: . This transaction can be retried"` — because the kvs layer interpolates `rocksdb::Error::to_string()` (which ends in a trailing colon for `Status::Busy`) into a `Display` template. That cosmetic issue is fixed in a separate commit in `surrealdb/surrealdb-private` and is not required for this PR to be effective.

## Test plan

- [x] `cargo check --features surrealdb`
- [x] `cargo clippy --features surrealdb --no-deps`
- [x] `cargo fmt --check`
- [ ] Re-run `Scan · where_field_integer_eq` at 100K samples with `-c 128 -t 48` against an embedded RocksDB backend and confirm the phase completes (previously aborted in ~30s)
- [ ] Spot-check that the `warn!` retry lines appear under contention and that the per-DML latency tail stays bounded (worst case ≈1.5s with the chosen budget)