### PR TITLE
Make Postgres no-sync match the other adapters' durability tier

### DIFF
--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -80,10 +80,15 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 		max_wal_gb,
 		min_wal_gb,
 	) = calculate_postgres_memory();
-	// fsync and synchronous_commit must agree: with fsync=off the WAL is not
-	// flushed to disk, so synchronous_commit=on cannot give the durability it
-	// claims. Set both consistently based on `options.sync`.
-	let sync_setting = if options.sync {
+	// `synchronous_commit=on` makes every commit force a `write(2)` of the WAL
+	// to the OS page cache before returning; `fsync` then carries the `--sync`
+	// flag: `on` fsyncs that WAL to disk per commit (full durability), `off`
+	// skips the fsync but keeps the per-commit page-cache write. The no-`--sync`
+	// profile is therefore process-crash safe / power-crash unsafe, matching
+	// SurrealDB (RocksDB `sync=never`) and ArcadeDB (`txWALFlush=1`) — rather
+	// than `synchronous_commit=off`, which defers the `write(2)` itself and so
+	// skips work the other adapters still do. See issue #256.
+	let fsync_setting = if options.sync {
 		"on"
 	} else {
 		"off"
@@ -114,14 +119,14 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 				-c effective_io_concurrency=200 \
 				-c min_wal_size={min_wal_gb}GB \
 				-c max_wal_size={max_wal_gb}GB \
-				-c fsync={sync_setting} \
-				-c synchronous_commit={sync_setting}"
+				-c fsync={fsync_setting} \
+				-c synchronous_commit=on"
 			),
 			// Default configuration
 			false => format!(
 				"postgres -N 1024 \
-				-c fsync={sync_setting} \
-				-c synchronous_commit={sync_setting}"
+				-c fsync={fsync_setting} \
+				-c synchronous_commit=on"
 			),
 		},
 	}


### PR DESCRIPTION
## What

At `--sync=false`, the Postgres adapter used `fsync=off, synchronous_commit=off`. This change pins `synchronous_commit=on` and lets `fsync` carry the `--sync` flag instead:

| `--sync` | Before | After |
|---|---|---|
| `true` | `fsync=on, synchronous_commit=on` | `fsync=on, synchronous_commit=on` (unchanged) |
| `false` | `fsync=off, synchronous_commit=off` | **`fsync=off, synchronous_commit=on`** |

## Why

`synchronous_commit=off` defers the per-commit WAL `write(2)` itself — committed rows live only in Postgres shared memory until `wal_writer` catches up (~200ms). That's strictly more aggressive than every other adapter at `--sync=false`:

- **SurrealDB-RocksDB** (`sync=never`), **SurrealKV**, **ArcadeDB** (`txWALFlush=1`), standalone **rocksdb** — all still `write(2)` to the OS page cache on *every* commit and only skip the fsync. They're process-crash safe, just OS/power-crash unsafe.

So Postgres was skipping work the others perform, giving it an unfair edge in cross-adapter latency/throughput numbers. Pinning `synchronous_commit=on` restores the per-commit page-cache write; `fsync=off` skips only the fsync. No-sync Postgres now sits in the same durability tier as SurrealDB/ArcadeDB. `--sync=true` is unchanged (full durability).

## Reviewer note — this is the *inverse* of the snippet in the issue

[#256](https://github.com/surrealdb/crud-bench/issues/256) proposes `fsync=on, synchronous_commit=off`. But that keeps `synchronous_commit=off`, which is exactly what defers the write the issue itself flags as the problem — it matches **MongoDB**'s `journal(false)` tier (in-memory ack, ~100ms background batched flush), not the SurrealDB tier the prose targets. `synchronous_commit` (not `fsync`) is the knob that controls the per-commit `write(2)`, so the flag has to ride on `fsync` to get "page-cache write per commit, no fsync." Worth updating the issue's "Proposed fix" so it isn't re-applied the other way.

## Follow-up (not in this PR)

The **MariaDB** adapter has the same over-aggressiveness this PR removes from Postgres: its no-sync uses `innodb_flush_log_at_trx_commit=0` (most-aggressive tier). Moving it to `2` would bring it into the same fair tier. Left out to keep this change scoped to #256.

## Testing

`cargo check` passes (the `postgres` feature is in the default set).

Fixes #256.