### PR TITLE
Use GIN index for Postgres JSONB array-containment scans

### DIFF
--- a/src/dialect.rs
+++ b/src/dialect.rs
@@ -127,6 +127,23 @@ impl PostgresDialect {
 			.collect::<Vec<_>>()
 			.join(", ")
 	}
+
+	/// JSONB array/object columns targeted by Surreal-style `tags.*` wildcard specs.
+	///
+	/// The `[string] CONTAINS string` scan filters these with the `@>` containment
+	/// operator, which only a GIN index (`jsonb_path_ops`) can serve — a B-tree on
+	/// the column is unusable. Returned escaped, ready for a `USING GIN (...)` clause.
+	pub(crate) fn gin_containment_columns(columns: &Columns, spec: &crate::Index) -> Vec<String> {
+		spec.fields
+			.iter()
+			.filter_map(|field| {
+				let base = field.strip_suffix(".*")?;
+				let (_, col_type) = columns.0.iter().find(|(n, _)| n == base)?;
+				matches!(col_type, ColumnType::Array | ColumnType::Object)
+					.then(|| AnsiSqlDialect::escape_field(base.to_string()))
+			})
+			.collect()
+	}
 }
 
 // --------------------------------------------------
@@ -534,5 +551,52 @@ mod mongodb_tests {
 	fn leaves_plain_fields_untouched() {
 		let keys = MongoDBDialect::index_key_list(&index(&["status", "created_at"]));
 		assert_eq!(keys, vec!["status".to_string(), "created_at".to_string()]);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::Index;
+
+	fn columns() -> Columns {
+		Columns(vec![
+			("tags".to_string(), ColumnType::Array),
+			("created_at".to_string(), ColumnType::DateTime),
+		])
+	}
+
+	fn index(fields: &[&str]) -> Index {
+		Index {
+			skip: false,
+			fields: fields.iter().map(|s| s.to_string()).collect(),
+			unique: None,
+			index_type: None,
+		}
+	}
+
+	#[test]
+	fn postgres_gin_containment_selects_only_jsonb_array_column() {
+		// `tags.*` filters with `@>`, which needs GIN; the companion ordering
+		// column `created_at` cannot live in a GIN index and is dropped.
+		let cols = columns();
+		let spec = index(&["tags.*", "created_at"]);
+		assert_eq!(PostgresDialect::gin_containment_columns(&cols, &spec), vec!["\"tags\""]);
+	}
+
+	#[test]
+	fn postgres_gin_containment_empty_without_wildcard() {
+		// A plain composite btree spec has no array-containment column.
+		let cols = columns();
+		let spec = index(&["created_at"]);
+		assert!(PostgresDialect::gin_containment_columns(&cols, &spec).is_empty());
+	}
+
+	#[test]
+	fn postgres_btree_key_list_still_collapses_wildcard_to_bare_column() {
+		// The btree path (used when no GIN column is present) is unchanged.
+		let cols = columns();
+		let spec = index(&["tags.*", "created_at"]);
+		assert_eq!(PostgresDialect::btree_index_key_list(&cols, &spec), "\"tags\", \"created_at\"");
 	}
 }

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -254,6 +254,10 @@ impl BenchmarkClient for PostgresClient {
 		.to_string();
 		// Get the fields
 		let fields = PostgresDialect::btree_index_key_list(&self.columns, spec);
+		// Surreal-style `tags.*` specs target a JSONB array/object column that the
+		// scan filters with the `@>` containment operator — a B-tree cannot serve
+		// it, so these columns need a GIN index instead.
+		let gin_columns = PostgresDialect::gin_containment_columns(&self.columns, spec);
 		// Check if an index type is specified
 		let stmt = match &spec.index_type {
 			Some(kind) if kind == "fulltext" => {
@@ -267,6 +271,20 @@ impl BenchmarkClient for PostgresClient {
 			}
 			Some(kind) => {
 				format!("CREATE {unique} INDEX {name} ON record USING {kind} ({fields})")
+			}
+			// Auto-select GIN for JSONB array-containment fields. GIN returns an
+			// unordered bitmap, so it indexes only the JSONB column(s) with
+			// `jsonb_path_ops`; any companion ordering column (e.g. created_at) is
+			// dropped, since it cannot coexist usefully in a GIN index. This makes
+			// the `@>` filter index-assisted (the prior B-tree was unusable), though
+			// the trailing `ORDER BY ... LIMIT` still forces a Top-N sort.
+			None if !gin_columns.is_empty() => {
+				let cols = gin_columns
+					.iter()
+					.map(|c| format!("{c} jsonb_path_ops"))
+					.collect::<Vec<_>>()
+					.join(", ");
+				format!("CREATE INDEX {name} ON record USING GIN ({cols})")
 			}
 			None => {
 				format!("CREATE {unique} INDEX {name} ON record ({fields})")


### PR DESCRIPTION
## Summary

Fixes #260.

For the `[string] CONTAINS string` benchmark (`where_field_many_contains_string_order_by_desc`), the Postgres adapter built a default **B-tree** index on the `tags` JSONB column, but the scan filters with the containment operator `@>`. B-tree cannot serve `@>`, so the index was unusable — the "indexed" leg silently fell back to a sequential scan + Top-N sort, producing a result identical to the full-scan leg. The row was mislabeled as "indexed".

## What changed

- **`src/dialect.rs`** — new `PostgresDialect::gin_containment_columns()` helper. It detects Surreal-style `tags.*` specs that point at `Array`/`Object` (JSONB) columns and returns them escaped, ready for a `USING GIN (...)` clause. Mirrors the existing detection in `btree_index_key_list`.
- **`src/postgres.rs`** — `build_index` gains a `None if !gin_columns.is_empty()` match arm that auto-selects a GIN index when no explicit `index_type` is set. For the benchmark's `fields = ["tags.*", "created_at"]` it now emits:

  ```sql
  CREATE INDEX <name> ON record USING GIN ("tags" jsonb_path_ops)
  ```

  The companion ordering column (`created_at`) is dropped, since it cannot coexist usefully in a GIN index. `jsonb_path_ops` is chosen deliberately: it is the smaller/faster GIN opclass and supports exactly the `@>` operator the scan uses (it omits the key-existence operators we don't need).
- Three unit tests in `src/dialect.rs` lock in the GIN-column detection.

This was the **auto-select** option proposed in the issue (over a per-dialect `index_type` override), keeping the change localized to the Postgres adapter with no config or shared-struct changes. Both `config/bench.toml` and `config/ci.toml` carry the identical scan spec (neither sets `index_type`), so both are covered by this single change.

## Why this doesn't close the performance gap (and shouldn't)

This fixes the **honesty** problem: the filter is now genuinely index-assisted instead of using an unusable B-tree. It does **not** make Postgres competitive on this query, and that's expected and correct. GIN returns an unordered bitmap, so the trailing `ORDER BY created_at DESC LIMIT 1000` still forces a Top-N sort over all matched rows (~20% of the table). You cannot build a useful compound `(tags, created_at)` GIN to serve the ordering.

That is the legitimate architectural distinction the benchmark should show: inverted indexes (Postgres GIN, MySQL multi-valued, Mongo multikey) can index array containment but cannot combine it with an ordered-LIMIT short-circuit, whereas SurrealDB's composite `tags.*, created_at` index can.

## Testing

All CI checks pass locally:

- `cargo check --features postgres` — clean
- `cargo test --features postgres` — 3 new tests pass
- `cargo fmt --all --check` — clean
- `cargo clippy --tests --all-features -- -D warnings` — clean

A live Postgres `EXPLAIN` to confirm planner index usage was not possible in this environment (Docker unavailable), but `jsonb_path_ops` GIN serving `@>` is standard Postgres behavior and the generated DDL is unit-tested.

## Related

- #257 (original report covering Postgres + MongoDB) — this is the Postgres half.
