### PR TITLE
Fix MongoDB dead index on Surreal-style `tags.*` array path

### DIFF
--- a/src/dialect.rs
+++ b/src/dialect.rs
@@ -475,6 +475,15 @@ impl Dialect for MongoDBDialect {}
 
 #[cfg(feature = "mongodb")]
 impl MongoDBDialect {
+	/// Bench `tags.*` denotes an array-element index; MongoDB has no Surreal-style
+	/// path syntax and would treat `*` as a literal sub-field, building a dead index
+	/// on a path no document has. The `.*` suffix is itself the array/object signal
+	/// in the bench schema, so strip it: the key then targets the field directly,
+	/// which MongoDB auto-promotes to a multikey index.
+	pub(crate) fn index_key_list(spec: &crate::Index) -> Vec<String> {
+		spec.fields.iter().map(|f| f.strip_suffix(".*").unwrap_or(f).to_string()).collect()
+	}
+
 	/// Constructs the filter document for [S]scan tests
 	pub fn filter_clause(scan: &Scan) -> Result<Document> {
 		if let Some(ref c) = scan.condition {
@@ -496,5 +505,34 @@ impl MongoDBDialect {
 				_ => bail!(NOT_SUPPORTED_ERROR),
 			},
 		}
+	}
+}
+
+#[cfg(all(test, feature = "mongodb"))]
+mod mongodb_tests {
+	use super::*;
+	use crate::Index;
+
+	fn index(fields: &[&str]) -> Index {
+		Index {
+			skip: false,
+			fields: fields.iter().map(|s| s.to_string()).collect(),
+			unique: None,
+			index_type: None,
+		}
+	}
+
+	#[test]
+	fn strips_array_element_suffix() {
+		// `tags.*` is Surreal index syntax; the MongoDB key must target the
+		// `tags` array itself so it auto-promotes to a multikey index.
+		let keys = MongoDBDialect::index_key_list(&index(&["tags.*", "created_at"]));
+		assert_eq!(keys, vec!["tags".to_string(), "created_at".to_string()]);
+	}
+
+	#[test]
+	fn leaves_plain_fields_untouched() {
+		let keys = MongoDBDialect::index_key_list(&index(&["status", "created_at"]));
+		assert_eq!(keys, vec!["status".to_string(), "created_at".to_string()]);
 	}
 }

--- a/src/mongodb.rs
+++ b/src/mongodb.rs
@@ -272,23 +272,26 @@ impl BenchmarkClient for MongoDBClient {
 	async fn build_index(&self, spec: &Index, name: &str) -> Result<()> {
 		// Define the index document
 		let mut doc = Document::new();
+		// Translate bench `tags.*` array-element paths to the base array field so
+		// the index targets a real path (MongoDB has no Surreal-style path syntax).
+		let fields = MongoDBDialect::index_key_list(spec);
 		// Check if an index type is specified
 		match &spec.index_type {
 			Some(kind) if kind == "fulltext" => {
 				// Create a text index
-				for field in &spec.fields {
+				for field in &fields {
 					doc.insert(field, "text");
 				}
 			}
 			Some(kind) => {
 				// Other index types (e.g., "2d", "2dsphere", "hashed")
-				for field in &spec.fields {
+				for field in &fields {
 					doc.insert(field, kind.as_str());
 				}
 			}
 			None => {
 				// Standard ascending index
-				for field in &spec.fields {
+				for field in &fields {
 					doc.insert(field, 1);
 				}
 			}


### PR DESCRIPTION
## Summary

Fixes #258 — the MongoDB half of #257.

The MongoDB adapter inserted configured index field keys **verbatim**, so the `tags.*` spec (SurrealDB array-element syntax) created a MongoDB index on a literal `tags.*` sub-field that no document has. The index built without error but was empty and never used, so the **"indexed query" leg silently ran an unindexed `COLLSCAN` + blocking sort** — producing numbers identical to the full-table-scan leg (~3 ops/s with and without the index).

## What changed

- **`src/dialect.rs`** — add `MongoDBDialect::index_key_list(spec)`, which strips a trailing `.*` so the key targets the array field directly. `tags.*` → `tags`, which MongoDB auto-promotes to a multikey index.
- **`src/mongodb.rs`** — `build_index` now builds its key document from `index_key_list(spec)` instead of inserting `spec.fields` verbatim. The configured `["tags.*", "created_at"]` now yields `{ tags: 1, created_at: 1 }` instead of the dead `{ "tags.*": 1, "created_at": 1 }`.

## Design note

The SQL dialects' `btree_index_key_list` gate the `.*` strip behind a column-type check (`Array | Object`). Here the strip is **unconditional**: the `.*` suffix is itself the array-element signal in the bench schema (crud-bench owns its config, so a `scalar.*` spec can't occur). This keeps MongoDB's `build_index` free of any schema dependency — unlike the SQL clients, which already hold `Columns` for inserts/reads, MongoDB otherwise needs none, so threading it through just to guard an impossible state isn't worth it.

## Caveat

The corrected index still cannot avoid the in-memory sort — a multikey index can't provide a sort on a field that follows the array field. The point is to make the filter index-assisted and the result **honest**, not competitive.

## Verification

- `cargo test --features mongodb mongodb_tests` → 2 passed, 0 failed (regression tests pinning `tags.*` → `tags` and plain-field passthrough); full crate compiles.
- `cargo fmt --check` → clean.
- Runtime checks from the issue (`db.record.getIndexes()` showing a `tags` key, `explain()` showing `IXSCAN` over `COLLSCAN`) require a live MongoDB instance and were not run here.