### PR TITLE
Fix MongoDB select(*) scan to materialize full documents

### DIFF
--- a/src/mongodb.rs
+++ b/src/mongodb.rs
@@ -558,24 +558,14 @@ impl MongoDBClient {
 				.await
 			}
 			Projection::Full => {
+				// No projection: return the full document, matching `SELECT *`
+				// in the SQL/Surreal adapters. (`Projection::Id` above projects
+				// only `_id`.)
 				consume(match o {
 					Some(o) => {
-						self.collection()
-							.find(c)
-							.sort(o)
-							.skip(s as u64)
-							.limit(l as i64)
-							.projection(doc! { "_id": 1 })
-							.await?
+						self.collection().find(c).sort(o).skip(s as u64).limit(l as i64).await?
 					}
-					None => {
-						self.collection()
-							.find(c)
-							.skip(s as u64)
-							.limit(l as i64)
-							.projection(doc! { "_id": 1 })
-							.await?
-					}
+					None => self.collection().find(c).skip(s as u64).limit(l as i64).await?,
 				})
 				.await
 			}


### PR DESCRIPTION
## What

The MongoDB adapter's `Projection::Full` scan path (`select(*)`) applied `.projection(doc! { "_id": 1 })` — identical to the `Projection::Id` arm just above it — so it fetched only `_id` rather than the entire document.

This PR drops the projection from the `Projection::Full` arm so the full document is materialized, matching `SELECT *` semantics. `Projection::Id` is left unchanged (still projects `_id` only).

## Why

Every other adapter materializes full rows for `select(*)` (e.g. Postgres `SELECT *`, SurrealDB `SELECT *`). MongoDB was shipping only `_id`, an `_id`-only covered read, on every full-projection scan. This unfairly favored MongoDB on scans where document size/transfer matters — the plain `limit`, `start_limit`, and `where(...) select(*)` cases especially. On sort-dominated `CONTAINS` / `IN ... ORDER BY ... LIMIT` scans the effect is negligible (only 1000 docs returned, sort dominates), but the semantics were still wrong and inconsistent with the other engines.

## Verification

- `cargo check --features mongodb` — clean (no errors or warnings)
- `cargo fmt --check` — clean

Runtime verification (re-running a `limit` / `start_limit` scan against a live MongoDB to confirm full-document decode) requires Docker + a benchmark run and was not executed here; the change is verified at the compile/semantic level against the SQL/Surreal adapters.

## Note for reviewers

While confirming the intended `Id` vs `Full` semantics, I noticed ScyllaDB (`src/scylladb.rs`) has the same class of bug — its `Projection::Full` arm uses `SELECT id` rather than `SELECT *`, despite the table having full columns. That's out of scope for this MongoDB fix and left for a separate change.

Fixes #259