### PR TITLE
Rename scan/batch `samples` to `iterations`

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Each scan object can make use of the following values:
 
 - `id` (**required**): Stable identifier for grouping in the CLI, result tables, CSV output, and for **index create/drop** when `with_index` is present and not skipped. Use a simple identifier (e.g. `where_field_integer_eq`); human-readable titles live in `name` / run `name` and may contain characters that are not valid in SurrealDB or Neo4j index names.
 - `name`: A descriptive name for the test (use this **or** `runs`, not both).
-- `runs`: An array of `{ "name", "projection"? }` objects that share the same scan parameters (`samples`, `condition`, `with_index`, and so on). Each run becomes a separate benchmark with its own display name. Per-run `projection` overrides the entry-level `projection` when both are set; if a run omits `projection`, the entry-level value applies (defaulting to full-record scans like a single-object entry without `projection`).
+- `runs`: An array of `{ "name", "projection"? }` objects that share the same scan parameters (`iterations`, `condition`, `with_index`, and so on). Each run becomes a separate benchmark with its own display name. Per-run `projection` overrides the entry-level `projection` when both are set; if a run omits `projection`, the entry-level value applies (defaulting to full-record scans like a single-object entry without `projection`).
 - `projection`: The projection type of the scan:
     - `"ID"`: only the ID is returned.
     - `"FULL"`: the whole record is returned.
@@ -271,7 +271,7 @@ Multiple benchmarks that share the same filter, index, and write settings can us
       { "name": "select(*) where(x = 1)", "projection": "FULL" },
       { "name": "count(*) where(x = 1)", "projection": "COUNT" }
     ],
-    "samples": 10000,
+    "iterations": 10000,
     "condition": { "sql": "x = 1", "mysql": "x = 1" },
     "with_index": { "fields": ["x"] }
   }

--- a/config/bench.toml
+++ b/config/bench.toml
@@ -4,7 +4,7 @@
 # tests (`[[batches]]`).
 #
 # Scans — Each `[[scans]]` row is one logical benchmark. Optional keys include `id`,
-# `name`, `projection`, `samples`, paging (`limit`, `start`, `expect`). Use `[[scans.runs]]`
+# `name`, `projection`, `iterations`, paging (`limit`, `start`, `expect`). Use `[[scans.runs]]`
 # when the same parameters define multiple named runs (each run has `name` and optional
 # `projection`). Conditional scans add `[scans.condition]` with per-dialect filter strings
 # (`sql`, `postgres`, `sqlite`, `mysql`, `neo4j`, `arangodb`, `surrealdb`) plus inline `mongodb = { ... }` for the
@@ -16,7 +16,7 @@
 # the strategy needs one) is derived from `field` — engines without vector support skip the run.
 #
 # Batches — Each `[[batches]]` row names a throughput case: `name`, `operation` (CREATE,
-# READ, UPDATE, DELETE), `batch_size`, and `samples` (how many timed iterations).
+# READ, UPDATE, DELETE), `batch_size`, and `iterations` (how many timed iterations).
 #
 # Value — The `[value]` table defines the generated document shape for each row.
 #
@@ -59,7 +59,7 @@ geography.description = "words:100;hello,world,foo,bar,test,search,data,query,in
 id = "count"
 name = "count()"
 projection = "COUNT"
-samples = 1000
+iterations = 1000
 
 # ============================================================================
 # limit
@@ -67,7 +67,7 @@ samples = 1000
 
 [[scans]]
 id = "limit"
-samples = 10000
+iterations = 10000
 limit = 100
 expect = 100
 
@@ -85,7 +85,7 @@ projection = "FULL"
 
 [[scans]]
 id = "start_limit"
-samples = 10000
+iterations = 10000
 start = 5000
 limit = 100
 expect = 100
@@ -104,7 +104,7 @@ projection = "FULL"
 
 [[scans]]
 id = "where_field_integer_eq"
-samples = 1000
+iterations = 1000
 
 [[scans.runs]]
 name = "count(*) where(integer = integer)"
@@ -141,7 +141,7 @@ operation = "UPDATE"
 
 [[scans]]
 id = "where_field_integer_eq_or_eq"
-samples = 1000
+iterations = 1000
 
 [[scans.runs]]
 name = "count(*) where(integer = integer OR integer = integer)"
@@ -181,7 +181,7 @@ operation = "UPDATE"
 
 [[scans]]
 id = "where_field_integer_gte_lte"
-samples = 1000
+iterations = 1000
 
 [[scans.runs]]
 name = "count(*) where(integer >= integer AND integer <= integer)"
@@ -218,7 +218,7 @@ operation = "UPDATE"
 
 [[scans]]
 id = "where_field_integer_in_many"
-samples = 1000
+iterations = 1000
 limit = 1000
 
 [[scans.runs]]
@@ -263,7 +263,7 @@ operation = "UPDATE"
 
 [[scans]]
 id = "where_field_string_eq_order_by_desc"
-samples = 1000
+iterations = 1000
 limit = 1000
 
 [[scans.runs]]
@@ -309,7 +309,7 @@ operation = "UPDATE"
 
 [[scans]]
 id = "where_field_integer_in_many_order_by_desc"
-samples = 1000
+iterations = 1000
 limit = 1000
 
 [[scans.runs]]
@@ -355,7 +355,7 @@ operation = "UPDATE"
 
 [[scans]]
 id = "where_field_many_contains_string_order_by_desc"
-samples = 1000
+iterations = 1000
 limit = 1000
 
 [[scans.runs]]
@@ -405,7 +405,7 @@ operation = "UPDATE"
 id = "where_field_fulltext_single"
 name = "select(*) where(string @@ string) limit(1000) - BM25"
 projection = "FULL"
-samples = 1000
+iterations = 1000
 limit = 1000
 
 [scans.condition]
@@ -427,7 +427,7 @@ index_type = "fulltext"
 id = "where_field_fulltext_multi_and"
 name = "select(*) where(string @@ string AND string @@ string) limit(1000) - BM25"
 projection = "FULL"
-samples = 1000
+iterations = 1000
 limit = 1000
 
 [scans.condition]
@@ -449,7 +449,7 @@ index_type = "fulltext"
 id = "where_field_fulltext_multi_or"
 name = "select(*) where(string @@ string OR string @@ string) limit(1000) - BM25"
 projection = "FULL"
-samples = 1000
+iterations = 1000
 limit = 1000
 
 [scans.condition]
@@ -471,7 +471,7 @@ index_type = "fulltext"
 name = "batch_create_100"
 operation = "CREATE"
 batch_size = 100
-samples = 250
+iterations = 250
 
 # ============================================================================
 # batch_read_100
@@ -481,7 +481,7 @@ samples = 250
 name = "batch_read_100"
 operation = "READ"
 batch_size = 100
-samples = 250
+iterations = 250
 
 # ============================================================================
 # batch_update_100
@@ -491,7 +491,7 @@ samples = 250
 name = "batch_update_100"
 operation = "UPDATE"
 batch_size = 100
-samples = 250
+iterations = 250
 
 # ============================================================================
 # batch_delete_100
@@ -501,7 +501,7 @@ samples = 250
 name = "batch_delete_100"
 operation = "DELETE"
 batch_size = 100
-samples = 250
+iterations = 250
 
 # ============================================================================
 # batch_create_1000
@@ -511,7 +511,7 @@ samples = 250
 name = "batch_create_1000"
 operation = "CREATE"
 batch_size = 1000
-samples = 250
+iterations = 250
 
 # ============================================================================
 # batch_read_1000
@@ -521,7 +521,7 @@ samples = 250
 name = "batch_read_1000"
 operation = "READ"
 batch_size = 1000
-samples = 250
+iterations = 250
 
 # ============================================================================
 # batch_update_1000
@@ -531,7 +531,7 @@ samples = 250
 name = "batch_update_1000"
 operation = "UPDATE"
 batch_size = 1000
-samples = 250
+iterations = 250
 
 # ============================================================================
 # batch_delete_1000
@@ -541,4 +541,4 @@ samples = 250
 name = "batch_delete_1000"
 operation = "DELETE"
 batch_size = 1000
-samples = 250
+iterations = 250

--- a/config/cache.toml
+++ b/config/cache.toml
@@ -4,7 +4,7 @@
 # tests (`[[batches]]`).
 #
 # Scans — Each `[[scans]]` row is one logical benchmark. Optional keys include `id`,
-# `name`, `projection`, `samples`, paging (`limit`, `start`, `expect`). Use `[[scans.runs]]`
+# `name`, `projection`, `iterations`, paging (`limit`, `start`, `expect`). Use `[[scans.runs]]`
 # when the same parameters define multiple named runs (each run has `name` and optional
 # `projection`). Conditional scans add `[scans.condition]` with per-dialect filter strings
 # (`sql`, `postgres`, `sqlite`, `mysql`, `neo4j`, `arangodb`, `surrealdb`) plus inline `mongodb = { ... }` for the
@@ -14,7 +14,7 @@
 # `[[scans.with_writes]]` blocks (`ratio`, `mode`, `operation`).
 #
 # Batches — Each `[[batches]]` row names a throughput case: `name`, `operation` (CREATE,
-# READ, UPDATE, DELETE), `batch_size`, and `samples` (how many timed iterations).
+# READ, UPDATE, DELETE), `batch_size`, and `iterations` (how many timed iterations).
 #
 # Value — The `[value]` table defines the generated document shape for each row.
 #
@@ -57,7 +57,7 @@ geography.description = "words:100;hello,world,foo,bar,test,search,data,query,in
 id = "count"
 name = "count()"
 projection = "COUNT"
-samples = 1000
+iterations = 1000
 
 # ============================================================================
 # limit
@@ -65,7 +65,7 @@ samples = 1000
 
 [[scans]]
 id = "limit"
-samples = 10000
+iterations = 10000
 limit = 100
 expect = 100
 
@@ -83,7 +83,7 @@ projection = "FULL"
 
 [[scans]]
 id = "start_limit"
-samples = 10000
+iterations = 10000
 start = 5000
 limit = 100
 expect = 100
@@ -104,7 +104,7 @@ projection = "FULL"
 name = "batch_create_100"
 operation = "CREATE"
 batch_size = 100
-samples = 1000
+iterations = 1000
 
 # ============================================================================
 # batch_read_100
@@ -114,7 +114,7 @@ samples = 1000
 name = "batch_read_100"
 operation = "READ"
 batch_size = 100
-samples = 1000
+iterations = 1000
 
 # ============================================================================
 # batch_update_100
@@ -124,7 +124,7 @@ samples = 1000
 name = "batch_update_100"
 operation = "UPDATE"
 batch_size = 100
-samples = 1000
+iterations = 1000
 
 # ============================================================================
 # batch_delete_100
@@ -134,7 +134,7 @@ samples = 1000
 name = "batch_delete_100"
 operation = "DELETE"
 batch_size = 100
-samples = 1000
+iterations = 1000
 
 # ============================================================================
 # batch_create_1000
@@ -144,7 +144,7 @@ samples = 1000
 name = "batch_create_1000"
 operation = "CREATE"
 batch_size = 1000
-samples = 1000
+iterations = 1000
 
 # ============================================================================
 # batch_read_1000
@@ -154,7 +154,7 @@ samples = 1000
 name = "batch_read_1000"
 operation = "READ"
 batch_size = 1000
-samples = 1000
+iterations = 1000
 
 # ============================================================================
 # batch_update_1000
@@ -164,7 +164,7 @@ samples = 1000
 name = "batch_update_1000"
 operation = "UPDATE"
 batch_size = 1000
-samples = 1000
+iterations = 1000
 
 # ============================================================================
 # batch_delete_1000
@@ -174,4 +174,4 @@ samples = 1000
 name = "batch_delete_1000"
 operation = "DELETE"
 batch_size = 1000
-samples = 1000
+iterations = 1000

--- a/config/ci.toml
+++ b/config/ci.toml
@@ -4,7 +4,7 @@
 # tests (`[[batches]]`).
 #
 # Scans — Each `[[scans]]` row is one logical benchmark. Optional keys include `id`,
-# `name`, `projection`, `samples`, paging (`limit`, `start`, `expect`). Use `[[scans.runs]]`
+# `name`, `projection`, `iterations`, paging (`limit`, `start`, `expect`). Use `[[scans.runs]]`
 # when the same parameters define multiple named runs (each run has `name` and optional
 # `projection`). Conditional scans add `[scans.condition]` with per-dialect filter strings
 # (`sql`, `postgres`, `sqlite`, `mysql`, `neo4j`, `arangodb`, `surrealdb`) plus inline `mongodb = { ... }` for the
@@ -16,7 +16,7 @@
 # the strategy needs one) is derived from `field` — engines without vector support skip the run.
 #
 # Batches — Each `[[batches]]` row names a throughput case: `name`, `operation` (CREATE,
-# READ, UPDATE, DELETE), `batch_size`, and `samples` (how many timed iterations).
+# READ, UPDATE, DELETE), `batch_size`, and `iterations` (how many timed iterations).
 #
 # Value — The `[value]` table defines the generated document shape for each row.
 #
@@ -60,7 +60,7 @@ embedding = "vector:128"
 id = "count"
 name = "count()"
 projection = "COUNT"
-samples = 10
+iterations = 10
 
 # ============================================================================
 # limit
@@ -68,7 +68,7 @@ samples = 10
 
 [[scans]]
 id = "limit"
-samples = 10
+iterations = 10
 limit = 100
 expect = 100
 
@@ -86,7 +86,7 @@ projection = "FULL"
 
 [[scans]]
 id = "start_limit"
-samples = 10
+iterations = 10
 start = 5000
 limit = 100
 expect = 100
@@ -105,7 +105,7 @@ projection = "FULL"
 
 [[scans]]
 id = "where_field_integer_eq"
-samples = 10
+iterations = 10
 
 [[scans.runs]]
 name = "count(*) where(integer = integer)"
@@ -137,7 +137,7 @@ operation = "UPDATE"
 
 [[scans]]
 id = "where_field_integer_eq_or_eq"
-samples = 10
+iterations = 10
 
 [[scans.runs]]
 name = "count(*) where(integer = integer OR integer = integer)"
@@ -172,7 +172,7 @@ operation = "UPDATE"
 
 [[scans]]
 id = "where_field_integer_gte_lte"
-samples = 10
+iterations = 10
 
 [[scans.runs]]
 name = "count(*) where(integer >= integer AND integer <= integer)"
@@ -204,7 +204,7 @@ operation = "UPDATE"
 
 [[scans]]
 id = "where_field_integer_in_many"
-samples = 10
+iterations = 10
 limit = 1000
 
 [[scans.runs]]
@@ -244,7 +244,7 @@ operation = "UPDATE"
 
 [[scans]]
 id = "where_field_string_eq_order_by_desc"
-samples = 10
+iterations = 10
 limit = 1000
 
 [[scans.runs]]
@@ -285,7 +285,7 @@ operation = "UPDATE"
 
 [[scans]]
 id = "where_field_integer_in_many_order_by_desc"
-samples = 10
+iterations = 10
 limit = 1000
 
 [[scans.runs]]
@@ -326,7 +326,7 @@ operation = "UPDATE"
 
 [[scans]]
 id = "where_field_many_contains_string_order_by_desc"
-samples = 10
+iterations = 10
 limit = 1000
 
 [[scans.runs]]
@@ -371,7 +371,7 @@ operation = "UPDATE"
 id = "where_field_fulltext_single"
 name = "select(*) where(string @@ string) limit(1000) - BM25"
 projection = "FULL"
-samples = 10
+iterations = 10
 limit = 1000
 
 [scans.condition]
@@ -393,7 +393,7 @@ index_type = "fulltext"
 id = "where_field_fulltext_multi_and"
 name = "select(*) where(string @@ string AND string @@ string) limit(1000) - BM25"
 projection = "FULL"
-samples = 10
+iterations = 10
 limit = 1000
 
 [scans.condition]
@@ -415,7 +415,7 @@ index_type = "fulltext"
 id = "where_field_fulltext_multi_or"
 name = "select(*) where(string @@ string OR string @@ string) limit(1000) - BM25"
 projection = "FULL"
-samples = 10
+iterations = 10
 limit = 1000
 
 [scans.condition]
@@ -440,7 +440,7 @@ index_type = "fulltext"
 
 [[scans]]
 id = "vector_knn"
-samples = 10
+iterations = 10
 
 [[scans.runs]]
 name = "bruteforce knn(10)"
@@ -477,7 +477,7 @@ holdout = { count = 50, seed = 42 }
 name = "batch_create_100"
 operation = "CREATE"
 batch_size = 100
-samples = 10
+iterations = 10
 
 # ============================================================================
 # batch_read_100
@@ -487,7 +487,7 @@ samples = 10
 name = "batch_read_100"
 operation = "READ"
 batch_size = 100
-samples = 10
+iterations = 10
 
 # ============================================================================
 # batch_update_100
@@ -497,7 +497,7 @@ samples = 10
 name = "batch_update_100"
 operation = "UPDATE"
 batch_size = 100
-samples = 10
+iterations = 10
 
 # ============================================================================
 # batch_delete_100
@@ -507,4 +507,4 @@ samples = 10
 name = "batch_delete_100"
 operation = "DELETE"
 batch_size = 100
-samples = 10
+iterations = 10

--- a/config/test.toml
+++ b/config/test.toml
@@ -11,7 +11,7 @@ expect = 100
 name = "batch_test"
 operation = "CREATE"
 batch_size = 5
-samples = 10
+iterations = 10
 
 [value]
 text = "String:50"

--- a/config/vector.toml
+++ b/config/vector.toml
@@ -8,7 +8,7 @@
 # The query set is built deterministically from the inserted records: at the
 # end of the create phase the framework picks `count` ids using `seed`, reads
 # each row once (outside the timing window), and reuses those embedding
-# vectors across all scan samples. Only the KNN call itself is timed, so the
+# vectors across all scan iterations. Only the KNN call itself is timed, so the
 # benchmark's RAM footprint is constant in `count` (independent of `-s N`).
 
 # ============================================================================
@@ -53,7 +53,7 @@ embedding = "vector:3072"
 
 [[scans]]
 id = "vector_knn"
-samples = 1000
+iterations = 1000
 
 [[scans.runs]]
 name = "bruteforce knn(10)"

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -285,7 +285,7 @@ impl Benchmark {
 			}
 			let id = scan.id.clone();
 			let name = scan.name.clone();
-			let samples = scan.samples.map(|s| s as u32).unwrap_or(self.samples);
+			let iterations = scan.iterations.map(|s| s as u32).unwrap_or(self.samples);
 			let write_specs = scan.with_writes.as_slice();
 			let w = write_specs.len();
 			let index_spec = scan.with_index.as_ref().filter(|i| !i.skip);
@@ -334,7 +334,7 @@ impl Benchmark {
 						ScanResult {
 							id: id.clone(),
 							name,
-							samples,
+							iterations,
 							index_build: None,
 							index_remove: None,
 							runs,
@@ -387,7 +387,7 @@ impl Benchmark {
 								),
 								kp,
 								vp.clone(),
-								samples,
+								iterations,
 							)
 							.await?
 						} else {
@@ -415,7 +415,7 @@ impl Benchmark {
 						ScanResult {
 							id: id.clone(),
 							name,
-							samples,
+							iterations,
 							index_build: vec_index_build,
 							index_remove: vec_index_remove,
 							runs,
@@ -432,7 +432,7 @@ impl Benchmark {
 						BenchmarkOperation::Scan(scan.clone(), ScanContext::WithoutIndex),
 						kp,
 						vp.clone(),
-						samples,
+						iterations,
 					)
 					.await?;
 				runs.push(ScanRun {
@@ -452,7 +452,7 @@ impl Benchmark {
 							),
 							kp,
 							vp.clone(),
-							samples,
+							iterations,
 						)
 						.await?;
 					runs.push(ScanRun {
@@ -487,7 +487,7 @@ impl Benchmark {
 							BenchmarkOperation::Scan(scan.clone(), ScanContext::WithIndex),
 							kp,
 							vp.clone(),
-							samples,
+							iterations,
 						)
 						.await?;
 					let mut iw = Vec::with_capacity(w);
@@ -502,7 +502,7 @@ impl Benchmark {
 								),
 								kp,
 								vp.clone(),
-								samples,
+								iterations,
 							)
 							.await?,
 						);
@@ -556,7 +556,7 @@ impl Benchmark {
 				ScanResult {
 					id: id.clone(),
 					name,
-					samples,
+					iterations,
 					index_build,
 					index_remove,
 					runs,
@@ -570,7 +570,7 @@ impl Benchmark {
 						BenchmarkOperation::Scan(scan.clone(), ScanContext::WithoutIndex),
 						kp,
 						vp.clone(),
-						samples,
+						iterations,
 					)
 					.await?;
 				runs.push(ScanRun {
@@ -589,7 +589,7 @@ impl Benchmark {
 							),
 							kp,
 							vp.clone(),
-							samples,
+							iterations,
 						)
 						.await?;
 					runs.push(ScanRun {
@@ -603,7 +603,7 @@ impl Benchmark {
 				ScanResult {
 					id: id.clone(),
 					name,
-					samples,
+					iterations,
 					index_build: None,
 					index_remove: None,
 					runs,
@@ -635,7 +635,7 @@ impl Benchmark {
 			// Get the name of the batch operation
 			let name = batch.name.clone();
 			let groups = batch.batch_size;
-			let samples = batch.samples.map(|s| s as u32).unwrap_or(self.samples);
+			let iterations = batch.iterations.map(|s| s as u32).unwrap_or(self.samples);
 			// Determine the batch operation type
 			let operation = match batch.operation {
 				crate::BatchOperationType::Create => BenchmarkOperation::BatchCreate(batch.clone()),
@@ -645,9 +645,9 @@ impl Benchmark {
 			};
 			// Execute the batch benchmark
 			let duration =
-				self.run_operation::<C, D>(&clients, operation, kp, vp.clone(), samples).await?;
+				self.run_operation::<C, D>(&clients, operation, kp, vp.clone(), iterations).await?;
 			// Store the batch benchmark result
-			batch_results.push((name, samples, groups, duration));
+			batch_results.push((name, iterations, groups, duration));
 		}
 		// Mark the benchmark as complete
 		if self.emit_phase_markers {
@@ -673,7 +673,7 @@ impl Benchmark {
 	/// Build the held-out [`VectorQuerySet`] for a vector-search scan.
 	/// Reads N rows (id picked deterministically from `seed`) and extracts the
 	/// `field` column. The read cost is paid once here, off the timed window;
-	/// the resulting `Vec<f32>` queries are reused across all scan samples.
+	/// the resulting `Vec<f32>` queries are reused across all scan iterations.
 	///
 	/// Returns `Ok(None)` when the engine cannot surface vector reads (the
 	/// holdout extraction hits [`NOT_SUPPORTED_ERROR`]) so the caller can skip

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,8 +217,8 @@ pub(crate) struct ScanSpec {
 	name: Option<String>,
 	/// Multiple named projections sharing the same parameters; omit when using `name` instead.
 	runs: Option<Vec<ScanRun>>,
-	/// Overrides the global sample count for this scan when set.
-	samples: Option<usize>,
+	/// Number of timed scan iterations; falls back to CLI `--samples` when unset.
+	iterations: Option<usize>,
 	/// Per-dialect filter fragments (`WHERE`); omit for unrestricted/table scans.
 	condition: Option<Condition>,
 	/// Per-dialect `ORDER BY` fragments; omit for unordered scans.
@@ -249,7 +249,7 @@ impl ScanSpec {
 			id,
 			name,
 			runs,
-			samples,
+			iterations,
 			condition,
 			order_by,
 			start,
@@ -284,7 +284,7 @@ impl ScanSpec {
 					spec_group,
 					multi_run_spec: false,
 					name: n,
-					samples,
+					iterations,
 					condition,
 					order_by,
 					start,
@@ -311,7 +311,7 @@ impl ScanSpec {
 						spec_group,
 						multi_run_spec,
 						name: run.name,
-						samples,
+						iterations,
 						condition: condition.clone(),
 						order_by: order_by.clone(),
 						start,
@@ -373,7 +373,7 @@ fn validate_scan_index_ids(scans: &[Scan]) -> Result<()> {
 			}
 			// Mixed read/write workloads on a vector index need separate
 			// plumbing (the write path would invalidate the index between
-			// scan samples). Reject the combination at parse time so the
+			// scan iterations). Reject the combination at parse time so the
 			// benchmark doesn't silently drop the write legs and report
 			// read-only KNN as if it were a mixed workload.
 			if !scan.with_writes.is_empty() {
@@ -495,8 +495,8 @@ pub(crate) struct Scan {
 	pub(crate) multi_run_spec: bool,
 	/// Human-readable title for this scan row (from `name` or a `runs[]` entry).
 	name: String,
-	/// Sample count for this scan; falls back to CLI `--samples` when unset.
-	samples: Option<usize>,
+	/// Number of timed scan iterations; falls back to CLI `--samples` when unset.
+	iterations: Option<usize>,
 	/// Filter predicates per dialect; omit for full scans.
 	condition: Option<Condition>,
 	/// Optional `ORDER BY` per datastore (omit for unordered scans).
@@ -520,14 +520,14 @@ pub(crate) struct Scan {
 	pub(crate) vector_query: Option<VectorQuerySpec>,
 }
 
-/// Mixed read/write scan leg: scan samples plus paired updates that touch indexed columns while
+/// Mixed read/write scan leg: scan iterations plus paired updates that touch indexed columns while
 /// keeping approximate match cardinality stable (see `workloads` module).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub(crate) struct ScanWithWrites {
-	/// Fraction of samples that include compensating writes after the scan (0.0–1.0).
+	/// Fraction of iterations that include compensating writes after the scan (0.0–1.0).
 	#[serde(default = "default_writes_ratio")]
 	pub(crate) ratio: f64,
-	/// How writes are interleaved with scan samples for this leg.
+	/// How writes are interleaved with scan iterations for this leg.
 	#[serde(default)]
 	pub(crate) mode: ScanWritesMode,
 	/// Which datastore operation the write leg performs (currently update-only).
@@ -544,7 +544,7 @@ fn default_writes_ratio() -> f64 {
 #[serde(rename_all = "lowercase")]
 /// Scheduling of writes relative to scan iterations for mixed workloads.
 pub(crate) enum ScanWritesMode {
-	/// Perform compensating writes interleaved with scan samples.
+	/// Perform compensating writes interleaved with scan iterations.
 	#[default]
 	Interleaved,
 }
@@ -642,8 +642,8 @@ pub(crate) struct BatchOperation {
 	pub(crate) operation: BatchOperationType,
 	/// Records per batch transaction or pipeline.
 	pub(crate) batch_size: usize,
-	/// Timed iterations for this batch case; backend may default when unset.
-	pub(crate) samples: Option<usize>,
+	/// Number of timed batch iterations; falls back to CLI `--samples` when unset.
+	pub(crate) iterations: Option<usize>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -980,7 +980,7 @@ mod test {
 	#[test]
 	fn scan_spec_name_only() -> Result<()> {
 		let specs: Vec<super::ScanSpec> =
-			serde_json::from_str(r#"[{"id":"spec_a","name":"a","samples":1,"projection":"ID"}]"#)?;
+			serde_json::from_str(r#"[{"id":"spec_a","name":"a","iterations":1,"projection":"ID"}]"#)?;
 		let scans = super::expand_scan_specs(specs)?;
 		assert_eq!(scans.len(), 1);
 		assert_eq!(scans[0].name, "a");
@@ -993,7 +993,7 @@ mod test {
 	#[test]
 	fn scan_spec_runs_expand() -> Result<()> {
 		let specs: Vec<super::ScanSpec> = serde_json::from_str(
-			r#"[{"id":"spec_runs","runs":[{"name":"x","projection":"FULL"},{"name":"y","projection":"COUNT"}],"samples":2}]"#,
+			r#"[{"id":"spec_runs","runs":[{"name":"x","projection":"FULL"},{"name":"y","projection":"COUNT"}],"iterations":2}]"#,
 		)?;
 		let scans = super::expand_scan_specs(specs)?;
 		assert_eq!(scans.len(), 2);
@@ -1011,7 +1011,7 @@ mod test {
 	#[test]
 	fn scan_spec_groups_increment() -> Result<()> {
 		let specs: Vec<super::ScanSpec> = serde_json::from_str(
-			r#"[{"id":"ga","name":"a","samples":1,"projection":"ID"},{"id":"gb","name":"b","samples":1,"projection":"ID"}]"#,
+			r#"[{"id":"ga","name":"a","iterations":1,"projection":"ID"},{"id":"gb","name":"b","iterations":1,"projection":"ID"}]"#,
 		)?;
 		let scans = super::expand_scan_specs(specs)?;
 		assert_eq!(scans.len(), 2);
@@ -1025,7 +1025,7 @@ mod test {
 	#[test]
 	fn scan_spec_single_run_array_not_multi() -> Result<()> {
 		let specs: Vec<super::ScanSpec> = serde_json::from_str(
-			r#"[{"id":"one","runs":[{"name":"only","projection":"FULL"}],"samples":1}]"#,
+			r#"[{"id":"one","runs":[{"name":"only","projection":"FULL"}],"iterations":1}]"#,
 		)?;
 		let scans = super::expand_scan_specs(specs)?;
 		assert_eq!(scans.len(), 1);
@@ -1045,7 +1045,7 @@ mod test {
 	#[test]
 	fn scan_spec_json_requires_id_field() {
 		let err = serde_json::from_str::<Vec<super::ScanSpec>>(
-			r#"[{"name":"x","samples":1,"projection":"ID"}]"#,
+			r#"[{"name":"x","iterations":1,"projection":"ID"}]"#,
 		);
 		assert!(err.is_err());
 	}
@@ -1053,7 +1053,7 @@ mod test {
 	#[test]
 	fn scan_spec_rejects_whitespace_id() {
 		let specs: Vec<super::ScanSpec> =
-			serde_json::from_str(r#"[{"id":"   ","name":"x","samples":1,"projection":"ID"}]"#)
+			serde_json::from_str(r#"[{"id":"   ","name":"x","iterations":1,"projection":"ID"}]"#)
 				.unwrap();
 		assert!(super::expand_scan_specs(specs).is_err());
 	}
@@ -1061,7 +1061,7 @@ mod test {
 	#[test]
 	fn scan_with_index_ok_when_id_present() {
 		let specs: Vec<super::ScanSpec> = serde_json::from_str(
-			r#"[{"id":"x","name":"y","samples":1,"with_index":{"fields":["n"]}}]"#,
+			r#"[{"id":"x","name":"y","iterations":1,"with_index":{"fields":["n"]}}]"#,
 		)
 		.unwrap();
 		let scans = super::expand_scan_specs(specs).unwrap();
@@ -1071,7 +1071,7 @@ mod test {
 	#[test]
 	fn scan_spec_with_writes_rejects_single_object() {
 		let err = serde_json::from_str::<Vec<super::ScanSpec>>(
-			r#"[{"id":"w","name":"n","samples":1,"with_writes":{"ratio":0.2}}]"#,
+			r#"[{"id":"w","name":"n","iterations":1,"with_writes":{"ratio":0.2}}]"#,
 		);
 		assert!(err.is_err());
 	}
@@ -1079,7 +1079,7 @@ mod test {
 	#[test]
 	fn scan_spec_with_writes_vec() {
 		let specs: Vec<super::ScanSpec> = serde_json::from_str(
-			r#"[{"id":"w","name":"n","samples":1,"with_writes":[{"ratio":0.1},{"ratio":0.5}]}]"#,
+			r#"[{"id":"w","name":"n","iterations":1,"with_writes":[{"ratio":0.1},{"ratio":0.5}]}]"#,
 		)
 		.unwrap();
 		let scans = super::expand_scan_specs(specs).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -979,8 +979,9 @@ mod test {
 
 	#[test]
 	fn scan_spec_name_only() -> Result<()> {
-		let specs: Vec<super::ScanSpec> =
-			serde_json::from_str(r#"[{"id":"spec_a","name":"a","iterations":1,"projection":"ID"}]"#)?;
+		let specs: Vec<super::ScanSpec> = serde_json::from_str(
+			r#"[{"id":"spec_a","name":"a","iterations":1,"projection":"ID"}]"#,
+		)?;
 		let scans = super::expand_scan_specs(specs)?;
 		assert_eq!(scans.len(), 1);
 		assert_eq!(scans[0].name, "a");

--- a/src/result.rs
+++ b/src/result.rs
@@ -84,7 +84,7 @@ where
 pub(crate) enum ScanWorkload {
 	/// Pure read/query workload.
 	Read,
-	/// Read path plus compensating writes at this percentage of samples.
+	/// Read path plus compensating writes at this percentage of iterations.
 	ReadWrite {
 		write_ratio_percent: u32,
 	},
@@ -108,7 +108,7 @@ pub(crate) fn writes_ratio_percent(spec: &crate::ScanWithWrites) -> u32 {
 }
 
 /// Table row title for a scan leg (matches `[S]can` markers in stdout tables).
-pub(crate) fn scan_run_row_label(id: &str, name: &str, samples: u32, run: &ScanRun) -> String {
+pub(crate) fn scan_run_row_label(id: &str, name: &str, iterations: u32, run: &ScanRun) -> String {
 	let index_slug = if run.indexed {
 		"indexed"
 	} else {
@@ -120,7 +120,7 @@ pub(crate) fn scan_run_row_label(id: &str, name: &str, samples: u32, run: &ScanR
 			write_ratio_percent: p,
 		} => format!("reads+writes ({p}%) - {index_slug}"),
 	};
-	format!("[S]can · {id} · {name} - {mid} ({samples})")
+	format!("[S]can · {id} · {name} - {mid} ({iterations})")
 }
 
 impl ScanRun {
@@ -147,8 +147,8 @@ pub(crate) struct ScanResult {
 	pub(crate) id: String,
 	/// Human-readable scan title.
 	pub(crate) name: String,
-	/// Sample count for timed scan legs (may override global default).
-	pub(crate) samples: u32,
+	/// Iteration count for timed scan legs (may override global default).
+	pub(crate) iterations: u32,
 	/// Index creation phase when an indexed leg exists.
 	pub(crate) index_build: Option<OperationResult>,
 	/// Index teardown phase.
@@ -233,7 +233,7 @@ impl Display for BenchmarkResult {
 		}
 		for scan in &self.scans {
 			for run in scan.runs.iter().filter(|r| !r.indexed) {
-				let label = scan_run_row_label(&scan.id, &scan.name, scan.samples, run);
+				let label = scan_run_row_label(&scan.id, &scan.name, scan.iterations, run);
 				if let Some(res) = &run.result {
 					table.add_row(res.output(label));
 				} else {
@@ -253,7 +253,7 @@ impl Display for BenchmarkResult {
 				}
 			}
 			for run in scan.runs.iter().filter(|r| r.indexed) {
-				let label = scan_run_row_label(&scan.id, &scan.name, scan.samples, run);
+				let label = scan_run_row_label(&scan.id, &scan.name, scan.iterations, run);
 				if let Some(res) = &run.result {
 					table.add_row(res.output(label));
 				} else {
@@ -273,8 +273,8 @@ impl Display for BenchmarkResult {
 				}
 			}
 		}
-		for (name, samples, groups, result) in &self.batches {
-			let name = format!("[B]atch::{name} ({samples} batches of {groups})");
+		for (name, iterations, groups, result) in &self.batches {
+			let name = format!("[B]atch::{name} ({iterations} batches of {groups})");
 			if let Some(res) = &result {
 				table.add_row(res.output(name));
 			} else {
@@ -325,7 +325,7 @@ impl BenchmarkResult {
 		// Add the [S]cans results to the output
 		for scan in &self.scans {
 			for run in scan.runs.iter().filter(|r| !r.indexed) {
-				let label = scan_run_row_label(&scan.id, &scan.name, scan.samples, run);
+				let label = scan_run_row_label(&scan.id, &scan.name, scan.iterations, run);
 				if let Some(res) = &run.result {
 					w.write_record(res.output_csv(label))?;
 				} else {
@@ -345,7 +345,7 @@ impl BenchmarkResult {
 				}
 			}
 			for run in scan.runs.iter().filter(|r| r.indexed) {
-				let label = scan_run_row_label(&scan.id, &scan.name, scan.samples, run);
+				let label = scan_run_row_label(&scan.id, &scan.name, scan.iterations, run);
 				if let Some(res) = &run.result {
 					w.write_record(res.output_csv(label))?;
 				} else {
@@ -366,8 +366,8 @@ impl BenchmarkResult {
 			}
 		}
 		// Add the [B]atch results to the output
-		for (name, samples, groups, result) in &self.batches {
-			let name = format!("[B]atch::{name} ({samples} batches of {groups})");
+		for (name, iterations, groups, result) in &self.batches {
+			let name = format!("[B]atch::{name} ({iterations} batches of {groups})");
 			if let Some(res) = &result {
 				w.write_record(res.output_csv(name))?;
 			} else {


### PR DESCRIPTION
## Summary

The TOML field `samples` under `[[scans]]` and `[[batches]]` named the number of timed iterations to run, which clashed with the CLI `--samples` flag (the number of CRUD records). Reading a config, you couldn't tell which `samples` you were looking at — and the CRUD `--samples` value silently served as the fallback for both scan iterations and batch iterations, making the overload load-bearing rather than cosmetic.

This rename disambiguates: scans and batches now configure `iterations`. CRUD `--samples` keeps its existing name.

## What changed

- TOML deserialization: `ScanSpec.samples`, `Scan.samples`, `BatchOperation.samples` → `iterations` (`src/main.rs`)
- JSON output: `ScanResult.samples` → `iterations` so `result.json` mirrors the new TOML name (`src/result.rs`)
- All 6 config files updated: `bench.toml`, `ci.toml`, `test.toml`, `vector.toml`, `cache.toml` (plus the header comments at the top of each)
- Local variables in the scan/batch loops and the `scan_run_row_label` parameter renamed so the code no longer overloads `samples` against itself (`src/benchmark.rs`)
- Doc comments and the README scan-config example updated

CRUD samples kept as-is: CLI `--samples`, `Args.samples`, `BenchmarkMetadata.samples`, `Benchmark.samples`, and unrelated `cpu_samples` / `memory_samples` etc.

## Breaking changes

1. Existing TOML configs using `samples = N` under `[[scans]]` or `[[batches]]` will fail to deserialize and must rename to `iterations = N`. No `#[serde(alias = "samples")]` was added — the point was to remove the overload, not carry it forward.
2. `result.json` consumers will see `scans[].iterations` instead of `scans[].samples`.

## Test plan

- [x] `cargo check --tests` clean
- [x] `cargo test scan_spec` — all 9 parser tests pass
- [ ] Smoke run against `config/test.toml` with `-d dry`
- [ ] Confirm `result.json` shape downstream consumers (if any) handle the field rename