### PR TITLE
Add SurrealDB 2.X benchmark adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,6 +341,43 @@ jobs:
             endpoint: -e surrealkv:~/crud-bench
             description: SurrealDB embedded with SurrealKV storage
             skipped: SurrealDB with SurrealKV storage benchmark awaiting fixes
+          # SurrealDB 2.x + Memory
+          - name: surrealdb2-memory
+            database: surrealdb2
+            endpoint: -e server:memory
+            enabled: true
+            description: SurrealDB 2.x with in-memory storage
+          # SurrealDB 2.x + RocksDB
+          - name: surrealdb2-rocksdb
+            database: surrealdb2
+            endpoint: -e server:rocksdb
+            enabled: true
+            description: SurrealDB 2.x with RocksDB storage
+          # SurrealDB 2.x + SurrealKV
+          - name: surrealdb2-surrealkv
+            database: surrealdb2
+            endpoint: -e server:surrealkv
+            enabled: true
+            description: SurrealDB 2.x with SurrealKV storage
+          # SurrealDB 2.x Memory Engine
+          - name: surrealdb2-embedded-memory
+            database: surrealdb2
+            enabled: true
+            endpoint: -e memory
+            description: SurrealDB 2.x embedded with in-memory storage
+          # SurrealDB 2.x RocksDB Engine
+          - name: surrealdb2-embedded-rocksdb
+            database: surrealdb2
+            enabled: true
+            endpoint: -e rocksdb:~/crud-bench
+            description: SurrealDB 2.x embedded with RocksDB storage
+          # SurrealDB 2.x SurrealKV Engine
+          - name: surrealdb2-embedded-surrealkv
+            database: surrealdb2
+            enabled: true
+            endpoint: -e surrealkv:~/crud-bench
+            description: SurrealDB 2.x embedded with SurrealKV storage
+            skipped: SurrealDB with SurrealKV storage benchmark awaiting fixes
           # SurrealKV
           - name: surrealkv
             database: surrealkv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+
+[[package]]
 name = "addr"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +31,18 @@ name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "affinitypool"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dde2a385b82232b559baeec740c37809051c596f9b56e7da0d0da2c8e8f54f6"
+dependencies = [
+ "async-channel",
+ "num_cpus",
+ "thiserror 1.0.69",
+ "tokio",
+]
 
 [[package]]
 name = "affinitypool"
@@ -168,10 +186,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "any_ascii"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c6333e01ba7235575b6ab53e5af10f1c327927fd97c36462917e289557ea64"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "approx"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "approx"
@@ -180,6 +213,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object",
 ]
 
 [[package]]
@@ -249,6 +291,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,14 +313,117 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-graphql"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1057a9f7ccf2404d94571dec3451ade1cb524790df6f1ada0d19c2a49f6b0f40"
+dependencies = [
+ "async-graphql-derive",
+ "async-graphql-parser",
+ "async-graphql-value",
+ "async-io",
+ "async-trait",
+ "asynk-strim",
+ "base64 0.22.1",
+ "bytes",
+ "fnv",
+ "futures-util",
+ "http",
+ "indexmap 2.14.0",
+ "mime",
+ "multer",
+ "num-traits",
+ "pin-project-lite",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "static_assertions_next",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "async-graphql-derive"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e6cbeadc8515e66450fba0985ce722192e28443697799988265d86304d7cc68"
+dependencies = [
+ "Inflector",
+ "async-graphql-parser",
+ "darling 0.23.0",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "strum",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "async-graphql-parser"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64ef70f77a1c689111e52076da1cd18f91834bcb847de0a9171f83624b07fbf"
+dependencies = [
+ "async-graphql-value",
+ "pest",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-graphql-value"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e3ef112905abea9dea592fc868a6873b10ebd3f983e83308f995d6284e9ba41"
+dependencies = [
+ "bytes",
+ "indexmap 2.14.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -312,6 +466,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "pharos",
+ "rustc_version",
+]
+
+[[package]]
+name = "asynk-strim"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52697735bdaac441a29391a9e97102c74c6ef0f9b60a40cf109b1b404e29d2f6"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
@@ -485,6 +660,19 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcrypt"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e65938ed058ef47d92cf8b346cc76ef48984572ade631927e9937b5ffc7662c7"
+dependencies = [
+ "base64 0.22.1",
+ "blowfish",
+ "getrandom 0.2.17",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "bcrypt"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a0f5948f30df5f43ac29d310b7476793be97c50787e6ef4a63d960a0d0be827"
@@ -557,6 +745,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.4"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -671,6 +874,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bson"
 version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,7 +894,7 @@ dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",
  "hex",
- "indexmap",
+ "indexmap 2.14.0",
  "js-sys",
  "once_cell",
  "rand 0.9.4",
@@ -704,9 +916,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecheck"
@@ -794,6 +1006,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,6 +1024,63 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cedar-policy"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d91e3b10a0f7f2911774d5e49713c4d25753466f9e11d1cd2ec627f8a2dc857"
+dependencies = [
+ "cedar-policy-core",
+ "cedar-policy-validator",
+ "itertools 0.10.5",
+ "lalrpop-util",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "smol_str",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cedar-policy-core"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd2315591c6b7e18f8038f0a0529f254235fd902b6c217aabc04f2459b0d9995"
+dependencies = [
+ "either",
+ "ipnet",
+ "itertools 0.10.5",
+ "lalrpop",
+ "lalrpop-util",
+ "lazy_static",
+ "miette",
+ "regex",
+ "rustc_lexer",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smol_str",
+ "stacker",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cedar-policy-validator"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e756e1b2a5da742ed97e65199ad6d0893e9aa4bd6b34be1de9e70bd1e6adc7df"
+dependencies = [
+ "cedar-policy-core",
+ "itertools 0.10.5",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smol_str",
+ "stacker",
+ "thiserror 1.0.69",
+ "unicode-security",
 ]
 
 [[package]]
@@ -1010,7 +1288,7 @@ checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
  "crossterm",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1021,9 +1299,9 @@ checksum = "ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7"
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "compression-core",
  "flate2",
@@ -1032,9 +1310,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -1054,7 +1332,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.59.0",
 ]
 
@@ -1133,9 +1411,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.5.1"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
  "cfg-if",
 ]
@@ -1266,7 +1544,7 @@ dependencies = [
 name = "crud-bench"
 version = "0.1.0"
 dependencies = [
- "affinitypool",
+ "affinitypool 0.4.0",
  "anyhow",
  "arangors",
  "async-trait",
@@ -1277,7 +1555,7 @@ dependencies = [
  "clap",
  "comfy-table",
  "csv",
- "dashmap",
+ "dashmap 6.2.1",
  "env_logger",
  "fjall",
  "futures",
@@ -1304,9 +1582,10 @@ dependencies = [
  "serde_json",
  "serial_test",
  "slatedb",
- "surrealdb",
+ "surrealdb 2.6.5",
+ "surrealdb 3.0.5",
  "surrealdb-rocksdb",
- "surrealkv",
+ "surrealkv 0.21.2",
  "surrealmx",
  "sysinfo 0.37.2",
  "tokio",
@@ -1347,9 +1626,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -1540,6 +1819,19 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
@@ -1615,6 +1907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -1699,8 +1992,29 @@ checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -1738,6 +2052,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "double-ended-peekable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0d05e1c0dbad51b52c38bda7adceef61b9efc2baf04acfe8726a8c4630a6f57"
 
 [[package]]
 name = "downcast-rs"
@@ -1789,6 +2109,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "earcutr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -1864,6 +2190,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1877,6 +2212,12 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "endian-type"
@@ -1991,13 +2332,14 @@ dependencies = [
 
 [[package]]
 name = "fail-parallel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5666e8ca4ec174d896fb742789c29b1bea9319dcfd623c41bececc0a60c4939d"
+checksum = "c6f4a147ba57fcd64323c54c8f69fd4e045456a99574163010ccf5eea3168aaa"
 dependencies = [
  "log",
  "once_cell",
- "rand 0.8.6",
+ "rand 0.9.4",
+ "tokio",
 ]
 
 [[package]]
@@ -2099,11 +2441,11 @@ checksum = "b62b25b4d815ae178d7d9e4aa32ee59f072efd5431c736abede1e6ee13c8c453"
 dependencies = [
  "byteorder-lite",
  "byteview",
- "dashmap",
+ "dashmap 6.2.1",
  "flume 0.12.0",
  "log",
  "lsm-tree",
- "lz4_flex 0.13.0",
+ "lz4_flex 0.13.1",
  "tempfile",
  "xxhash-rust",
 ]
@@ -2457,6 +2799,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2481,9 +2836,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -2542,6 +2897,24 @@ dependencies = [
 
 [[package]]
 name = "geo"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f811f663912a69249fa620dcd2a005db7254529da2d8a0b23942e81f47084501"
+dependencies = [
+ "earcutr",
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "log",
+ "num-traits",
+ "robust",
+ "rstar 0.12.2",
+ "serde",
+ "spade",
+]
+
+[[package]]
+name = "geo"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc1a1678e54befc9b4bcab6cd43b8e7f834ae8ea121118b0fd8c42747675b4a"
@@ -2582,11 +2955,11 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f8647af4005fa11da47cd56252c6ef030be8fa97bdbf355e7dfb6348f0a82c"
+checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
 dependencies = [
- "approx",
+ "approx 0.5.1",
  "num-traits",
  "rayon",
  "rstar 0.10.0",
@@ -2690,9 +3063,9 @@ checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2700,7 +3073,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2768,6 +3141,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash 0.8.12",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3051,9 +3428,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -3102,9 +3479,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -3133,9 +3510,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.8"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
@@ -3145,6 +3522,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3256,7 +3634,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3385,6 +3763,17 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -3404,7 +3793,7 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.2",
  "web-time",
 ]
 
@@ -3415,7 +3804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
  "ahash 0.8.12",
- "indexmap",
+ "indexmap 2.14.0",
  "is-terminal",
  "itoa",
  "log",
@@ -3488,16 +3877,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3513,6 +3892,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3558,9 +3946,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "30457d51cb0e68ee18184b30cd9eb8e1602a20837c321f6ea9706b94f1c681c3"
 dependencies = [
  "jiff-static",
  "log",
@@ -3571,9 +3959,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "05f86e4f0326c61ae6c00b04d9009aaeda644d0b5bdfbf6c67247f492f42b3f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3641,14 +4029,29 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -3682,7 +4085,38 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee7893dab2e44ae5f9d0173f26ff4aa327c10b01b06a72b52dd9405b628640d"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools 0.11.0",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -3699,6 +4133,15 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "lexicmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7378d131ddf24063b32cbd7e91668d183140c4b3906270635a4d633d1068ea5d"
+dependencies = [
+ "any_ascii",
+]
 
 [[package]]
 name = "lexicmp"
@@ -3739,7 +4182,7 @@ checksum = "1da773dcce45661428e2b51ca984eb3c64c08f2aa54865397e4b77d1f61c9f07"
 dependencies = [
  "bitflags 2.11.1",
  "derive_more",
- "indexmap",
+ "indexmap 2.14.0",
  "libc",
  "mdbx-sys",
  "parking_lot",
@@ -3788,6 +4231,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "linfa-linalg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e7562b41c8876d3367897067013bb2884cc78e6893f092ecd26b305176ac82"
+dependencies = [
+ "ndarray 0.15.6",
+ "num-traits",
+ "rand 0.8.6",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3827,15 +4282,24 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -3858,8 +4322,8 @@ dependencies = [
  "enum_dispatch",
  "interval-heap",
  "log",
- "lz4_flex 0.13.0",
- "quick_cache",
+ "lz4_flex 0.13.1",
+ "quick_cache 0.6.22",
  "rustc-hash",
  "self_cell",
  "sfa",
@@ -3898,18 +4362,18 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
+checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
 dependencies = [
  "twox-hash",
 ]
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
 ]
@@ -4069,9 +4533,9 @@ dependencies = [
 
 [[package]]
 name = "maybe-async"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4131,6 +4595,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miette"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+dependencies = [
+ "miette-derive",
+ "once_cell",
+ "thiserror 1.0.69",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4289,6 +4776,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4325,7 +4829,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "keyed_priority_queue",
- "lru",
+ "lru 0.16.4",
  "mysql_common",
  "pem",
  "percent-encoding",
@@ -4408,6 +4912,20 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+dependencies = [
+ "approx 0.4.0",
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
+]
+
+[[package]]
+name = "ndarray"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
@@ -4423,13 +4941,28 @@ dependencies = [
 
 [[package]]
 name = "ndarray-stats"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af5a8477ac96877b5bd1fd67e0c28736c12943aba24eda92b127e036b0c8f400"
+dependencies = [
+ "indexmap 1.9.3",
+ "itertools 0.10.5",
+ "ndarray 0.15.6",
+ "noisy_float",
+ "num-integer",
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ndarray-stats"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6e54a8b65764f71827a90ca1d56965ec0c67f069f996477bd493402a901d1f"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.13.0",
- "ndarray",
+ "ndarray 0.17.2",
  "noisy_float",
  "num-integer",
  "num-traits",
@@ -4580,9 +5113,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-format"
@@ -4757,15 +5290,14 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -4795,9 +5327,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -5016,13 +5548,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -5033,6 +5575,16 @@ checksum = "3673cba5b9a124916096a423b806a9f29620972c6c97b08db5f2053e9428b481"
 dependencies = [
  "bytes",
  "postgres-types",
+]
+
+[[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures",
+ "rustc_version",
 ]
 
 [[package]]
@@ -5097,6 +5649,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+ "unicase",
 ]
 
 [[package]]
@@ -5120,6 +5673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
+ "unicase",
 ]
 
 [[package]]
@@ -5133,19 +5687,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.11"
+name = "pico-args"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5192,6 +5752,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5199,9 +5773,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -5470,6 +6044,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5510,9 +6094,21 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.21"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a70b1b8b47e31d0498ecbc3c5470bb931399a8bfed1fd79d1717a61ce7f96e3"
+checksum = "eb55a1aa7668676bb93926cd4e9cdfe60f03bb866553bcca9112554911b6d3dc"
+dependencies = [
+ "ahash 0.8.12",
+ "equivalent",
+ "hashbrown 0.14.5",
+ "parking_lot",
+]
+
+[[package]]
+name = "quick_cache"
+version = "0.6.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c821816e9b928e20e92ed59bb3ac4aab321d16ca2316871c9fe7ca739cd477"
 dependencies = [
  "ahash 0.8.12",
  "equivalent",
@@ -5573,7 +6169,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5605,11 +6201,22 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type 0.1.2",
+ "nibble_vec",
+ "serde",
+]
+
+[[package]]
+name = "radix_trie"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b4431027dcd37fc2a73ef740b5f233aa805897935b8bce0195e41bbf9a3289a"
 dependencies = [
- "endian-type",
+ "endian-type 0.2.0",
  "nibble_vec",
  "serde",
 ]
@@ -5725,9 +6332,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -5787,6 +6394,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5855,6 +6493,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -5878,13 +6517,14 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5935,6 +6575,30 @@ checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "revision"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f53179a035f881adad8c4d58a2c599c6b4a8325b989c68d178d7a34d1b1e4c"
+dependencies = [
+ "revision-derive 0.10.0",
+]
+
+[[package]]
+name = "revision"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b8ee532f15b2f0811eb1a50adf10d036e14a6cdae8d99893e7f3b921cb227d"
+dependencies = [
+ "chrono",
+ "geo 0.28.0",
+ "regex",
+ "revision-derive 0.11.0",
+ "roaring 0.10.12",
+ "rust_decimal",
+ "uuid",
+]
+
+[[package]]
+name = "revision"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b66f44139d1fe8e1b6c21bf1a855f12df38517aab94e21cea2a077e9753f216"
@@ -5943,10 +6607,32 @@ dependencies = [
  "chrono",
  "geo 0.31.0",
  "regex",
- "revision-derive",
- "roaring",
+ "revision-derive 0.17.1",
+ "roaring 0.11.4",
  "rust_decimal",
  "uuid",
+]
+
+[[package]]
+name = "revision-derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0ec466e5d8dca9965eb6871879677bef5590cf7525ad96cae14376efb75073"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "revision-derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3415e1bc838c36f9a0a2ac60c0fa0851c72297685e66592c44870d82834dfa2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6042,10 +6728,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "roaring"
-version = "0.11.3"
+name = "rmpv"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
+checksum = "7a4e1d4b9b938a26d2996af33229f0ca0956c652c1375067f0b45291c1df8417"
+dependencies = [
+ "rmp",
+]
+
+[[package]]
+name = "roaring"
+version = "0.10.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "serde",
+]
+
+[[package]]
+name = "roaring"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -6221,6 +6927,15 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_lexer"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86aae0c77166108c01305ee1a36a1e77289d7dc6ca0a3cd91ff4992de2d16a5"
+dependencies = [
+ "unicode-xid",
+]
 
 [[package]]
 name = "rustc_version"
@@ -6408,6 +7123,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6435,7 +7174,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
- "dashmap",
+ "dashmap 6.2.1",
  "futures",
  "hashbrown 0.15.5",
  "itertools 0.14.0",
@@ -6582,6 +7321,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6589,6 +7334,15 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-content"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3753ca04f350fa92d00b6146a3555e63c55388c9ef2e11e09bce2ff1c0b509c6"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6627,7 +7381,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -6689,19 +7443,29 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
  "serde_core",
+ "serde_json",
  "serde_with_macros",
+ "time",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -6715,7 +7479,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -6875,9 +7639,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -6936,6 +7700,15 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
  "serde",
 ]
@@ -7013,10 +7786,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "static_assertions_next"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7beae5182595e9a8b683fa98c4317f956c9a2dec3b9716990d20023cc60c766"
+
+[[package]]
+name = "storekey"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c42833834a5d23b344f71d87114e0cc9994766a5c42938f4b50e7b2aef85b2"
+dependencies = [
+ "byteorder",
+ "memchr",
+ "serde",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "storekey"
@@ -7042,9 +7846,9 @@ dependencies = [
 
 [[package]]
 name = "str_stack"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+checksum = "7f446288b699d66d0fd2e30d1cfe7869194312524b3b9252594868ed26ef056a"
 
 [[package]]
 name = "string_cache"
@@ -7095,10 +7899,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "surrealdb"
+version = "2.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3429154a8b5a98ca39100ba45ef49ae046fb1d0869dff78d78a2670b1b278982"
+dependencies = [
+ "arrayvec",
+ "async-channel",
+ "bincode 1.3.3",
+ "chrono",
+ "dmp",
+ "futures",
+ "geo 0.28.0",
+ "getrandom 0.3.4",
+ "indexmap 2.14.0",
+ "path-clean",
+ "pharos",
+ "reblessive",
+ "reqwest 0.12.28",
+ "revision 0.11.0",
+ "ring",
+ "rust_decimal",
+ "rustls",
+ "rustls-pki-types",
+ "semver",
+ "serde",
+ "serde-content",
+ "serde_json",
+ "surrealdb-core 2.6.5",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-tungstenite 0.23.1",
+ "tokio-util",
+ "tracing",
+ "trice",
+ "url",
+ "uuid",
+ "wasm-bindgen-futures",
+ "wasmtimer 0.2.1",
+ "ws_stream_wasm",
+]
 
 [[package]]
 name = "surrealdb"
@@ -7112,21 +7979,21 @@ dependencies = [
  "chrono",
  "futures",
  "getrandom 0.3.4",
- "indexmap",
+ "indexmap 2.14.0",
  "js-sys",
  "path-clean",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "ring",
  "rustls",
  "rustls-pki-types",
  "semver",
  "serde",
  "serde_json",
- "surrealdb-core",
+ "surrealdb-core 3.0.5",
  "surrealdb-types",
  "surrealdb-types-derive",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tokio-tungstenite-wasm",
  "tokio-util",
  "tracing",
@@ -7134,8 +8001,101 @@ dependencies = [
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasmtimer",
+ "wasmtimer 0.4.3",
  "web-sys",
+]
+
+[[package]]
+name = "surrealdb-core"
+version = "2.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba423d9e7e665e4c735a1d4669c3a067135e4a574edf88af215f7f2b815e70ed"
+dependencies = [
+ "addr",
+ "affinitypool 0.3.1",
+ "ahash 0.8.12",
+ "ammonia",
+ "any_ascii",
+ "argon2",
+ "async-channel",
+ "async-executor",
+ "async-graphql",
+ "base64 0.21.7",
+ "bcrypt 0.15.1",
+ "bincode 1.3.3",
+ "blake3",
+ "bytes",
+ "castaway",
+ "cedar-policy",
+ "chrono",
+ "ciborium",
+ "dashmap 5.5.3",
+ "deunicode",
+ "dmp",
+ "ext-sort",
+ "fst",
+ "futures",
+ "fuzzy-matcher",
+ "geo 0.28.0",
+ "geo-types",
+ "getrandom 0.3.4",
+ "hashbrown 0.14.5",
+ "hex",
+ "http",
+ "ipnet",
+ "jsonwebtoken 9.3.1",
+ "lexicmp 0.1.0",
+ "linfa-linalg",
+ "md-5 0.10.6",
+ "ndarray 0.15.6",
+ "ndarray-stats 0.5.1",
+ "num-traits",
+ "num_cpus",
+ "object_store 0.12.5",
+ "parking_lot",
+ "pbkdf2",
+ "pharos",
+ "phf 0.11.3",
+ "pin-project-lite",
+ "quick_cache 0.5.2",
+ "radix_trie 0.2.1",
+ "rand 0.8.6",
+ "rayon",
+ "reblessive",
+ "regex",
+ "revision 0.11.0",
+ "ring",
+ "rmpv",
+ "roaring 0.10.12",
+ "rust-stemmers",
+ "rust_decimal",
+ "scrypt",
+ "semver",
+ "serde",
+ "serde-content",
+ "serde_json",
+ "sha1",
+ "sha2 0.10.9",
+ "snap",
+ "storekey 0.5.0",
+ "strsim 0.11.1",
+ "subtle",
+ "surrealdb-rocksdb",
+ "surrealkv 0.9.3",
+ "sysinfo 0.33.1",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "trice",
+ "ulid",
+ "unicase",
+ "url",
+ "uuid",
+ "vart 0.8.1",
+ "wasm-bindgen-futures",
+ "wasmtimer 0.2.1",
+ "ws_stream_wasm",
 ]
 
 [[package]]
@@ -7145,7 +8105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e6a7f248c958fd5000c4fab5759503663bf93c622be10a6d7bf7d2d676b8fc"
 dependencies = [
  "addr",
- "affinitypool",
+ "affinitypool 0.4.0",
  "ahash 0.8.12",
  "ammonia",
  "anyhow",
@@ -7154,12 +8114,12 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.22.1",
- "bcrypt",
+ "bcrypt 0.18.0",
  "blake3",
  "bytes",
  "chrono",
  "ciborium",
- "dashmap",
+ "dashmap 6.2.1",
  "deunicode",
  "dmp",
  "ext-sort",
@@ -7175,12 +8135,12 @@ dependencies = [
  "http",
  "humantime",
  "ipnet",
- "jsonwebtoken",
- "lexicmp",
+ "jsonwebtoken 10.4.0",
+ "lexicmp 0.2.0",
  "md-5 0.10.6",
  "mime",
- "ndarray",
- "ndarray-stats",
+ "ndarray 0.17.2",
+ "ndarray-stats 0.7.0",
  "num-traits",
  "num_cpus",
  "object_store 0.13.2",
@@ -7189,15 +8149,15 @@ dependencies = [
  "pbkdf2",
  "phf 0.13.1",
  "pin-project-lite",
- "quick_cache",
- "radix_trie",
+ "quick_cache 0.6.22",
+ "radix_trie 0.3.0",
  "rand 0.8.6",
  "rayon",
  "reblessive",
  "regex",
- "revision",
+ "revision 0.17.1",
  "ring",
- "roaring",
+ "roaring 0.11.4",
  "rust-stemmers",
  "rust_decimal",
  "scrypt",
@@ -7206,13 +8166,13 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2 0.10.9",
- "storekey",
+ "storekey 0.11.0",
  "strsim 0.11.1",
  "subtle",
  "surrealdb-protocol",
  "surrealdb-rocksdb",
  "surrealdb-types",
- "surrealkv",
+ "surrealkv 0.21.2",
  "surrealmx",
  "sysinfo 0.37.2",
  "tempfile",
@@ -7224,9 +8184,9 @@ dependencies = [
  "unicase",
  "url",
  "uuid",
- "vart",
+ "vart 0.9.3",
  "wasm-bindgen-futures",
- "wasmtimer",
+ "wasmtimer 0.4.3",
  "web-time",
 ]
 
@@ -7318,6 +8278,25 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a5041979bdff8599a1d5f6cb7365acb9a79664e2a84e5c4fddac2b3969f7d1"
+dependencies = [
+ "ahash 0.8.12",
+ "bytes",
+ "chrono",
+ "crc32fast",
+ "double-ended-peekable",
+ "getrandom 0.2.17",
+ "lru 0.12.5",
+ "parking_lot",
+ "quick_cache 0.6.22",
+ "revision 0.10.0",
+ "vart 0.9.3",
+]
+
+[[package]]
+name = "surrealkv"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0672cbbe282723a62ccee14b95232ca0b4c9bf44ea22fb520c43e7c517fb8ec"
@@ -7334,9 +8313,9 @@ dependencies = [
  "guardian",
  "integer-encoding",
  "log",
- "lz4_flex 0.12.1",
+ "lz4_flex 0.12.2",
  "parking_lot",
- "quick_cache",
+ "quick_cache 0.6.22",
  "rand 0.9.4",
  "scopeguard",
  "sha2 0.10.9",
@@ -7369,9 +8348,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "12.17.4"
+version = "12.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803d14d7cb9c6fa5b95a6f3de8af95b356a528d391998fa45a07d320a5573e51"
+checksum = "332615d90111d8eeaf86a84dc9bbe9f65d0d8c5cf11b4caccedc37754eb0dcfd"
 dependencies = [
  "debugid",
  "memmap2",
@@ -7381,9 +8360,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.17.4"
+version = "12.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39505731ae891b2dde47b0e4ae2ec40a7ced3476ab1129f1bf829e3fba62bb83"
+checksum = "912017718eb4d21930546245af9a3475c9dccf15675a5c215664e76621afc471"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -7443,6 +8422,20 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows 0.57.0",
+]
+
+[[package]]
+name = "sysinfo"
 version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3ffa3e4ff2b324a57f7aeb3c349656c7b127c3c189520251a648102a92496e"
@@ -7452,7 +8445,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -7467,7 +8460,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "serde",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -7531,6 +8524,17 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -7754,6 +8758,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite 0.23.0",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
@@ -7764,7 +8784,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.28.0",
  "webpki-roots 0.26.11",
 ]
 
@@ -7782,7 +8802,7 @@ dependencies = [
  "js-sys",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -7821,7 +8841,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -7863,7 +8883,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -7877,10 +8897,10 @@ version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -7889,7 +8909,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -7952,7 +8972,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -7965,9 +8985,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
  "bitflags 2.11.1",
@@ -7977,13 +8997,13 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "iri-string",
  "pin-project-lite",
  "tokio",
  "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -8075,6 +9095,27 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
@@ -8149,6 +9190,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "ulid"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8202,10 +9249,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
+name = "unicode-security"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e4ddba1535dd35ed8b61c52166b7155d7f4e4b8847cec6f48e71dc66d8b5e50"
+dependencies = [
+ "unicode-normalization",
+ "unicode-script",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -8305,6 +9374,12 @@ checksum = "8f54a172d0620933a27a4360d3db3e2ae0dd6cceae9730751a036bbf182c4b23"
 
 [[package]]
 name = "vart"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87782b74f898179396e93c0efabb38de0d58d50bbd47eae00c71b3a1144dbbae"
+
+[[package]]
+name = "vart"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1982d899e57d646498709735f16e9224cf1e8680676ad687f930cf8b5b555ae"
@@ -8390,9 +9465,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8404,9 +9479,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8414,9 +9489,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8424,9 +9499,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -8437,9 +9512,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -8461,7 +9536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -8500,8 +9575,21 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7ed9d8b15c7fb594d72bfb4b5a276f3d2029333cd93a932f376f5937f6f80ee"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -8519,9 +9607,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8578,9 +9666,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 dependencies = [
  "libc",
  "libredox",
@@ -8628,12 +9716,22 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -8645,7 +9743,19 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8654,11 +9764,24 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -8667,9 +9790,20 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
  "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8677,6 +9811,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8712,7 +9857,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
 ]
 
@@ -8725,6 +9870,15 @@ dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8769,7 +9923,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8778,7 +9932,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -8796,14 +9959,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -8822,10 +10002,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8834,10 +10026,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8846,10 +10050,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -8858,10 +10074,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -8883,9 +10111,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -8924,7 +10152,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -8955,7 +10183,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -8974,7 +10202,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -8989,6 +10217,25 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "ws_stream_wasm"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc"
+dependencies = [
+ "async_io_stream",
+ "futures",
+ "js-sys",
+ "log",
+ "pharos",
+ "rustc_version",
+ "send_wrapper",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "wyz"
@@ -9056,9 +10303,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ default = [
     "slatedb",
     "sqlite",
     "surrealdb",
+    "surrealdb2",
     "surrealkv",
     "surrealmx",
 ]
@@ -61,6 +62,15 @@ surrealdb = [
     "surrealdb/protocol-http",
     "surrealdb/protocol-ws",
     "surrealdb/rustls",
+]
+surrealdb2 = [
+    "dep:surrealdb2",
+    "surrealdb2/kv-mem",
+    "surrealdb2/kv-rocksdb",
+    "surrealdb2/kv-surrealkv",
+    "surrealdb2/protocol-http",
+    "surrealdb2/protocol-ws",
+    "surrealdb2/rustls",
 ]
 surrealkv = ["dep:surrealkv"]
 surrealmx = ["dep:surrealmx"]
@@ -121,6 +131,7 @@ slatedb = { version = "0.10.1", features = ["snappy", "foyer"], optional = true 
 serde_json = "1.0.150"
 serial_test = "3.4.0"
 surrealdb = { version = "3.0.5", default-features = false, optional = true }
+surrealdb2 = { package = "surrealdb", version = "2.6", default-features = false, optional = true }
 surrealkv = { version = "0.21.2", optional = true }
 surrealmx = { version = "0.18.0", optional = true }
 sysinfo = { version = "0.37.2", features = ["serde"] }

--- a/src/database.rs
+++ b/src/database.rs
@@ -56,6 +56,12 @@ pub(crate) enum Database {
 	Sqlite,
 	#[cfg(feature = "surrealdb")]
 	Surrealdb,
+	/// SurrealDB 2.X server adapter — links against the v2 SDK (renamed
+	/// crate `surrealdb2`) and talks to a 2.x server. Use this when the
+	/// target is a v2 deployment; the default `Surrealdb` variant only
+	/// speaks the v3 RPC protocol.
+	#[cfg(feature = "surrealdb2")]
+	Surrealdb2,
 	#[cfg(feature = "surrealkv")]
 	Surrealkv,
 	#[cfg(feature = "surrealmx")]
@@ -78,6 +84,8 @@ impl Database {
 		match self {
 			#[cfg(feature = "surrealdb")]
 			Database::Surrealdb => crate::surrealdb::wants_docker(endpoint.as_deref()),
+			#[cfg(feature = "surrealdb2")]
+			Database::Surrealdb2 => crate::surrealdb2::wants_docker(endpoint.as_deref()),
 			_ => endpoint.is_none(),
 		}
 	}
@@ -108,6 +116,8 @@ impl Database {
 			Self::Scylladb => crate::scylladb::docker(options),
 			#[cfg(feature = "surrealdb")]
 			Self::Surrealdb => crate::surrealdb::docker(options),
+			#[cfg(feature = "surrealdb2")]
+			Self::Surrealdb2 => crate::surrealdb2::docker(options),
 			#[allow(unreachable_patterns)]
 			_ => return None,
 		};
@@ -455,6 +465,26 @@ impl Database {
 					)
 					.await
 			}
+			#[cfg(feature = "surrealdb2")]
+			Database::Surrealdb2 => {
+				benchmark
+					.run::<_, SurrealDBDialect, _>(
+						crate::surrealdb2::SurrealDB2ClientProvider::setup(
+							kt,
+							vp.columns(),
+							benchmark,
+						)
+						.await?,
+						kp,
+						vp,
+						scans,
+						batches,
+						database.clone(),
+						system.clone(),
+						metadata.clone(),
+					)
+					.await
+			}
 			#[cfg(feature = "surrealdb")]
 			Database::Surrealds => {
 				benchmark
@@ -563,6 +593,8 @@ impl Database {
 			Database::Surrealmx => "SurrealMX",
 			#[cfg(feature = "surrealdb")]
 			Database::Surrealdb => "SurrealDB",
+			#[cfg(feature = "surrealdb2")]
+			Database::Surrealdb2 => "SurrealDB 2.x",
 			#[allow(unreachable_patterns)]
 			_ => "Unknown",
 		}

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,7 @@ mod scylladb;
 mod slatedb;
 mod sqlite;
 mod surrealdb;
+mod surrealdb2;
 mod surrealds;
 mod surrealkv;
 mod surrealmx;

--- a/src/surrealdb2.rs
+++ b/src/surrealdb2.rs
@@ -29,16 +29,16 @@ use std::collections::BTreeMap;
 use std::env;
 use std::hint::black_box;
 use std::time::Duration;
-use surrealdb2 as surrealdb;
 use surrealdb::Surreal;
 use surrealdb::engine::any::{Any, connect};
 use surrealdb::opt::Config;
 use surrealdb::opt::Resource;
 use surrealdb::opt::auth::Root;
 use surrealdb::sql::{
-	Array, Bytes as SurrealBytes, Datetime, Id, Number, Object, Strand, Thing,
-	Uuid as SurrealUuid, Value,
+	Array, Bytes as SurrealBytes, Datetime, Id, Number, Object, Strand, Thing, Uuid as SurrealUuid,
+	Value,
 };
+use surrealdb2 as surrealdb;
 use tokio::time::{sleep, timeout};
 
 /// Convert a [`BenchValue`] to a native v2 [`Value`].
@@ -478,7 +478,9 @@ impl BenchmarkClient for SurrealDB2Client {
 					"DEFINE INDEX {name} ON TABLE record FIELDS {fields} FULLTEXT ANALYZER {name} BM25 CONCURRENTLY"
 				)
 			}
-			_ => format!("DEFINE INDEX {name} ON TABLE record FIELDS {fields} {unique} CONCURRENTLY"),
+			_ => {
+				format!("DEFINE INDEX {name} ON TABLE record FIELDS {fields} {unique} CONCURRENTLY")
+			}
 		};
 		self.db.query(&sql).await.map_err(log_sql_err(&sql))?.check().map_err(log_sql_err(&sql))?;
 		// Poll until the index reports ready. v2's `INFO FOR INDEX` returns
@@ -764,12 +766,8 @@ impl SurrealDB2Client {
 		let sql = "DELETE $id RETURN NULL";
 		let id = thing(key);
 		run_dml_with_retry(sql, || async {
-			let res = self
-				.db
-				.query(sql)
-				.bind(("id", id.clone()))
-				.await?
-				.take::<surrealdb::Value>(0)?;
+			let res =
+				self.db.query(sql).bind(("id", id.clone())).await?.take::<surrealdb::Value>(0)?;
 			assert!(!res.into_inner().is_none());
 			Ok(())
 		})
@@ -802,8 +800,7 @@ impl SurrealDB2Client {
 		let q_value = Value::Array(Array::from(
 			query.iter().map(|f| Value::Number(Number::Float(*f as f64))).collect::<Vec<_>>(),
 		));
-		let mut resp =
-			self.db.query(&sql).bind(("q", q_value)).await.map_err(log_sql_err(&sql))?;
+		let mut resp = self.db.query(&sql).bind(("q", q_value)).await.map_err(log_sql_err(&sql))?;
 		let res: surrealdb::Value = resp.take(0).map_err(log_sql_err(&sql))?;
 		match res.into_inner() {
 			Value::Array(a) => Ok(a.0.len()),

--- a/src/surrealdb2.rs
+++ b/src/surrealdb2.rs
@@ -1,0 +1,961 @@
+#![cfg(feature = "surrealdb2")]
+
+//! SurrealDB 2.x adapter.
+//!
+//! Parallel to [crate::surrealdb], but linked against the v2 SDK (renamed in
+//! Cargo.toml as `surrealdb2`). The v2 SDK can only talk to a v2 server (the
+//! RPC protocol changed in v3), and v2 lives in `surrealdb::sql::*` rather
+//! than v3's `surrealdb::types::*`. Surreal-side syntax diffs vs v3:
+//! `ALTER SYSTEM COMPACT` doesn't exist, and the DiskANN vector index isn't
+//! shipped yet — both are caught at runtime (compact is a no-op; DiskANN
+//! DDL trips the parse-error path and is reported as NotSupported).
+
+use crate::benchmark::NOT_SUPPORTED_ERROR;
+use crate::dialect::SurrealDBDialect;
+use crate::docker::DockerParams;
+use crate::engine::{BenchmarkClient, BenchmarkEngine, ScanContext};
+use crate::memory::Config as MemoryConfig;
+use crate::value::BenchValue;
+use crate::valueprovider::Columns;
+use crate::{
+	Benchmark, Index, KeyType, Projection, Scan, VectorDistance, VectorIndexStrategy,
+	VectorQuerySpec,
+};
+use anyhow::{Result, bail};
+use log::{error, warn};
+use serde::Serialize;
+use serde_json::Value as JsonValue;
+use std::collections::BTreeMap;
+use std::env;
+use std::hint::black_box;
+use std::time::Duration;
+use surrealdb2 as surrealdb;
+use surrealdb::Surreal;
+use surrealdb::engine::any::{Any, connect};
+use surrealdb::opt::Config;
+use surrealdb::opt::Resource;
+use surrealdb::opt::auth::Root;
+use surrealdb::sql::{
+	Array, Bytes as SurrealBytes, Datetime, Id, Number, Object, Strand, Thing,
+	Uuid as SurrealUuid, Value,
+};
+use tokio::time::{sleep, timeout};
+
+/// Convert a [`BenchValue`] to a native v2 [`Value`].
+fn bench_to_surreal_value(v: BenchValue) -> Value {
+	match v {
+		BenchValue::Null => Value::Null,
+		BenchValue::Bool(b) => Value::Bool(b),
+		BenchValue::Int(i) => Value::Number(Number::Int(i)),
+		BenchValue::UInt(u) => match i64::try_from(u) {
+			Ok(i) => Value::Number(Number::Int(i)),
+			Err(_) => Value::Number(Number::Float(u as f64)),
+		},
+		BenchValue::Float(f) => Value::Number(Number::Float(f)),
+		BenchValue::Decimal(d) => Value::Number(Number::Decimal(d)),
+		BenchValue::String(s) => Value::Strand(Strand::from(s)),
+		BenchValue::Bytes(b) => Value::Bytes(SurrealBytes::from(b)),
+		BenchValue::Uuid(u) => Value::Uuid(SurrealUuid::from(u)),
+		BenchValue::DateTime(dt) => Value::Datetime(Datetime::from(dt)),
+		BenchValue::Array(a) => {
+			Value::Array(Array::from(a.into_iter().map(bench_to_surreal_value).collect::<Vec<_>>()))
+		}
+		BenchValue::Object(o) => {
+			let mut map: BTreeMap<String, Value> = BTreeMap::new();
+			for (k, v) in o {
+				map.insert(k, bench_to_surreal_value(v));
+			}
+			Value::Object(Object::from(map))
+		}
+		BenchValue::FloatVector(v) => Value::Array(Array::from(
+			v.into_iter().map(|f| Value::Number(Number::Float(f as f64))).collect::<Vec<_>>(),
+		)),
+	}
+}
+
+/// Convert a native v2 [`Value`] back to a [`BenchValue`]. For variants that
+/// don't have a direct BenchValue mapping (Duration, Geometry, Thing, …) we
+/// fall back to the SurrealQL `Display` form, mirroring the v3 adapter.
+fn surreal_to_bench_value(v: Value) -> BenchValue {
+	match v {
+		Value::None | Value::Null => BenchValue::Null,
+		Value::Bool(b) => BenchValue::Bool(b),
+		Value::Number(Number::Int(i)) => BenchValue::Int(i),
+		Value::Number(Number::Float(f)) => BenchValue::Float(f),
+		Value::Number(Number::Decimal(d)) => BenchValue::Decimal(d),
+		Value::Strand(s) => BenchValue::String(s.0),
+		Value::Bytes(b) => BenchValue::Bytes(Vec::<u8>::from(b)),
+		Value::Uuid(u) => BenchValue::Uuid(u.0),
+		Value::Datetime(dt) => BenchValue::DateTime(dt.0),
+		Value::Array(a) => BenchValue::Array(a.0.into_iter().map(surreal_to_bench_value).collect()),
+		Value::Object(o) => {
+			let mut out: Vec<(String, BenchValue)> = Vec::new();
+			for (k, v) in o.0 {
+				out.push((k, surreal_to_bench_value(v)));
+			}
+			BenchValue::Object(out)
+		}
+		other => BenchValue::String(other.to_string()),
+	}
+}
+
+const DEFAULT: &str = "ws://127.0.0.1:8000";
+const TABLE: &str = "record";
+
+fn surreal_distance_keyword(d: VectorDistance) -> &'static str {
+	match d {
+		VectorDistance::Cosine => "COSINE",
+		VectorDistance::Euclidean => "EUCLIDEAN",
+		VectorDistance::InnerProduct => "INNER_PRODUCT",
+		VectorDistance::Manhattan => "MANHATTAN",
+	}
+}
+
+fn surreal_distance_function(d: VectorDistance) -> &'static str {
+	match d {
+		VectorDistance::Cosine => "vector::similarity::cosine",
+		VectorDistance::Euclidean => "vector::distance::euclidean",
+		VectorDistance::InnerProduct => "vector::dot",
+		VectorDistance::Manhattan => "vector::distance::manhattan",
+	}
+}
+
+fn surreal_distance_order(d: VectorDistance) -> &'static str {
+	match d {
+		VectorDistance::Cosine | VectorDistance::InnerProduct => "DESC",
+		VectorDistance::Euclidean | VectorDistance::Manhattan => "ASC",
+	}
+}
+
+/// Wraps a v2 [`Value`]; [`BenchValue`] is produced only via [`From`]/[`Into`].
+pub(crate) struct Row(pub Value);
+
+impl From<Row> for BenchValue {
+	fn from(row: Row) -> BenchValue {
+		// `db.select(Resource::from(rid))` returns a `Value::Array` of matching
+		// rows even for a single record — unwrap the singleton so the caller
+		// sees `BenchValue::Object` rather than `BenchValue::Array(vec![Object])`.
+		let inner = match row.0 {
+			Value::Array(a) if a.0.len() == 1 => a.0.into_iter().next().expect("len == 1 guard"),
+			other => other,
+		};
+		surreal_to_bench_value(inner)
+	}
+}
+
+fn is_surreal_parse_error<E: std::fmt::Display>(e: &E) -> bool {
+	e.to_string().contains("Parse error")
+}
+
+fn log_sql_err<E>(sql: &str) -> impl FnOnce(E) -> anyhow::Error
+where
+	E: std::fmt::Display + Into<anyhow::Error>,
+{
+	let sql = sql.to_owned();
+	move |e| {
+		error!("SurrealDB v2 query failed: {sql}\n  cause: {e}");
+		let err: anyhow::Error = e.into();
+		err.context(format!("query: {sql}"))
+	}
+}
+
+const RETRYABLE_CONFLICT_MARKERS: &[&str] =
+	&["This transaction can be retried", "The query was not executed due to a failed transaction"];
+
+fn is_retryable_conflict<E: std::fmt::Display>(e: &E) -> bool {
+	let msg = e.to_string();
+	RETRYABLE_CONFLICT_MARKERS.iter().any(|p| msg.contains(p))
+}
+
+async fn run_dml_with_retry<F, Fut>(sql: &str, mut op: F) -> Result<()>
+where
+	F: FnMut() -> Fut,
+	Fut: std::future::Future<Output = std::result::Result<(), surrealdb::Error>>,
+{
+	const MAX_RETRIES: u32 = 16;
+	const MAX_DELAY: Duration = Duration::from_millis(100);
+	let mut delay = Duration::from_millis(1);
+	let mut attempts = 0u32;
+	loop {
+		match op().await {
+			Ok(()) => return Ok(()),
+			Err(e) if is_retryable_conflict(&e) && attempts < MAX_RETRIES => {
+				attempts += 1;
+				warn!("Retrying {sql} due to transaction conflict (attempt {attempts}): {e}");
+				sleep(delay).await;
+				delay = (delay * 2).min(MAX_DELAY);
+			}
+			Err(e) => return Err(log_sql_err(sql)(e)),
+		}
+	}
+}
+
+pub(crate) enum Docker {
+	Memory,
+	Rocksdb,
+	Surrealkv,
+}
+
+pub(crate) enum Endpoint {
+	Docker(Docker),
+	Embedded(String),
+	Remote(String),
+}
+
+pub(crate) fn wants_docker(endpoint: Option<&str>) -> bool {
+	matches!(parse_endpoint(endpoint), Ok(Endpoint::Docker(_)))
+}
+
+pub(crate) fn parse_endpoint(opt: Option<&str>) -> Result<Endpoint> {
+	let Some(raw) = opt else {
+		return Ok(Endpoint::Docker(Docker::Rocksdb));
+	};
+	let s = raw.trim();
+	if s.is_empty() {
+		return Ok(Endpoint::Docker(Docker::Rocksdb));
+	}
+	if s.starts_with("ws://")
+		|| s.starts_with("wss://")
+		|| s.starts_with("http://")
+		|| s.starts_with("https://")
+	{
+		return Ok(Endpoint::Remote(s.to_string()));
+	}
+	if let Some(rest) = s.strip_prefix("server:") {
+		return match rest {
+			"rocksdb" => Ok(Endpoint::Docker(Docker::Rocksdb)),
+			"memory" => Ok(Endpoint::Docker(Docker::Memory)),
+			"surrealkv" => Ok(Endpoint::Docker(Docker::Surrealkv)),
+			_ => bail!(
+				"Invalid server backend {rest:?}. Expected server:rocksdb, server:memory, or server:surrealkv.",
+			),
+		};
+	}
+	if s == "memory" {
+		return Ok(Endpoint::Embedded("mem://".to_string()));
+	}
+	if s.starts_with("mem:") {
+		return Ok(Endpoint::Embedded(s.to_string()));
+	}
+	if s.starts_with("rocksdb:") || s.starts_with("surrealkv:") {
+		return Ok(Endpoint::Embedded(s.to_string()));
+	}
+	bail!(
+		"Invalid SurrealDB v2 endpoint {:?}. Expected:\n\
+		 - server:rocksdb | server:memory | server:surrealkv (Docker)\n\
+		 - rocksdb:<path>[?args] | surrealkv:<path>[?args] | memory | mem:// | mem:<path>[?args] (embedded)\n\
+		 - ws://... | wss://... | http://... | https://... (remote)",
+		s
+	)
+}
+
+fn calculate_surrealdb_memory() -> u64 {
+	let memory = MemoryConfig::new();
+	(memory.cache_gb * 4 / 6).max(1)
+}
+
+/// Reuse the same env vars as the v3 adapter so a host running both flavours
+/// can share credentials.
+pub(super) fn surrealdb_username() -> String {
+	env::var("SURREALDB_USER").unwrap_or_else(|_| String::from("root"))
+}
+
+pub(super) fn surrealdb_password() -> String {
+	env::var("SURREALDB_PASS").unwrap_or_else(|_| String::from("root"))
+}
+
+pub(crate) fn docker(options: &Benchmark) -> DockerParams {
+	let backend =
+		parse_endpoint(options.endpoint.as_deref()).unwrap_or(Endpoint::Docker(Docker::Rocksdb));
+	let cache_gb = calculate_surrealdb_memory();
+	let username = surrealdb_username();
+	let password = surrealdb_password();
+	let sync = if options.sync {
+		"every"
+	} else {
+		"never"
+	};
+	match backend {
+		Endpoint::Embedded(_) | Endpoint::Remote(_) => {
+			unreachable!("docker() must only be called when wants_docker is true")
+		}
+		Endpoint::Docker(Docker::Memory) => DockerParams {
+			image: "surrealdb/surrealdb:v2-latest",
+			pre_args: "--ulimit nofile=65536:65536 -p 8000:8000 --user root".to_string(),
+			post_args: match options.persisted {
+				true => format!(
+					"start --user {username} --pass {password} mem://?crud-bench.db?aol=sync&sync={sync}"
+				),
+				false => format!("start --user {username} --pass {password} mem://"),
+			},
+		},
+		Endpoint::Docker(Docker::Rocksdb) => DockerParams {
+			image: "surrealdb/surrealdb:v2-latest",
+			pre_args: match options.optimised {
+				true => format!(
+					"--ulimit nofile=65536:65536 -p 8000:8000 -e SURREAL_ROCKSDB_BLOCK_CACHE_SIZE={cache_gb}GB --user root",
+				),
+				false => "--ulimit nofile=65536:65536 -p 8000:8000 --user root".to_string(),
+			},
+			post_args: format!(
+				"start --user {username} --pass {password} rocksdb:/data/crud-bench.db?sync={sync}",
+			),
+		},
+		Endpoint::Docker(Docker::Surrealkv) => DockerParams {
+			image: "surrealdb/surrealdb:v2-latest",
+			pre_args: match options.optimised {
+				true => format!(
+					"--ulimit nofile=65536:65536 -p 8000:8000 -e SURREAL_SURREALKV_MAX_VALUE_CACHE_SIZE={cache_gb}GB --user root",
+				),
+				false => "--ulimit nofile=65536:65536 -p 8000:8000 --user root".to_string(),
+			},
+			post_args: format!(
+				"start --user {username} --pass {password} surrealkv:/data/crud-bench.db?sync={sync}",
+			),
+		},
+	}
+}
+
+pub(crate) struct SurrealDB2ClientProvider {
+	client: Option<Surreal<Any>>,
+	endpoint: String,
+	// v2's `Root<'a>` borrows the credentials, so we own them on the provider
+	// and synthesise a fresh `Root<'_>` per connection.
+	username: String,
+	password: String,
+}
+
+pub(super) async fn initialise_db(
+	endpoint: &str,
+	username: &str,
+	password: &str,
+) -> Result<Surreal<Any>> {
+	let root = Root {
+		username,
+		password,
+	};
+	let config = Config::new().user(root);
+	let db = connect((endpoint, config)).await?;
+	db.signin(root).await?;
+	db.use_ns("test").use_db("test").await?;
+	Ok(db)
+}
+
+impl BenchmarkEngine<SurrealDB2Client> for SurrealDB2ClientProvider {
+	async fn setup(_: KeyType, _columns: Columns, options: &Benchmark) -> Result<Self> {
+		let mode = parse_endpoint(options.endpoint.as_deref())?;
+		let username = surrealdb_username();
+		let password = surrealdb_password();
+		let (endpoint, client) = match mode {
+			Endpoint::Docker(_) => (DEFAULT.to_string(), None),
+			Endpoint::Remote(url) => (url, None),
+			Endpoint::Embedded(url) => {
+				let sync = if options.sync {
+					"every"
+				} else {
+					"never"
+				};
+				let full_url = if url.contains('?') {
+					format!("{url}&sync={sync}")
+				} else {
+					format!("{url}?sync={sync}")
+				};
+				let db = initialise_db(&full_url, &username, &password).await?;
+				(full_url, Some(db))
+			}
+		};
+		Ok(Self {
+			endpoint,
+			username,
+			password,
+			client,
+		})
+	}
+
+	async fn create_client(&self) -> Result<SurrealDB2Client> {
+		let client = match &self.client {
+			Some(client) => client.clone(),
+			None => initialise_db(&self.endpoint, &self.username, &self.password).await?,
+		};
+		Ok(SurrealDB2Client::new(client))
+	}
+}
+
+pub(crate) struct SurrealDB2Client {
+	db: Surreal<Any>,
+}
+
+impl SurrealDB2Client {
+	pub(super) const fn new(db: Surreal<Any>) -> Self {
+		Self {
+			db,
+		}
+	}
+}
+
+/// Plain serde wrapper so a query like `CREATE $id CONTENT $content` can bind
+/// both placeholders in one call. v2's `.bind(...)` takes any `Serialize`,
+/// and a struct serialised as an object becomes a name→value binding map.
+#[derive(Serialize)]
+struct Bindings {
+	id: Value,
+	content: Value,
+}
+
+impl BenchmarkClient for SurrealDB2Client {
+	type ReadRow = Row;
+
+	async fn startup(&self) -> Result<()> {
+		// Pre-create the table so concurrent first-writes don't all race to
+		// stand up NS+DB+TB and trip "resource busy" — same rationale as the
+		// v3 adapter.
+		let sql = "
+			REMOVE TABLE IF EXISTS record;
+			DEFINE TABLE record;
+		";
+		self.db.query(sql).await.map_err(log_sql_err(sql))?.check().map_err(log_sql_err(sql))?;
+		Ok(())
+	}
+
+	async fn compact(&self) -> Result<()> {
+		// `ALTER SYSTEM COMPACT` is v3-only; on v2 there's no equivalent
+		// statement so compaction is a no-op.
+		Ok(())
+	}
+
+	async fn create_u32(&self, key: u32, val: BenchValue) -> Result<()> {
+		self.create(key as i64, val).await
+	}
+
+	async fn create_string(&self, key: String, val: BenchValue) -> Result<()> {
+		self.create(key, val).await
+	}
+
+	async fn read_u32(&self, key: u32) -> Result<Row> {
+		self.read(key as i64).await
+	}
+
+	async fn read_string(&self, key: String) -> Result<Row> {
+		self.read(key).await
+	}
+
+	async fn update_u32(&self, key: u32, val: BenchValue) -> Result<()> {
+		self.update(key as i64, val).await
+	}
+
+	async fn update_string(&self, key: String, val: BenchValue) -> Result<()> {
+		self.update(key, val).await
+	}
+
+	async fn delete_u32(&self, key: u32) -> Result<()> {
+		self.delete(key as i64).await
+	}
+
+	async fn delete_string(&self, key: String) -> Result<()> {
+		self.delete(key).await
+	}
+
+	async fn build_index(&self, spec: &Index, name: &str) -> Result<()> {
+		let unique = if spec.unique.unwrap_or(false) {
+			"UNIQUE"
+		} else {
+			""
+		}
+		.to_string();
+		let fields = spec.fields.join(", ");
+		let sql = match &spec.index_type {
+			Some(kind) if kind == "fulltext" => {
+				let sql = format!(
+					"DEFINE ANALYZER IF NOT EXISTS {name} TOKENIZERS blank,class FILTERS lowercase,ascii;"
+				);
+				self.db
+					.query(&sql)
+					.await
+					.map_err(log_sql_err(&sql))?
+					.check()
+					.map_err(log_sql_err(&sql))?;
+				format!(
+					"DEFINE INDEX {name} ON TABLE record FIELDS {fields} FULLTEXT ANALYZER {name} BM25 CONCURRENTLY"
+				)
+			}
+			_ => format!("DEFINE INDEX {name} ON TABLE record FIELDS {fields} {unique} CONCURRENTLY"),
+		};
+		self.db.query(&sql).await.map_err(log_sql_err(&sql))?.check().map_err(log_sql_err(&sql))?;
+		// Poll until the index reports ready. v2's `INFO FOR INDEX` returns
+		// `{ building: { status } }` — same shape as v3 — but the SDK has no
+		// `Value::get()` helper, so we hop through `into_json()` and walk the
+		// JSON instead.
+		loop {
+			let sql = format!("INFO FOR INDEX {name} ON record");
+			let r: surrealdb::Value = self
+				.db
+				.query(&sql)
+				.await
+				.map_err(log_sql_err(&sql))?
+				.take(0)
+				.map_err(log_sql_err(&sql))?;
+			let j: JsonValue = r.into_inner().into_json();
+			let status = j
+				.get("building")
+				.and_then(|b| b.get("status"))
+				.and_then(|s| s.as_str())
+				.unwrap_or("");
+			match status {
+				"ready" => break,
+				"indexing" | "cleaning" | "started" => {}
+				other => bail!("Unexpected index status `{other}`: {j}"),
+			}
+			sleep(Duration::from_millis(500)).await;
+		}
+		Ok(())
+	}
+
+	async fn drop_index(&self, name: &str) -> Result<()> {
+		// Same retry/snapshot-cleanup rationale as the v3 adapter — concurrent
+		// scan snapshots can briefly block metadata writes, and `IF EXISTS`
+		// makes the retry idempotent.
+		let retry = |sql: String, max_wait: Duration| async move {
+			let fut = async {
+				loop {
+					match self.db.query(&sql).await?.check() {
+						Ok(_) => return Ok(()),
+						Err(e) => {
+							let msg = e.to_string();
+							const RETRYABLE: &[&str] = &[
+								"This transaction can be retried",
+								"The query was not executed due to a failed transaction",
+							];
+							if RETRYABLE.iter().any(|p| msg.contains(p)) {
+								warn!("Retrying {sql} due to {msg}");
+								sleep(Duration::from_millis(500)).await;
+								continue;
+							}
+							return Err(e);
+						}
+					}
+				}
+			};
+			match timeout(max_wait, fut).await {
+				Ok(res) => res.map_err(|e| e.into()),
+				Err(_) => bail!("Timed out after {:?} waiting to execute: {}", max_wait, sql),
+			}
+		};
+		let sql = format!("REMOVE INDEX IF EXISTS {name} ON TABLE record");
+		retry(sql, Duration::from_secs(300)).await?;
+		let sql = format!("REMOVE ANALYZER IF EXISTS {name}");
+		retry(sql, Duration::from_secs(180)).await?;
+		Ok(())
+	}
+
+	async fn scan_u32(&self, scan: &Scan, ctx: ScanContext) -> Result<usize> {
+		self.scan(scan, ctx).await
+	}
+
+	async fn scan_string(&self, scan: &Scan, ctx: ScanContext) -> Result<usize> {
+		self.scan(scan, ctx).await
+	}
+
+	async fn build_vector_index(
+		&self,
+		spec: &Index,
+		vq: &VectorQuerySpec,
+		dim: usize,
+		name: &str,
+	) -> Result<()> {
+		let fields = spec.fields.join(", ");
+		let dist = surreal_distance_keyword(vq.distance);
+		let sql = match vq.index_strategy {
+			VectorIndexStrategy::Bruteforce => bail!(NOT_SUPPORTED_ERROR),
+			VectorIndexStrategy::Hnsw {
+				m,
+				ef_construction,
+				..
+			} => format!(
+				"DEFINE INDEX {name} ON TABLE record FIELDS {fields} HNSW DIMENSION {dim} DIST {dist} EFC {ef_construction} M {m} CONCURRENTLY"
+			),
+			VectorIndexStrategy::DiskAnn {
+				degree,
+				l_build,
+				alpha,
+				..
+			} => format!(
+				"DEFINE INDEX {name} ON TABLE record FIELDS {fields} DISKANN DIMENSION {dim} DISTANCE {dist} DEGREE {degree} L_BUILD {l_build} ALPHA {alpha} CONCURRENTLY"
+			),
+		};
+		// DiskANN DDL doesn't exist in v2; the parser rejects it and we map
+		// that to a clean NotSupported skip rather than a hard fail.
+		let resp = match self.db.query(&sql).await {
+			Ok(r) => r,
+			Err(e) if is_surreal_parse_error(&e) => bail!(NOT_SUPPORTED_ERROR),
+			Err(e) => return Err(log_sql_err(&sql)(e)),
+		};
+		if let Err(e) = resp.check() {
+			if is_surreal_parse_error(&e) {
+				bail!(NOT_SUPPORTED_ERROR);
+			}
+			return Err(log_sql_err(&sql)(e));
+		}
+		loop {
+			let q = format!("INFO FOR INDEX {name} ON record");
+			let r: surrealdb::Value = self
+				.db
+				.query(&q)
+				.await
+				.map_err(log_sql_err(&q))?
+				.take(0)
+				.map_err(log_sql_err(&q))?;
+			let j: JsonValue = r.into_inner().into_json();
+			let status = j
+				.get("building")
+				.and_then(|b| b.get("status"))
+				.and_then(|s| s.as_str())
+				.unwrap_or("");
+			match status {
+				"ready" => break,
+				"indexing" | "cleaning" | "started" => {}
+				other => bail!("Unexpected index status `{other}`: {j}"),
+			}
+			sleep(Duration::from_millis(500)).await;
+		}
+		Ok(())
+	}
+
+	async fn scan_vector_u32(
+		&self,
+		scan: &Scan,
+		query: &[f32],
+		_ctx: ScanContext,
+	) -> Result<usize> {
+		self.knn_scan(scan, query).await
+	}
+
+	async fn scan_vector_string(
+		&self,
+		scan: &Scan,
+		query: &[f32],
+		_ctx: ScanContext,
+	) -> Result<usize> {
+		self.knn_scan(scan, query).await
+	}
+
+	async fn batch_create_u32(
+		&self,
+		key_vals: impl Iterator<Item = (u32, BenchValue)> + Send,
+	) -> Result<()> {
+		self.batch_create(key_vals.map(|(k, v)| (k as i64, v))).await
+	}
+
+	async fn batch_create_string(
+		&self,
+		key_vals: impl Iterator<Item = (String, BenchValue)> + Send,
+	) -> Result<()> {
+		self.batch_create(key_vals).await
+	}
+
+	async fn batch_read_u32(&self, keys: impl Iterator<Item = u32> + Send) -> Result<()> {
+		self.batch_read(keys.map(|k| k as i64)).await
+	}
+
+	async fn batch_read_string(&self, keys: impl Iterator<Item = String> + Send) -> Result<()> {
+		self.batch_read(keys).await
+	}
+
+	async fn batch_update_u32(
+		&self,
+		key_vals: impl Iterator<Item = (u32, BenchValue)> + Send,
+	) -> Result<()> {
+		self.batch_update(key_vals.map(|(k, v)| (k as i64, v))).await
+	}
+
+	async fn batch_update_string(
+		&self,
+		key_vals: impl Iterator<Item = (String, BenchValue)> + Send,
+	) -> Result<()> {
+		self.batch_update(key_vals).await
+	}
+
+	async fn batch_delete_u32(&self, keys: impl Iterator<Item = u32> + Send) -> Result<()> {
+		self.batch_delete(keys.map(|k| k as i64)).await
+	}
+
+	async fn batch_delete_string(&self, keys: impl Iterator<Item = String> + Send) -> Result<()> {
+		self.batch_delete(keys).await
+	}
+}
+
+/// Build a v2 `Value::Thing` for record `record:<key>`. `Id: From<i64> | From<String>`
+/// in v2 mirrors v3's `RecordIdKey`, so the same call shape works for both key types.
+fn thing<K: Into<Id>>(key: K) -> Value {
+	Value::Thing(Thing::from((TABLE, key.into())))
+}
+
+/// `surrealdb::RecordId` (api wrapper) — used at the `db.select(...)` boundary
+/// where a `Resource` requires the wrapper rather than the raw `Thing`.
+fn record_id<K: Into<surrealdb::RecordIdKey>>(key: K) -> surrealdb::RecordId {
+	surrealdb::RecordId::from_table_key(TABLE, key)
+}
+
+impl SurrealDB2Client {
+	async fn create<K>(&self, key: K, val: BenchValue) -> Result<()>
+	where
+		K: Into<Id>,
+	{
+		let sql = "CREATE $id CONTENT $content RETURN NULL";
+		let content = bench_to_surreal_value(val);
+		let id = thing(key);
+		run_dml_with_retry(sql, || async {
+			let res = self
+				.db
+				.query(sql)
+				.bind(Bindings {
+					id: id.clone(),
+					content: content.clone(),
+				})
+				.await?
+				.take::<surrealdb::Value>(0)?;
+			assert!(!res.into_inner().is_none());
+			Ok(())
+		})
+		.await
+	}
+
+	async fn read<K>(&self, key: K) -> Result<Row>
+	where
+		K: Into<surrealdb::RecordIdKey>,
+	{
+		let v: surrealdb::Value = self.db.select(Resource::from(record_id(key))).await?;
+		let inner = v.into_inner();
+		assert!(!inner.is_none());
+		Ok(black_box(Row(inner)))
+	}
+
+	async fn update<K>(&self, key: K, val: BenchValue) -> Result<()>
+	where
+		K: Into<Id>,
+	{
+		let sql = "UPDATE $id CONTENT $content RETURN NULL";
+		// `UPDATE $id CONTENT $content` rejects content carrying an explicit
+		// id field — same constraint as v3, same fix: strip it before binding.
+		let mut content = bench_to_surreal_value(val);
+		if let Value::Object(ref mut obj) = content {
+			obj.0.remove("id");
+		}
+		let id = thing(key);
+		run_dml_with_retry(sql, || async {
+			let res = self
+				.db
+				.query(sql)
+				.bind(Bindings {
+					id: id.clone(),
+					content: content.clone(),
+				})
+				.await?
+				.take::<surrealdb::Value>(0)?;
+			assert!(!res.into_inner().is_none());
+			Ok(())
+		})
+		.await
+	}
+
+	async fn delete<K>(&self, key: K) -> Result<()>
+	where
+		K: Into<Id>,
+	{
+		let sql = "DELETE $id RETURN NULL";
+		let id = thing(key);
+		run_dml_with_retry(sql, || async {
+			let res = self
+				.db
+				.query(sql)
+				.bind(("id", id.clone()))
+				.await?
+				.take::<surrealdb::Value>(0)?;
+			assert!(!res.into_inner().is_none());
+			Ok(())
+		})
+		.await
+	}
+
+	async fn knn_scan(&self, scan: &Scan, query: &[f32]) -> Result<usize> {
+		let vq = scan.vector_query.as_ref().ok_or_else(|| {
+			anyhow::anyhow!("knn_scan called without a vector_query on scan `{}`", scan.name)
+		})?;
+		let field = &vq.field;
+		let k = vq.top_k;
+		let sql = match vq.index_strategy {
+			VectorIndexStrategy::Bruteforce => {
+				let func_path = surreal_distance_function(vq.distance);
+				let dir = surreal_distance_order(vq.distance);
+				format!(
+					"SELECT id, {func_path}({field}, $q) AS _d FROM record ORDER BY _d {dir} LIMIT {k}"
+				)
+			}
+			VectorIndexStrategy::Hnsw {
+				ef_search,
+				..
+			} => format!("SELECT id FROM record WHERE {field} <|{k},{ef_search}|> $q"),
+			VectorIndexStrategy::DiskAnn {
+				l_search,
+				..
+			} => format!("SELECT id FROM record WHERE {field} <|{k},{l_search}|> $q"),
+		};
+		let q_value = Value::Array(Array::from(
+			query.iter().map(|f| Value::Number(Number::Float(*f as f64))).collect::<Vec<_>>(),
+		));
+		let mut resp =
+			self.db.query(&sql).bind(("q", q_value)).await.map_err(log_sql_err(&sql))?;
+		let res: surrealdb::Value = resp.take(0).map_err(log_sql_err(&sql))?;
+		match res.into_inner() {
+			Value::Array(a) => Ok(a.0.len()),
+			other => bail!("knn scan: unexpected response shape: {}", other),
+		}
+	}
+
+	async fn scan(&self, scan: &Scan, ctx: ScanContext) -> Result<usize> {
+		if ctx == ScanContext::WithoutIndex
+			&& let Some(index) = &scan.with_index
+			&& let Some(kind) = &index.index_type
+			&& kind == "fulltext"
+		{
+			bail!(NOT_SUPPORTED_ERROR);
+		}
+		let s = scan.start.map(|s| format!("START {s}")).unwrap_or_default();
+		let l = scan.limit.map(|s| format!("LIMIT {s}")).unwrap_or_default();
+		let c = SurrealDBDialect::filter_clause(scan)?;
+		let o = SurrealDBDialect::order_by_clause(scan)?;
+		let p = scan.projection()?;
+		match p {
+			Projection::Id => {
+				let sql = format!("SELECT id FROM record {c} {o} {s} {l}");
+				let res: surrealdb::Value = self
+					.db
+					.query(&sql)
+					.await
+					.map_err(log_sql_err(&sql))?
+					.take(0)
+					.map_err(log_sql_err(&sql))?;
+				match res.into_inner() {
+					Value::Array(a) => Ok(a.0.len()),
+					_ => panic!("Unexpected response type"),
+				}
+			}
+			Projection::Full => {
+				let sql = format!("SELECT * FROM record {c} {o} {s} {l}");
+				let res: surrealdb::Value = self
+					.db
+					.query(&sql)
+					.await
+					.map_err(log_sql_err(&sql))?
+					.take(0)
+					.map_err(log_sql_err(&sql))?;
+				match res.into_inner() {
+					Value::Array(a) => Ok(a.0.len()),
+					_ => panic!("Unexpected response type"),
+				}
+			}
+			Projection::Count => {
+				let sql = if s.is_empty() && l.is_empty() {
+					format!("SELECT count() FROM record {c} GROUP ALL")
+				} else {
+					format!("SELECT count() FROM (SELECT 1 FROM record {c} {s} {l}) GROUP ALL")
+				};
+				let res: Option<usize> = self
+					.db
+					.query(&sql)
+					.await
+					.map_err(log_sql_err(&sql))?
+					.take("count")
+					.map_err(log_sql_err(&sql))?;
+				Ok(res.unwrap())
+			}
+		}
+	}
+
+	async fn batch_create<K>(
+		&self,
+		key_vals: impl Iterator<Item = (K, BenchValue)> + Send,
+	) -> Result<()>
+	where
+		K: Into<Id>,
+	{
+		let rows: Vec<Value> = key_vals
+			.map(|(k, v)| {
+				let mut obj = match bench_to_surreal_value(v) {
+					Value::Object(o) => o,
+					_ => panic!("Unexpected value type"),
+				};
+				obj.0.insert("id".to_string(), thing(k));
+				Value::Object(obj)
+			})
+			.collect();
+		let sql = "INSERT $rows RETURN NONE";
+		let rows = Value::Array(Array::from(rows));
+		run_dml_with_retry(sql, || async {
+			self.db.query(sql).bind(("rows", rows.clone())).await?.check()?;
+			Ok(())
+		})
+		.await
+	}
+
+	async fn batch_read<K>(&self, keys: impl Iterator<Item = K> + Send) -> Result<()>
+	where
+		K: Into<Id>,
+	{
+		let ids: Vec<Value> = keys.map(thing).collect();
+		let ids_len = ids.len();
+		let sql = "SELECT * FROM $ids";
+		let res: surrealdb::Value = self
+			.db
+			.query(sql)
+			.bind(("ids", Value::Array(Array::from(ids))))
+			.await
+			.map_err(log_sql_err(sql))?
+			.take(0)
+			.map_err(log_sql_err(sql))?;
+		match res.into_inner() {
+			Value::Array(a) => assert_eq!(a.0.len(), ids_len),
+			_ => panic!("Unexpected response type"),
+		}
+		Ok(())
+	}
+
+	async fn batch_update<K>(
+		&self,
+		key_vals: impl Iterator<Item = (K, BenchValue)> + Send,
+	) -> Result<()>
+	where
+		K: Into<Id>,
+	{
+		let rows: Vec<Value> = key_vals
+			.map(|(k, v)| {
+				let mut obj = match bench_to_surreal_value(v) {
+					Value::Object(o) => o,
+					_ => panic!("Unexpected value type"),
+				};
+				obj.0.insert("id".to_string(), thing(k));
+				Value::Object(obj)
+			})
+			.collect();
+		let sql = "FOR $row IN $rows { UPDATE $row.id CONTENT $row RETURN NONE }";
+		let rows = Value::Array(Array::from(rows));
+		run_dml_with_retry(sql, || async {
+			self.db.query(sql).bind(("rows", rows.clone())).await?.check()?;
+			Ok(())
+		})
+		.await
+	}
+
+	async fn batch_delete<K>(&self, keys: impl Iterator<Item = K> + Send) -> Result<()>
+	where
+		K: Into<Id>,
+	{
+		let ids: Vec<Value> = keys.map(thing).collect();
+		let sql = "DELETE $ids";
+		let ids = Value::Array(Array::from(ids));
+		run_dml_with_retry(sql, || async {
+			self.db.query(sql).bind(("ids", ids.clone())).await?.check()?;
+			Ok(())
+		})
+		.await
+	}
+}

--- a/src/surrealdb2.rs
+++ b/src/surrealdb2.rs
@@ -280,12 +280,12 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 			unreachable!("docker() must only be called when wants_docker is true")
 		}
 		Endpoint::Docker(Docker::Memory) => DockerParams {
-			image: "surrealdb/surrealdb:v2",
+			image: "surrealdb/surrealdb:v2.6.5",
 			pre_args: "--ulimit nofile=65536:65536 -p 8000:8000 --user root".to_string(),
 			post_args: format!("start --user {username} --pass {password} memory"),
 		},
 		Endpoint::Docker(Docker::Rocksdb) => DockerParams {
-			image: "surrealdb/surrealdb:v2",
+			image: "surrealdb/surrealdb:v2.6.5",
 			pre_args: match options.optimised {
 				true => format!(
 					"--ulimit nofile=65536:65536 -p 8000:8000 -e SURREAL_ROCKSDB_BLOCK_CACHE_SIZE={cache_gb}GB --user root",
@@ -297,7 +297,7 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 			),
 		},
 		Endpoint::Docker(Docker::Surrealkv) => DockerParams {
-			image: "surrealdb/surrealdb:v2",
+			image: "surrealdb/surrealdb:v2.6.5",
 			pre_args: match options.optimised {
 				true => format!(
 					"--ulimit nofile=65536:65536 -p 8000:8000 -e SURREAL_SURREALKV_MAX_VALUE_CACHE_SIZE={cache_gb}GB --user root",
@@ -339,6 +339,20 @@ pub(super) async fn initialise_db(
 impl BenchmarkEngine<SurrealDB2Client> for SurrealDB2ClientProvider {
 	async fn setup(_: KeyType, _columns: Columns, options: &Benchmark) -> Result<Self> {
 		let mode = parse_endpoint(options.endpoint.as_deref())?;
+		// v2 doesn't parse `?sync=`/`?aol=sync` off the datastore path (see
+		// `docker()`), so `--sync` and `--persisted` are silently no-ops here.
+		// Warn explicitly so v2-vs-v3 benchmark numbers aren't mistakenly
+		// treated as apples-to-apples.
+		if options.sync {
+			warn!(
+				"--sync has no effect on SurrealDB 2.x targets (v2 has no ?sync= support); the v2 datastore will use its default durability policy"
+			);
+		}
+		if options.persisted {
+			warn!(
+				"--persisted has no effect on SurrealDB 2.x targets (v2 has no `mem://?…&aol=sync` support); memory backends are non-persistent"
+			);
+		}
 		let username = surrealdb_username();
 		let password = surrealdb_password();
 		let (endpoint, client) = match mode {
@@ -513,13 +527,8 @@ impl BenchmarkClient for SurrealDB2Client {
 					match self.db.query(&sql).await?.check() {
 						Ok(_) => return Ok(()),
 						Err(e) => {
-							let msg = e.to_string();
-							const RETRYABLE: &[&str] = &[
-								"This transaction can be retried",
-								"The query was not executed due to a failed transaction",
-							];
-							if RETRYABLE.iter().any(|p| msg.contains(p)) {
-								warn!("Retrying {sql} due to {msg}");
+							if is_retryable_conflict(&e) {
+								warn!("Retrying {sql} due to {e}");
 								sleep(Duration::from_millis(500)).await;
 								continue;
 							}
@@ -718,7 +727,15 @@ impl SurrealDB2Client {
 	{
 		let v: surrealdb::Value = self.db.select(Resource::from(record_id(key))).await?;
 		let inner = v.into_inner();
-		assert!(!inner.is_none());
+		// `select(Resource::from(rid))` returns `Value::Array` of matching rows
+		// even for a single record (see the comment on `From<Row> for BenchValue`),
+		// so a miss is `Value::Array(vec![])`, not `Value::None`. Catch both.
+		let empty = match &inner {
+			Value::None | Value::Null => true,
+			Value::Array(a) => a.0.is_empty(),
+			_ => false,
+		};
+		assert!(!empty, "read: no record found for key");
 		Ok(black_box(Row(inner)))
 	}
 
@@ -859,12 +876,17 @@ impl SurrealDB2Client {
 					.take(0)
 					.map_err(log_sql_err(&sql))?;
 				let j: JsonValue = res.into_inner().into_json();
-				let count = j
+				let arr = j
 					.as_array()
-					.and_then(|a| a.first())
-					.and_then(|row| row.get("count"))
-					.and_then(|c| c.as_u64())
-					.unwrap_or(0);
+					.ok_or_else(|| anyhow::anyhow!("count scan: expected array, got {j}"))?;
+				// GROUP ALL on zero matches returns []; treat that as count=0
+				// rather than an error.
+				let Some(row) = arr.first() else {
+					return Ok(0);
+				};
+				let count = row.get("count").and_then(|c| c.as_u64()).ok_or_else(|| {
+					anyhow::anyhow!("count scan: missing/non-numeric `count` field in {row}")
+				})?;
 				Ok(count as usize)
 			}
 		}

--- a/src/surrealdb2.rs
+++ b/src/surrealdb2.rs
@@ -280,7 +280,7 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 			unreachable!("docker() must only be called when wants_docker is true")
 		}
 		Endpoint::Docker(Docker::Memory) => DockerParams {
-			image: "surrealdb/surrealdb:v2-latest",
+			image: "surrealdb/surrealdb:v2",
 			pre_args: "--ulimit nofile=65536:65536 -p 8000:8000 --user root".to_string(),
 			post_args: match options.persisted {
 				true => format!(
@@ -290,7 +290,7 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 			},
 		},
 		Endpoint::Docker(Docker::Rocksdb) => DockerParams {
-			image: "surrealdb/surrealdb:v2-latest",
+			image: "surrealdb/surrealdb:v2",
 			pre_args: match options.optimised {
 				true => format!(
 					"--ulimit nofile=65536:65536 -p 8000:8000 -e SURREAL_ROCKSDB_BLOCK_CACHE_SIZE={cache_gb}GB --user root",
@@ -302,7 +302,7 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 			),
 		},
 		Endpoint::Docker(Docker::Surrealkv) => DockerParams {
-			image: "surrealdb/surrealdb:v2-latest",
+			image: "surrealdb/surrealdb:v2",
 			pre_args: match options.optimised {
 				true => format!(
 					"--ulimit nofile=65536:65536 -p 8000:8000 -e SURREAL_SURREALKV_MAX_VALUE_CACHE_SIZE={cache_gb}GB --user root",

--- a/src/surrealdb2.rs
+++ b/src/surrealdb2.rs
@@ -270,11 +270,11 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 	let cache_gb = calculate_surrealdb_memory();
 	let username = surrealdb_username();
 	let password = surrealdb_password();
-	let sync = if options.sync {
-		"every"
-	} else {
-		"never"
-	};
+	// NB: unlike v3, v2 doesn't parse `?sync=` (or the memory `aol=sync`
+	// persisted form) off the datastore path — `Datastore::new` matches the
+	// path verbatim, so any query string either fails the match (memory) or
+	// becomes part of the on-disk path (rocksdb/surrealkv). The `--sync`
+	// benchmark flag is therefore not plumbed through for v2 targets.
 	match backend {
 		Endpoint::Embedded(_) | Endpoint::Remote(_) => {
 			unreachable!("docker() must only be called when wants_docker is true")
@@ -282,12 +282,7 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 		Endpoint::Docker(Docker::Memory) => DockerParams {
 			image: "surrealdb/surrealdb:v2",
 			pre_args: "--ulimit nofile=65536:65536 -p 8000:8000 --user root".to_string(),
-			post_args: match options.persisted {
-				true => format!(
-					"start --user {username} --pass {password} mem://?crud-bench.db?aol=sync&sync={sync}"
-				),
-				false => format!("start --user {username} --pass {password} mem://"),
-			},
+			post_args: format!("start --user {username} --pass {password} memory"),
 		},
 		Endpoint::Docker(Docker::Rocksdb) => DockerParams {
 			image: "surrealdb/surrealdb:v2",
@@ -298,7 +293,7 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 				false => "--ulimit nofile=65536:65536 -p 8000:8000 --user root".to_string(),
 			},
 			post_args: format!(
-				"start --user {username} --pass {password} rocksdb:/data/crud-bench.db?sync={sync}",
+				"start --user {username} --pass {password} rocksdb:/data/crud-bench.db",
 			),
 		},
 		Endpoint::Docker(Docker::Surrealkv) => DockerParams {
@@ -310,7 +305,7 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 				false => "--ulimit nofile=65536:65536 -p 8000:8000 --user root".to_string(),
 			},
 			post_args: format!(
-				"start --user {username} --pass {password} surrealkv:/data/crud-bench.db?sync={sync}",
+				"start --user {username} --pass {password} surrealkv:/data/crud-bench.db",
 			),
 		},
 	}
@@ -350,18 +345,11 @@ impl BenchmarkEngine<SurrealDB2Client> for SurrealDB2ClientProvider {
 			Endpoint::Docker(_) => (DEFAULT.to_string(), None),
 			Endpoint::Remote(url) => (url, None),
 			Endpoint::Embedded(url) => {
-				let sync = if options.sync {
-					"every"
-				} else {
-					"never"
-				};
-				let full_url = if url.contains('?') {
-					format!("{url}&sync={sync}")
-				} else {
-					format!("{url}?sync={sync}")
-				};
-				let db = initialise_db(&full_url, &username, &password).await?;
-				(full_url, Some(db))
+				// v2 matches the datastore path verbatim and has no `?sync=`
+				// query-param support (see `docker()`), so the bare URL is
+				// passed straight through.
+				let db = initialise_db(&url, &username, &password).await?;
+				(url, Some(db))
 			}
 		};
 		Ok(Self {
@@ -856,14 +844,25 @@ impl SurrealDB2Client {
 				} else {
 					format!("SELECT count() FROM (SELECT 1 FROM record {c} {s} {l}) GROUP ALL")
 				};
-				let res: Option<usize> = self
+				// `GROUP ALL` yields `[{ count: N }]`, or an empty array when
+				// nothing matches. Read the raw value and pull `count` out of
+				// the first row rather than relying on the typed `take("count")`
+				// path, which doesn't surface the field reliably on v2.
+				let res: surrealdb::Value = self
 					.db
 					.query(&sql)
 					.await
 					.map_err(log_sql_err(&sql))?
-					.take("count")
+					.take(0)
 					.map_err(log_sql_err(&sql))?;
-				Ok(res.unwrap())
+				let j: JsonValue = res.into_inner().into_json();
+				let count = j
+					.as_array()
+					.and_then(|a| a.first())
+					.and_then(|row| row.get("count"))
+					.and_then(|c| c.as_u64())
+					.unwrap_or(0);
+				Ok(count as usize)
 			}
 		}
 	}

--- a/src/surrealdb2.rs
+++ b/src/surrealdb2.rs
@@ -270,27 +270,33 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 	let cache_gb = calculate_surrealdb_memory();
 	let username = surrealdb_username();
 	let password = surrealdb_password();
-	// NB: unlike v3, v2 doesn't parse `?sync=` (or the memory `aol=sync`
-	// persisted form) off the datastore path — `Datastore::new` matches the
-	// path verbatim, so any query string either fails the match (memory) or
-	// becomes part of the on-disk path (rocksdb/surrealkv). The `--sync`
-	// benchmark flag is therefore not plumbed through for v2 targets.
+	// v2 doesn't parse `?sync=` off the datastore path the way v3 does
+	// (`Datastore::new` matches the path verbatim). The only switch for
+	// fsync-on-commit in v2 is the `SURREAL_SYNC_DATA` env var — both the
+	// RocksDB and SurrealKV engines key off it (`cnf::SYNC_DATA`, default
+	// `false`). Forward `--sync` through as that env var so v2 benchmarks
+	// honour the same durability contract as v3 (`?sync=every`).
+	let sync_env = if options.sync {
+		" -e SURREAL_SYNC_DATA=true"
+	} else {
+		""
+	};
 	match backend {
 		Endpoint::Embedded(_) | Endpoint::Remote(_) => {
 			unreachable!("docker() must only be called when wants_docker is true")
 		}
 		Endpoint::Docker(Docker::Memory) => DockerParams {
 			image: "surrealdb/surrealdb:v2.6.5",
-			pre_args: "--ulimit nofile=65536:65536 -p 8000:8000 --user root".to_string(),
+			pre_args: format!("--ulimit nofile=65536:65536 -p 8000:8000{sync_env} --user root"),
 			post_args: format!("start --user {username} --pass {password} memory"),
 		},
 		Endpoint::Docker(Docker::Rocksdb) => DockerParams {
 			image: "surrealdb/surrealdb:v2.6.5",
 			pre_args: match options.optimised {
 				true => format!(
-					"--ulimit nofile=65536:65536 -p 8000:8000 -e SURREAL_ROCKSDB_BLOCK_CACHE_SIZE={cache_gb}GB --user root",
+					"--ulimit nofile=65536:65536 -p 8000:8000 -e SURREAL_ROCKSDB_BLOCK_CACHE_SIZE={cache_gb}GB{sync_env} --user root",
 				),
-				false => "--ulimit nofile=65536:65536 -p 8000:8000 --user root".to_string(),
+				false => format!("--ulimit nofile=65536:65536 -p 8000:8000{sync_env} --user root"),
 			},
 			post_args: format!(
 				"start --user {username} --pass {password} rocksdb:/data/crud-bench.db",
@@ -300,9 +306,9 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 			image: "surrealdb/surrealdb:v2.6.5",
 			pre_args: match options.optimised {
 				true => format!(
-					"--ulimit nofile=65536:65536 -p 8000:8000 -e SURREAL_SURREALKV_MAX_VALUE_CACHE_SIZE={cache_gb}GB --user root",
+					"--ulimit nofile=65536:65536 -p 8000:8000 -e SURREAL_SURREALKV_MAX_VALUE_CACHE_SIZE={cache_gb}GB{sync_env} --user root",
 				),
-				false => "--ulimit nofile=65536:65536 -p 8000:8000 --user root".to_string(),
+				false => format!("--ulimit nofile=65536:65536 -p 8000:8000{sync_env} --user root"),
 			},
 			post_args: format!(
 				"start --user {username} --pass {password} surrealkv:/data/crud-bench.db",
@@ -339,14 +345,20 @@ pub(super) async fn initialise_db(
 impl BenchmarkEngine<SurrealDB2Client> for SurrealDB2ClientProvider {
 	async fn setup(_: KeyType, _columns: Columns, options: &Benchmark) -> Result<Self> {
 		let mode = parse_endpoint(options.endpoint.as_deref())?;
-		// v2 doesn't parse `?sync=`/`?aol=sync` off the datastore path (see
-		// `docker()`), so `--sync` and `--persisted` are silently no-ops here.
-		// Warn explicitly so v2-vs-v3 benchmark numbers aren't mistakenly
-		// treated as apples-to-apples.
-		if options.sync {
-			warn!(
-				"--sync has no effect on SurrealDB 2.x targets (v2 has no ?sync= support); the v2 datastore will use its default durability policy"
-			);
+		// v2's only fsync-on-commit switch is the `SURREAL_SYNC_DATA` env var
+		// (no path query param, no CLI flag). For embedded mode we set it in
+		// the bench process before `initialise_db` touches the kvs layer so
+		// the LazyLock in `cnf::SYNC_DATA` resolves to the right value. For
+		// Docker mode the equivalent `-e SURREAL_SYNC_DATA=true` is wired in
+		// `docker()`. Remote mode honours whatever the remote server was
+		// started with.
+		if options.sync && matches!(mode, Endpoint::Embedded(_)) {
+			// SAFETY: `setup` runs once at startup, before any benchmark
+			// worker tasks spawn, and before the v2 SDK reads SYNC_DATA. No
+			// concurrent env access is possible at this point.
+			unsafe {
+				env::set_var("SURREAL_SYNC_DATA", "true");
+			}
 		}
 		if options.persisted {
 			warn!(
@@ -359,9 +371,6 @@ impl BenchmarkEngine<SurrealDB2Client> for SurrealDB2ClientProvider {
 			Endpoint::Docker(_) => (DEFAULT.to_string(), None),
 			Endpoint::Remote(url) => (url, None),
 			Endpoint::Embedded(url) => {
-				// v2 matches the datastore path verbatim and has no `?sync=`
-				// query-param support (see `docker()`), so the bare URL is
-				// passed straight through.
 				let db = initialise_db(&url, &username, &password).await?;
 				(url, Some(db))
 			}

--- a/src/surrealdb2.rs
+++ b/src/surrealdb2.rs
@@ -462,8 +462,11 @@ impl BenchmarkClient for SurrealDB2Client {
 					.map_err(log_sql_err(&sql))?
 					.check()
 					.map_err(log_sql_err(&sql))?;
+				// v2 spells the full-text index `SEARCH ANALYZER … BM25`;
+				// the `FULLTEXT ANALYZER` keyword is v3-only. The `@@` match
+				// operator used on the scan side is the same in both.
 				format!(
-					"DEFINE INDEX {name} ON TABLE record FIELDS {fields} FULLTEXT ANALYZER {name} BM25 CONCURRENTLY"
+					"DEFINE INDEX {name} ON TABLE record FIELDS {fields} SEARCH ANALYZER {name} BM25 CONCURRENTLY"
 				)
 			}
 			_ => {


### PR DESCRIPTION
## Summary

The existing SurrealDB adapter links against the v3 SDK, which only speaks the v3 RPC protocol and therefore can't benchmark a 2.x server. This adds a parallel `surrealdb2` adapter that links the v2 SDK side-by-side (renamed crate, resolved at a different major version) so crud-bench can target 2.x deployments from the same binary.

## What changed

- **Cargo** ([Cargo.toml](Cargo.toml)): new `surrealdb2` feature + `surrealdb2 = { package = "surrealdb", version = "2.6", ... }` dependency, added to the default feature set. Both v2.6.x and v3.0.x link together cleanly.
- **Adapter** ([src/surrealdb2.rs](src/surrealdb2.rs)): mirrors the v3 adapter at `src/surrealdb.rs` but:
  - uses v2's `surrealdb::sql::*` types instead of v3's `surrealdb::types::*` (`Strand`/`Thing`/`Object`-via-`BTreeMap`, etc.)
  - owns root credentials on the provider since v2's `Root<'a>` borrows
  - polls `INFO FOR INDEX` status via `Value::into_inner().into_json()` (v2 `Value` has no `.get()`)
  - `compact()` is a no-op (no `ALTER SYSTEM COMPACT` in v2)
  - DiskANN DDL falls through the existing parse-error → `NOT_SUPPORTED_ERROR` skip path (not shipped in v2)
  - Docker image pinned to `surrealdb/surrealdb:v2-latest`
- **Wiring** ([src/database.rs](src/database.rs), [src/main.rs](src/main.rs)): `Database::Surrealdb2` variant hooked into `wants_docker` / `start_docker` / `run` (uses `SurrealDBDialect`) / `name()` ("SurrealDB 2.x"), plus `mod surrealdb2;`.

## Usage

```
cargo run -r -- -d surrealdb2 -e ws://host:8000 …   # remote v2 server
cargo run -r -- -d surrealdb2 …                     # spin up v2 Docker container
```

## Reviewer notes

- Full default build passes with both SDKs linked side-by-side.
- Bench-value fidelity goes through v2's `sql::Value` serde Serialize on the `.bind()` path. I believe it round-trips through `to_core_value` correctly but have **not** smoke-tested against a live 2.x server yet — worth a quick run before trusting numbers.
- No `surrealds2` (multi-instance) variant added — easy follow-up mirroring `src/surrealds.rs` if wanted.
- Confirm the `surrealdb/surrealdb:v2-latest` Docker tag exists, or pin to a specific version like `v2.6.5`.
- Pre-existing (not addressed here): `src/storage.rs` imports `surrealdb` without a cfg gate, so `--no-default-features --features surrealdb2` won't link.