### PR TITLE
ci: move CI onto spot org runners and add sccache

### DIFF
--- a/.github/actions/setup-cache/action.yml
+++ b/.github/actions/setup-cache/action.yml
@@ -1,4 +1,4 @@
-name: Setup sccache
+name: Setup cache
 description: >-
   Configure the sccache S3 compiler cache (RUSTC_WRAPPER) and the companion
   Swatinem/rust-cache. Expects the SCCACHE_* config to be present in the

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -1,0 +1,48 @@
+name: Setup sccache
+description: >-
+  Configure the sccache S3 compiler cache (RUSTC_WRAPPER) and the companion
+  Swatinem/rust-cache. Expects the SCCACHE_* config to be present in the
+  environment (set at the workflow level) and the AWS credentials the daemon
+  reads to be set by the calling job. The repository must already be checked
+  out, since this is a local action.
+
+runs:
+  using: composite
+  steps:
+    - name: Configure AWS credentials for sccache
+      shell: bash
+      run: |
+        # Materialize whatever credentials the AWS CLI resolves (static env
+        # keys here, or an instance role) so the sccache S3 daemon can read
+        # them — it loads its creds at start time, before the steps below.
+        # Non-fatal and skipped when SCCACHE_BUCKET is empty (fork PRs).
+        if [[ -n "$SCCACHE_BUCKET" ]]; then
+          aws configure export-credentials --format env-no-export >> "$GITHUB_ENV" \
+            || echo "::warning title=sccache::no AWS credentials resolved; compiling without the cache"
+        fi
+
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
+
+    - name: Configure sccache environment
+      shell: bash
+      run: |
+        # Only enable RUSTC_WRAPPER if the S3 backend is actually reachable.
+        # If it isn't — missing perms, bucket outage, or a fork PR with no
+        # creds — compile uncached rather than failing every rustc call.
+        echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
+        sccache --stop-server >/dev/null 2>&1 || true
+        if sccache --start-server; then
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          echo "sccache backend reachable — compiler cache enabled"
+        else
+          echo "::warning title=sccache disabled::sccache server failed to start (cache backend unreachable); compiling without the cache"
+        fi
+
+    - name: Setup cache
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      with:
+        cache-on-failure: true
+        save-if: ${{ github.ref == 'refs/heads/main' }}
+        # sccache owns compilation-artifact caching, so don't also cache target/.
+        cache-targets: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,40 +73,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Configure AWS credentials for sccache
-        run: |
-          # Materialize whatever credentials the AWS CLI resolves (static env
-          # keys here, or an instance role) so the sccache S3 daemon can read
-          # them — it loads its creds at start time, before the steps below.
-          # Non-fatal and skipped when SCCACHE_BUCKET is empty (fork PRs).
-          if [[ -n "$SCCACHE_BUCKET" ]]; then
-            aws configure export-credentials --format env-no-export >> "$GITHUB_ENV" \
-              || echo "::warning title=sccache::no AWS credentials resolved; compiling without the cache"
-          fi
-
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
-
-      - name: Configure sccache environment
-        run: |
-          # Only enable RUSTC_WRAPPER if the S3 backend is actually reachable.
-          # If it isn't — missing perms, bucket outage, or a fork PR with no
-          # creds — compile uncached rather than failing every rustc call.
-          echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
-          sccache --stop-server >/dev/null 2>&1 || true
-          if sccache --start-server; then
-            echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-            echo "sccache backend reachable — compiler cache enabled"
-          else
-            echo "::warning title=sccache disabled::sccache server failed to start (cache backend unreachable); compiling without the cache"
-          fi
-
-      - name: Setup cache
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          cache-on-failure: true
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          cache-targets: false
+        uses: ./.github/actions/setup-sccache
 
       - name: Check clippy
         run: cargo clippy --tests --all-features -- -D warnings
@@ -126,40 +94,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Configure AWS credentials for sccache
-        run: |
-          # Materialize whatever credentials the AWS CLI resolves (static env
-          # keys here, or an instance role) so the sccache S3 daemon can read
-          # them — it loads its creds at start time, before the steps below.
-          # Non-fatal and skipped when SCCACHE_BUCKET is empty (fork PRs).
-          if [[ -n "$SCCACHE_BUCKET" ]]; then
-            aws configure export-credentials --format env-no-export >> "$GITHUB_ENV" \
-              || echo "::warning title=sccache::no AWS credentials resolved; compiling without the cache"
-          fi
-
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
-
-      - name: Configure sccache environment
-        run: |
-          # Only enable RUSTC_WRAPPER if the S3 backend is actually reachable.
-          # If it isn't — missing perms, bucket outage, or a fork PR with no
-          # creds — compile uncached rather than failing every rustc call.
-          echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
-          sccache --stop-server >/dev/null 2>&1 || true
-          if sccache --start-server; then
-            echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-            echo "sccache backend reachable — compiler cache enabled"
-          else
-            echo "::warning title=sccache disabled::sccache server failed to start (cache backend unreachable); compiling without the cache"
-          fi
-
-      - name: Setup cache
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          cache-on-failure: true
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          cache-targets: false
+        uses: ./.github/actions/setup-sccache
 
       - name: Check tests
         run: cargo test
@@ -188,40 +124,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Configure AWS credentials for sccache
-        run: |
-          # Materialize whatever credentials the AWS CLI resolves (static env
-          # keys here, or an instance role) so the sccache S3 daemon can read
-          # them — it loads its creds at start time, before the steps below.
-          # Non-fatal and skipped when SCCACHE_BUCKET is empty (fork PRs).
-          if [[ -n "$SCCACHE_BUCKET" ]]; then
-            aws configure export-credentials --format env-no-export >> "$GITHUB_ENV" \
-              || echo "::warning title=sccache::no AWS credentials resolved; compiling without the cache"
-          fi
-
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
-
-      - name: Configure sccache environment
-        run: |
-          # Only enable RUSTC_WRAPPER if the S3 backend is actually reachable.
-          # If it isn't — missing perms, bucket outage, or a fork PR with no
-          # creds — compile uncached rather than failing every rustc call.
-          echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
-          sccache --stop-server >/dev/null 2>&1 || true
-          if sccache --start-server; then
-            echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-            echo "sccache backend reachable — compiler cache enabled"
-          else
-            echo "::warning title=sccache disabled::sccache server failed to start (cache backend unreachable); compiling without the cache"
-          fi
-
-      - name: Setup cache
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          cache-on-failure: true
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          cache-targets: false
+        uses: ./.github/actions/setup-sccache
 
       - name: Build benchmark
         run: cargo build --release --target ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,24 @@ defaults:
   run:
     shell: bash
 
+# sccache → S3 backend, shared across the compile jobs (clippy, test, build).
+# Set at workflow level so the values are in the environment when the
+# sccache-action daemon starts (it reads its backend config at start time).
+# The AWS credentials the daemon needs are scoped to each compile job instead
+# of here, so they don't override the docker-build job's ECR authentication.
+# Fork PRs have no secrets, so SCCACHE_BUCKET is empty there and sccache
+# transparently falls back to a local cache — builds still succeed, just
+# without the shared cache.
+env:
+  SCCACHE_BUCKET: ${{ secrets.AWS_S3_SCCACHE_BUCKET_NAME }}
+  SCCACHE_REGION: us-east-1
+  SCCACHE_S3_KEY_PREFIX: ${{ github.repository }} # scope cache to this repo
+  SCCACHE_IDLE_TIMEOUT: "0" # don't let the daemon exit mid-compile
+
 jobs:
   format:
     name: Check format
-    runs-on: [runner-amd64-large]
+    runs-on: [runner-amd-16-cores-spot]
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
@@ -45,7 +59,10 @@ jobs:
 
   clippy:
     name: Check clippy
-    runs-on: [runner-amd64-large]
+    runs-on: [runner-amd-16-cores-spot]
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AMAZON_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AMAZON_SECRET_KEY }}
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
@@ -56,18 +73,50 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Configure AWS credentials for sccache
+        run: |
+          # Materialize whatever credentials the AWS CLI resolves (static env
+          # keys here, or an instance role) so the sccache S3 daemon can read
+          # them — it loads its creds at start time, before the steps below.
+          # Non-fatal and skipped when SCCACHE_BUCKET is empty (fork PRs).
+          if [[ -n "$SCCACHE_BUCKET" ]]; then
+            aws configure export-credentials --format env-no-export >> "$GITHUB_ENV" \
+              || echo "::warning title=sccache::no AWS credentials resolved; compiling without the cache"
+          fi
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
+
+      - name: Configure sccache environment
+        run: |
+          # Only enable RUSTC_WRAPPER if the S3 backend is actually reachable.
+          # If it isn't — missing perms, bucket outage, or a fork PR with no
+          # creds — compile uncached rather than failing every rustc call.
+          echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
+          sccache --stop-server >/dev/null 2>&1 || true
+          if sccache --start-server; then
+            echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+            echo "sccache backend reachable — compiler cache enabled"
+          else
+            echo "::warning title=sccache disabled::sccache server failed to start (cache backend unreachable); compiling without the cache"
+          fi
+
       - name: Setup cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-targets: false
 
       - name: Check clippy
         run: cargo clippy --tests --all-features -- -D warnings
 
   test:
     name: Check tests
-    runs-on: [runner-amd64-large]
+    runs-on: [runner-amd-16-cores-spot]
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AMAZON_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AMAZON_SECRET_KEY }}
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
@@ -77,11 +126,40 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Configure AWS credentials for sccache
+        run: |
+          # Materialize whatever credentials the AWS CLI resolves (static env
+          # keys here, or an instance role) so the sccache S3 daemon can read
+          # them — it loads its creds at start time, before the steps below.
+          # Non-fatal and skipped when SCCACHE_BUCKET is empty (fork PRs).
+          if [[ -n "$SCCACHE_BUCKET" ]]; then
+            aws configure export-credentials --format env-no-export >> "$GITHUB_ENV" \
+              || echo "::warning title=sccache::no AWS credentials resolved; compiling without the cache"
+          fi
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
+
+      - name: Configure sccache environment
+        run: |
+          # Only enable RUSTC_WRAPPER if the S3 backend is actually reachable.
+          # If it isn't — missing perms, bucket outage, or a fork PR with no
+          # creds — compile uncached rather than failing every rustc call.
+          echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
+          sccache --stop-server >/dev/null 2>&1 || true
+          if sccache --start-server; then
+            echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+            echo "sccache backend reachable — compiler cache enabled"
+          else
+            echo "::warning title=sccache disabled::sccache server failed to start (cache backend unreachable); compiling without the cache"
+          fi
+
       - name: Setup cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-targets: false
 
       - name: Check tests
         run: cargo test
@@ -92,12 +170,15 @@ jobs:
       matrix:
         include:
           - name: amd64
-            runner: runner-amd64-large
+            runner: runner-amd-32-cores-spot
             target: x86_64-unknown-linux-gnu
           - name: arm64
-            runner: runner-arm64-large
+            runner: runner-arm-32-cores-spot
             target: aarch64-unknown-linux-gnu
     runs-on: ${{ matrix.runner }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AMAZON_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AMAZON_SECRET_KEY }}
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
@@ -107,11 +188,40 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Configure AWS credentials for sccache
+        run: |
+          # Materialize whatever credentials the AWS CLI resolves (static env
+          # keys here, or an instance role) so the sccache S3 daemon can read
+          # them — it loads its creds at start time, before the steps below.
+          # Non-fatal and skipped when SCCACHE_BUCKET is empty (fork PRs).
+          if [[ -n "$SCCACHE_BUCKET" ]]; then
+            aws configure export-credentials --format env-no-export >> "$GITHUB_ENV" \
+              || echo "::warning title=sccache::no AWS credentials resolved; compiling without the cache"
+          fi
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
+
+      - name: Configure sccache environment
+        run: |
+          # Only enable RUSTC_WRAPPER if the S3 backend is actually reachable.
+          # If it isn't — missing perms, bucket outage, or a fork PR with no
+          # creds — compile uncached rather than failing every rustc call.
+          echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
+          sccache --stop-server >/dev/null 2>&1 || true
+          if sccache --start-server; then
+            echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+            echo "sccache backend reachable — compiler cache enabled"
+          else
+            echo "::warning title=sccache disabled::sccache server failed to start (cache backend unreachable); compiling without the cache"
+          fi
+
       - name: Setup cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-targets: false
 
       - name: Build benchmark
         run: cargo build --release --target ${{ matrix.target }}
@@ -124,7 +234,7 @@ jobs:
 
   docker-build:
     name: Build Docker image
-    runs-on: [runner-amd64-large-private]
+    runs-on: [runner-arm-4-cores-spot-private]
     needs: build
     steps:
       - name: Checkout sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ env:
 jobs:
   format:
     name: Check format
-    runs-on: [runner-amd-16-cores-spot]
+    runs-on: [runner-arm-4-cores-spot]
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
@@ -59,7 +59,7 @@ jobs:
 
   clippy:
     name: Check clippy
-    runs-on: [runner-amd-16-cores-spot]
+    runs-on: [runner-arm-16-cores-spot]
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AMAZON_ACCESS_KEY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AMAZON_SECRET_KEY }}
@@ -113,7 +113,7 @@ jobs:
 
   test:
     name: Check tests
-    runs-on: [runner-amd-16-cores-spot]
+    runs-on: [runner-arm-16-cores-spot]
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AMAZON_ACCESS_KEY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AMAZON_SECRET_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ defaults:
 # sccache → S3 backend, shared across the compile jobs (clippy, test, build).
 # Set at workflow level so the values are in the environment when the
 # sccache-action daemon starts (it reads its backend config at start time).
-# The AWS credentials the daemon needs are scoped to each compile job instead
-# of here, so they don't override the docker-build job's ECR authentication.
 # Fork PRs have no secrets, so SCCACHE_BUCKET is empty there and sccache
 # transparently falls back to a local cache — builds still succeed, just
 # without the shared cache.
@@ -33,6 +31,8 @@ env:
   SCCACHE_REGION: us-east-1
   SCCACHE_S3_KEY_PREFIX: ${{ github.repository }} # scope cache to this repo
   SCCACHE_IDLE_TIMEOUT: "0" # don't let the daemon exit mid-compile
+  AWS_ACCESS_KEY_ID: ${{ secrets.AMAZON_ACCESS_KEY }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AMAZON_SECRET_KEY }}
 
 jobs:
   format:
@@ -60,9 +60,6 @@ jobs:
   clippy:
     name: Check clippy
     runs-on: [runner-arm-16-cores-spot]
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AMAZON_ACCESS_KEY }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AMAZON_SECRET_KEY }}
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
@@ -114,9 +111,6 @@ jobs:
   test:
     name: Check tests
     runs-on: [runner-arm-16-cores-spot]
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AMAZON_ACCESS_KEY }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AMAZON_SECRET_KEY }}
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
@@ -176,9 +170,6 @@ jobs:
             runner: runner-arm-32-cores-spot
             target: aarch64-unknown-linux-gnu
     runs-on: ${{ matrix.runner }}
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AMAZON_ACCESS_KEY }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AMAZON_SECRET_KEY }}
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Setup sccache
-        uses: ./.github/actions/setup-sccache
+      - name: Setup cache
+        uses: ./.github/actions/setup-cache
 
       - name: Check clippy
         run: cargo clippy --tests --all-features -- -D warnings
@@ -94,8 +94,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Setup sccache
-        uses: ./.github/actions/setup-sccache
+      - name: Setup cache
+        uses: ./.github/actions/setup-cache
 
       - name: Check tests
         run: cargo test
@@ -124,8 +124,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Setup sccache
-        uses: ./.github/actions/setup-sccache
+      - name: Setup cache
+        uses: ./.github/actions/setup-cache
 
       - name: Build benchmark
         run: cargo build --release --target ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ defaults:
 # sccache → S3 backend, shared across the compile jobs (clippy, test, build).
 # Set at workflow level so the values are in the environment when the
 # sccache-action daemon starts (it reads its backend config at start time).
+# The AWS credentials the daemon needs are scoped to each compile job instead
+# of here, so they don't override the docker-build job's ECR authentication.
 # Fork PRs have no secrets, so SCCACHE_BUCKET is empty there and sccache
 # transparently falls back to a local cache — builds still succeed, just
 # without the shared cache.
@@ -31,8 +33,6 @@ env:
   SCCACHE_REGION: us-east-1
   SCCACHE_S3_KEY_PREFIX: ${{ github.repository }} # scope cache to this repo
   SCCACHE_IDLE_TIMEOUT: "0" # don't let the daemon exit mid-compile
-  AWS_ACCESS_KEY_ID: ${{ secrets.AMAZON_ACCESS_KEY }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AMAZON_SECRET_KEY }}
 
 jobs:
   format:
@@ -60,6 +60,9 @@ jobs:
   clippy:
     name: Check clippy
     runs-on: [runner-arm-16-cores-spot]
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AMAZON_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AMAZON_SECRET_KEY }}
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
@@ -111,6 +114,9 @@ jobs:
   test:
     name: Check tests
     runs-on: [runner-arm-16-cores-spot]
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AMAZON_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AMAZON_SECRET_KEY }}
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
@@ -170,6 +176,9 @@ jobs:
             runner: runner-arm-32-cores-spot
             target: aarch64-unknown-linux-gnu
     runs-on: ${{ matrix.runner }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AMAZON_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AMAZON_SECRET_KEY }}
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable


### PR DESCRIPTION
## What does this change do?

Moves CI off the old `runner-*-large` labels onto the org's spot runner pools, and adds an sccache S3 compiler cache to the compiling jobs.

### Runner remapping

| Job(s) | Before | After |
|---|---|---|
| `format` | `runner-amd64-large` | `runner-arm-4-cores-spot` |
| `clippy` | `runner-amd64-large` | `runner-arm-16-cores-spot` |
| `test` | `runner-amd64-large` | `runner-arm-16-cores-spot` |
| `build` (amd64 leg) | `runner-amd64-large` | `runner-amd-32-cores-spot` |
| `build` (arm64 leg) | `runner-arm64-large` | `runner-arm-32-cores-spot` |
| `docker-build` (multi-arch push) | `runner-amd64-large-private` | `runner-arm-4-cores-spot-private` |

`benchmark` stays on `ubuntu-latest`.

### sccache

Mirrors [surrealdb-private#378](https://github.com/surrealdb/surrealdb-private/pull/378). Added to the three compiling jobs (`clippy`, `test`, `build`):

- The sccache + `rust-cache` setup lives in a local composite action, `.github/actions/setup-cache`, that each compile job calls via `uses: ./.github/actions/setup-cache` (following the `.github/actions` layout in surrealdb-private).
- Pinned `mozilla-actions/sccache-action@v0.0.10` with an S3 backend (`SCCACHE_BUCKET` + region/prefix set at workflow level).
- `RUSTC_WRAPPER=sccache` is only enabled if the backend actually starts — otherwise the job warns and compiles uncached, so fork PRs without secrets still pass.
- `CARGO_INCREMENTAL=0` and `cache-targets: false` on `rust-cache`, since sccache now owns compilation-artifact caching.
- `format` gets no sccache (it only runs `cargo fmt --check`, which doesn't compile).

### Deliberate deviation from #378

The AWS credentials (`AMAZON_ACCESS_KEY` / `AMAZON_SECRET_KEY`) are scoped **per compile job**, not at workflow level as in #378. `docker-build` authenticates to a different account's ECR via `aws ecr get-login-password` using the runner's ambient/instance credentials; workflow-level sccache creds would have clobbered that login. The job-level creds are inherited by the composite action's steps.

## Follow-ups before merge

- [ ] Confirm the secrets `AWS_S3_SCCACHE_BUCKET_NAME`, `AMAZON_ACCESS_KEY`, `AMAZON_SECRET_KEY` exist in this repo.
- [ ] Confirm the new spot runner labels are registered/online in the org runner group.
