### PR TITLE
Fix ScyllaDB Full-projection scan fetching only the key

### DIFF
--- a/src/scylladb.rs
+++ b/src/scylladb.rs
@@ -279,12 +279,13 @@ impl ScylladbClient {
 				Ok(count)
 			}
 			Projection::Full => {
-				let stm = format!("SELECT id FROM bench.record {c} {l}");
+				let stm = format!("SELECT JSON * FROM bench.record {c} {l}");
 				let mut res = self.session.query_iter(stm, ()).await?.rows_stream()?.skip(s);
 				let mut count = 0;
 				while let Some(v) = res.next().await {
-					let v: (String,) = v?;
-					black_box(v);
+					let (v,): (String,) = v?;
+					let json: serde_json::Value = serde_json::from_str(&v)?;
+					black_box(BenchValue::from(&json));
 					count += 1;
 				}
 				Ok(count)


### PR DESCRIPTION
## What

Fixes the `Projection::Full` scan in the **ScyllaDB** adapter, which only fetched the key column instead of full rows.

The `Projection::Full` branch ([`src/scylladb.rs`](https://github.com/surrealdb/crud-bench/blob/main/src/scylladb.rs#L281)) was byte-for-byte identical to `Projection::Id` — it ran `SELECT id FROM bench.record …` and decoded only `(String,)`.

## Why

`Projection::Full` is meant to measure scanning and materializing **full rows**, as the counterpart to the key-only `Projection::Id`. Because the branch only read/decoded the `id` column, the full-scan numbers measured a key-only scan — artificially fast and not comparable to the other engines, whose `Full` branches all `SELECT *` (Postgres, MySQL, SurrealDB).

## How

Mirror the adapter's own `read()` path: `SELECT JSON * FROM bench.record …`, then parse each row's JSON and build a `BenchValue`.

## Notes for reviewers

- Scope is **ScyllaDB only**. The MongoDB adapter had the identical bug; it is fixed separately in #268.
- Verified with `cargo check` (default features, which include the ScyllaDB adapter) and `cargo fmt --check`.

Closes #262.
