### PR TITLE
Align MySQL/MariaDB no-sync durability with the other adapters

### DIFF
--- a/src/mariadb.rs
+++ b/src/mariadb.rs
@@ -42,6 +42,23 @@ fn calculate_mariadb_memory() -> (u64, u64, u64) {
 pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 	// Calculate memory allocation
 	let (buffer_pool_gb, redo_log_gb, buffer_pool_instances) = calculate_mariadb_memory();
+	// Durability keyed on `--sync`. At `--sync=false`, innodb_flush_log_at_trx_commit=2
+	// still writes the redo log to the OS page cache on every commit and only
+	// defers the fsync (~1/sec) — the same no-sync tier as the other adapters
+	// (process-crash safe, OS/power-crash unsafe). `0` would also skip the
+	// per-commit write, which is strictly more aggressive. `--sync=true` keeps a
+	// full per-commit fsync (`1`). sync_binlog stays 0/1: at 0 the binlog is
+	// still written per commit, only its fsync is skipped — already this tier.
+	let trx_commit = if options.sync {
+		"1"
+	} else {
+		"2"
+	};
+	let sync_binlog = if options.sync {
+		"1"
+	} else {
+		"0"
+	};
 	DockerParams {
 		image: "mariadb",
 		pre_args: "--ulimit nofile=65536:65536 -p 127.0.0.1:3306:3306 -e MARIADB_ROOT_PASSWORD=mariadb -e MARIADB_DATABASE=bench".to_string(),
@@ -70,18 +87,8 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 				--binlog-format=ROW \
 				--server-id=1 \
 				--binlog-row-image=MINIMAL \
-				--sync_binlog={} \
-				--innodb-flush-log-at-trx-commit={}",
-				if options.sync {
-					"1"
-				} else {
-					"0"
-				},
-				if options.sync {
-					"1"
-				} else {
-					"0"
-				}
+				--sync_binlog={sync_binlog} \
+				--innodb-flush-log-at-trx-commit={trx_commit}"
 			),
 			false => format!(
 				"--max-connections=1024 \
@@ -89,18 +96,8 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 				--binlog-format=ROW \
 				--server-id=1 \
 				--binlog-row-image=FULL \
-				--sync_binlog={} \
-				--innodb-flush-log-at-trx-commit={}",
-				if options.sync {
-					"1"
-				} else {
-					"0"
-				},
-				if options.sync {
-					"1"
-				} else {
-					"0"
-				}
+				--sync_binlog={sync_binlog} \
+				--innodb-flush-log-at-trx-commit={trx_commit}"
 			),
 		},
 	}

--- a/src/mysql.rs
+++ b/src/mysql.rs
@@ -40,6 +40,23 @@ fn calculate_mysql_memory() -> (u64, u64, u64) {
 pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 	// Calculate memory allocation
 	let (buffer_pool_gb, redo_log_gb, buffer_pool_instances) = calculate_mysql_memory();
+	// Durability keyed on `--sync`. At `--sync=false`, innodb_flush_log_at_trx_commit=2
+	// still writes the redo log to the OS page cache on every commit and only
+	// defers the fsync (~1/sec) — the same no-sync tier as the other adapters
+	// (process-crash safe, OS/power-crash unsafe). `0` would also skip the
+	// per-commit write, which is strictly more aggressive. `--sync=true` keeps a
+	// full per-commit fsync (`1`). sync_binlog stays 0/1: at 0 the binlog is
+	// still written per commit, only its fsync is skipped — already this tier.
+	let trx_commit = if options.sync {
+		"1"
+	} else {
+		"2"
+	};
+	let sync_binlog = if options.sync {
+		"1"
+	} else {
+		"0"
+	};
 	// Return Docker parameters
 	DockerParams {
 		image: "mysql",
@@ -69,18 +86,8 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 				--binlog-format=ROW \
 				--server-id=1 \
 				--binlog-row-image=MINIMAL \
-				--sync_binlog={} \
-				--innodb-flush-log-at-trx-commit={}",
-				if options.sync {
-					"1"
-				} else {
-					"0"
-				},
-				if options.sync {
-					"1"
-				} else {
-					"0"
-				}
+				--sync_binlog={sync_binlog} \
+				--innodb-flush-log-at-trx-commit={trx_commit}"
 			),
 			// Default configuration
 			false => format!(
@@ -89,18 +96,8 @@ pub(crate) fn docker(options: &Benchmark) -> DockerParams {
 				--binlog-format=ROW \
 				--server-id=1 \
 				--binlog-row-image=FULL \
-				--sync_binlog={} \
-				--innodb-flush-log-at-trx-commit={}",
-				if options.sync {
-					"1"
-				} else {
-					"0"
-				},
-				if options.sync {
-					"1"
-				} else {
-					"0"
-				}
+				--sync_binlog={sync_binlog} \
+				--innodb-flush-log-at-trx-commit={trx_commit}"
 			),
 		},
 	}


### PR DESCRIPTION
## What

At `--sync=false`, both the MySQL and MariaDB adapters set `--innodb-flush-log-at-trx-commit=0`. This moves the no-sync value to `2`; `--sync=true` is unchanged at `1`.

| `--sync` | Before | After |
|---|---|---|
| `true` | `innodb_flush_log_at_trx_commit=1` | `1` (unchanged) |
| `false` | `innodb_flush_log_at_trx_commit=0` | **`2`** |

`--sync_binlog` is unchanged (`1`/`0`).

## Why

`innodb_flush_log_at_trx_commit=0` is the *most*-aggressive InnoDB durability tier: the redo log is written **and** fsync'd by a background thread only ~once per second, with *nothing* happening at commit. A mere `mysqld` process crash loses the last ~1s of commits.

That's strictly more aggressive than every other adapter at `--sync=false`:

| Adapter | no-sync setting | At commit |
|---|---|---|
| MySQL / MariaDB (before) | `innodb_flush_log_at_trx_commit=0` | nothing per commit; redo write+fsync ~1/sec |
| SurrealDB (RocksDB) | `sync=never` | `write(2)` to page cache, no fsync |
| ArcadeDB | `txWALFlush=1` | `write(2)` to page cache, no fsync |
| Postgres | `fsync=off` | `write(2)` to page cache, no fsync |

`2` writes the redo log to the OS page cache on every commit and defers only the fsync (~1/sec) — process-crash safe, OS/power-crash unsafe, the same tier as the rest. This makes cross-adapter `--sync=false` latency/throughput numbers apples-to-apples. `--sync=true` keeps a full per-commit fsync (`1`), so full-durability runs are unaffected.

`--sync_binlog` needs no change: at `0` the binlog is still `write(2)`-ten to the OS cache on every commit and only the fsync is skipped — already the target tier.

## Notes

- Sibling of #256 / #264 (Postgres). PR #264 explicitly flagged this as the follow-up: *"The MariaDB adapter has the same over-aggressiveness this PR removes from Postgres ... Moving it to `2` would bring it into the same fair tier."*
- Collapses the four duplicated inline `if options.sync { "1" } else { "0" }` ternaries into two documented `let` bindings (`trx_commit`, `sync_binlog`), mirroring how `postgres.rs` documents its `sync_setting`. Net −6 lines, and the asymmetry (`trx_commit` 1/2 vs `sync_binlog` 1/0) is now explained in one place so it isn't "fixed" back to symmetric 0/1.

## Testing

`cargo check` passes (both `mysql` and `mariadb` are in the default feature set). `cargo fmt --check` is clean.

Fixes #267.
