### PR TITLE
feat: add steady-state backend comparison

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
+name = "TinyUFO"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cc2a7d25b49809b7bf199e443f949c4078ff48a492e8fb4cbc0477bdcf7bc9"
+dependencies = [
+ "ahash 0.8.12",
+ "crossbeam-queue",
+ "crossbeam-skiplist",
+ "flurry",
+]
+
+[[package]]
 name = "addr"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -1240,6 +1253,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,6 +1287,15 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "combine"
@@ -1563,6 +1594,7 @@ dependencies = [
  "heed",
  "http",
  "indicatif",
+ "kv-engine",
  "libmdbx",
  "log",
  "mimalloc",
@@ -2297,6 +2329,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2328,6 +2366,17 @@ dependencies = [
  "rmp-serde",
  "serde",
  "tempfile",
+]
+
+[[package]]
+name = "fail"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5e43d0f78a42ad591453aedb1d7ae631ce7ee445c7643691055a9ed8d3b01c"
+dependencies = [
+ "log",
+ "once_cell",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2496,6 +2545,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "spin 0.9.8",
+]
+
+[[package]]
+name = "flurry"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5efcf77a4da27927d3ab0509dec5b0954bb3bc59da5a1de9e52642ebd4cdf9"
+dependencies = [
+ "ahash 0.8.12",
+ "num_cpus",
+ "parking_lot",
+ "seize 0.3.3",
 ]
 
 [[package]]
@@ -3416,6 +3477,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3855,6 +3925,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595a0399f411a508feb2ec1e970a4a30c249351e30208960d58298de8660b0e5"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3951,10 +4031,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30457d51cb0e68ee18184b30cd9eb8e1602a20837c321f6ea9706b94f1c681c3"
 dependencies = [
  "jiff-static",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3966,6 +4048,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -4086,6 +4183,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee7893dab2e44ae5f9d0173f26ff4aa327c10b01b06a72b52dd9405b628640d"
 dependencies = [
  "indexmap 2.14.0",
+]
+
+[[package]]
+name = "kv-engine"
+version = "0.1.0"
+dependencies = [
+ "TinyUFO",
+ "ahash 0.8.12",
+ "anyhow",
+ "arc-swap",
+ "bytes",
+ "clap",
+ "crc32fast",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-skiplist",
+ "dashmap 6.2.1",
+ "fail",
+ "io-uring",
+ "libc",
+ "log",
+ "logforth",
+ "nom",
+ "ouroboros",
+ "parking_lot",
+ "rand 0.8.6",
+ "rustyline",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -4282,9 +4410,97 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "logforth"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "522000d3921e4b089de59204d2d3ca8792cd53f8ce5a54b5ac8b9a6e867259f0"
+dependencies = [
+ "log",
+ "logforth-append-async",
+ "logforth-append-file",
+ "logforth-bridge-log",
+ "logforth-core",
+ "logforth-filter-rustlog",
+ "logforth-layout-json",
+ "logforth-layout-text",
+]
+
+[[package]]
+name = "logforth-append-async"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c2f35f57d9a476b768927b079e364674db9a19d6389f623b69f202376bfb1f"
+dependencies = [
+ "logforth-core",
+ "oneshot",
+]
+
+[[package]]
+name = "logforth-append-file"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80f4ed78a03a30c12285135d98330f0f5d53cb0019bd1ac6d66863dae72d8d52"
+dependencies = [
+ "jiff",
+ "logforth-core",
+]
+
+[[package]]
+name = "logforth-bridge-log"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7224c78547e542572ae4d1f787f96c4395a4c3f24513bf221bd8e49888f610"
+dependencies = [
+ "log",
+ "logforth-core",
+]
+
+[[package]]
+name = "logforth-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "400ba5305e0cb6819efa6c2c503020562eb5b47fd53c91c935be55af1ffd374e"
+dependencies = [
+ "anyhow",
+ "serde",
+]
+
+[[package]]
+name = "logforth-filter-rustlog"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e8431cfa1d3eeca479c363651320a66c7003350528f678b30e8c1474fb0d802"
+dependencies = [
+ "logforth-core",
+]
+
+[[package]]
+name = "logforth-layout-json"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d86a105f8f32151ca1e0a6d4097d478badb02d5715239ba0fa431a188a5d966"
+dependencies = [
+ "jiff",
+ "logforth-core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "logforth-layout-text"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eafe007ac55293d807e8c7f5a23002e2518d32e476e195443cde23e7845416a"
+dependencies = [
+ "colored",
+ "jiff",
+ "logforth-core",
+]
 
 [[package]]
 name = "lru"
@@ -5040,6 +5256,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "noisy_float"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5289,6 +5517,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oneshot"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe21416a02c693fb9f980befcb230ecc70b0b3d1cc4abf88b9675c4c1457f0c"
+
+[[package]]
 name = "openssl"
 version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5417,7 +5651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7"
 dependencies = [
  "equivalent",
- "seize",
+ "seize 0.5.1",
 ]
 
 [[package]]
@@ -5841,7 +6075,7 @@ dependencies = [
  "inferno",
  "libc",
  "log",
- "nix",
+ "nix 0.26.4",
  "once_cell",
  "prost 0.12.6",
  "prost-build",
@@ -7075,6 +7309,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rustyline"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a990b25f351b25139ddc7f21ee3f6f56f86d6846b74ac8fad3a719a287cd4a0"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "clipboard-win",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.31.3",
+ "radix_trie 0.3.0",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+ "utf8parse",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7293,6 +7548,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "seize"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "689224d06523904ebcc9b482c6a3f4f7fb396096645c4cd10c0d2ff7371a34d3"
 
 [[package]]
 name = "seize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4210,6 +4210,7 @@ dependencies = [
  "ouroboros",
  "parking_lot",
  "rand 0.8.6",
+ "rand_chacha 0.3.1",
  "rustyline",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ surrealdb2 = [
 ]
 surrealkv = ["dep:surrealkv"]
 surrealmx = ["dep:surrealmx"]
+toykv = ["dep:toykv"]
 
 [profile.release]
 lto = true
@@ -134,6 +135,7 @@ surrealdb = { version = "3.0.5", default-features = false, optional = true }
 surrealdb2 = { package = "surrealdb", version = "2.6", default-features = false, optional = true }
 surrealkv = { version = "0.21.2", optional = true }
 surrealmx = { version = "0.18.0", optional = true }
+toykv = { path = "../toy-kv-engine/kv-engine", package = "kv-engine", optional = true }
 sysinfo = { version = "0.37.2", features = ["serde"] }
 tokio = { version = "1.52.3", features = ["macros", "time", "rt-multi-thread"] }
 toml = "0.8"

--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ cargo run -r -- --help
 
 Open [`compare/index.html`](compare/index.html) locally (drag and drop benchmark JSON artefacts). Rows and labels match CLI/CSV ordering from [`src/result.rs`](src/result.rs). Nothing is uploaded; ApexCharts loads from jsDelivr (works offline only if that script is cached or vendored beside the HTML file).
 
+If you only want the Fjall vs ToyKV comparison path, build without default features and enable just those two backends:
+
+```bash
+cargo run --no-default-features --features fjall,toykv -- -d fjall -s 100000 -c 12 -t 24 -r
+```
+
+That compare build does not need `sqlite` or `rocksdb`.
+
 Workload shape (document template, scan cases, and batch throughput tests) is defined in a single TOML file. Use
 `--config <PATH>` or the environment variable `CRUD_BENCH_CONFIG` (default: `config/bench.toml`).
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,23 @@ For more detailed help information run the following command:
 cargo run -r -- --help
 ```
 
+### Performance gates
+
+Use `perf-gate` to compare generated CSV artifacts before accepting a
+performance-sensitive storage change:
+
+```bash
+cargo run --release --bin perf-gate -- \
+  --baseline-sync baseline-sync.csv \
+  --current-sync current-sync.csv \
+  --baseline-nosync baseline-nosync.csv \
+  --current-nosync current-nosync.csv \
+  --fjall-sync fjall-sync.csv
+```
+
+Add `--baseline-latency-sync` and `--current-latency-sync` with single-client
+sync CSVs to enforce the p95/p99 latency gate.
+
 ### Comparing `result*.json` files in the browser
 
 Open [`compare/index.html`](compare/index.html) locally (drag and drop benchmark JSON artefacts). Rows and labels match CLI/CSV ordering from [`src/result.rs`](src/result.rs). Nothing is uploaded; ApexCharts loads from jsDelivr (works offline only if that script is cached or vendored beside the HTML file).

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ and lists those which are planned in the future.
 
 **Workloads**
 
-- [ ] Workload support for creating, updating, and reading records concurrently
+- [x] Steady-state workload support for concurrent reads, updates, range scans, and sustained ingest
 
 ## Requirements
 
@@ -123,7 +123,7 @@ cargo run -r -- -h
 Usage: crud-bench [OPTIONS] --database <DATABASE> --samples <SAMPLES>
 
 Options:
-  -n, --name <NAME>                            An optional name for the test, used as a suffix for the JSON result file name
+  -n, --name <NAME>                            An optional name for result artifacts (`result-<name>.json`, `result-<name>.csv`, `result-<name>.html`, and steady-state sidecar CSV when applicable)
   -d, --database <DATABASE>                    The database to benchmark [possible values: dry, map, arangodb, dragonfly, fjall, keydb, mdbx, lmdb, mariadb, mongodb, mysql, neo4j, postgres, redb, redis, rocksdb, scylladb, slatedb, sqlite, surrealdb, surrealkv, surrealmx, surrealds]
   -i, --image <IMAGE>                          Specify a custom Docker image
   -p, --privileged                             Whether to run Docker in privileged mode
@@ -149,8 +149,27 @@ Options:
       --skip-batches                           Skip all batch benchmarks
       --skip-indexes                           Skip index operations, but still table scan queries
       --emit-phase-markers                     Emit line-oriented phase markers (`… starting`, `Benchmark starting`) for log-based tooling (e.g. `dev.sh` perf windows). Off by default; also on when `CRUD_BENCH_EMIT_PHASE_MARKERS` is `1`, `true`, `yes`, or `on`
+      --suite <SUITE>                          Benchmark suite to run [default: crud] [possible values: crud, steady-state]
+      --bench <BENCH>                          Comma-separated steady-state workload names
+      --preset <PRESET>                        Steady-state scale preset [default: default] [possible values: smoke, default, large]
+      --warmup-secs <WARMUP_SECS>              Override steady-state warmup duration in seconds
+      --measurement-secs <MEASUREMENT_SECS>    Override steady-state measurement duration in seconds
+      --latency-sample-every <N>               Record one steady-state latency sample every N completed operations
+      --seed <SEED>                            Steady-state deterministic key-selection seed
+      --zipfian-exponent <ZIPFIAN_EXPONENT>    Steady-state Zipfian exponent
+      --operation-mix <OPERATION_MIX>          Custom steady-state operation mix, for example `read=50,update=50`
+      --operation-mix-period <N>               Custom operation mix period
   -h, --help                                   Print help (see more with '--help')
   ```
+
+Steady-state runs write the normal JSON, CSV, and HTML artifacts. They also
+write `result-<name>-steady-state.csv` (or `result-steady-state.csv`) with row
+status, unsupported/failure reasons, validation counts, latency sample counts,
+drain state, and workload metadata. Use the JSON artifact as the `perf-gate`
+source for steady-state comparisons. Select rows with `--bench`; available
+steady-state rows are `balanced_zipfian`, `read_heavy_zipfian`,
+`update_heavy_zipfian`, `point_read_zipfian`, `range_scan_uniform`, and
+`sustained_ingest`. Omitting `--bench` runs all six default steady-state rows.
 
 For more detailed help information run the following command:
 
@@ -174,6 +193,23 @@ cargo run --release --bin perf-gate -- \
 
 Add `--baseline-latency-sync` and `--current-latency-sync` with single-client
 sync CSVs to enforce the p95/p99 latency gate.
+
+Use steady-state JSON artifacts for steady-state gates:
+
+```bash
+cargo run --release --bin perf-gate -- \
+  --baseline-steady-state-json baseline-steady-state.json \
+  --current-steady-state-json current-steady-state.json \
+  --steady-state-row balanced_zipfian \
+  --steady-state-row point_read_zipfian \
+  --optional-steady-state-row range_scan_uniform
+```
+
+Omit `--steady-state-row` to gate the default steady-state rows:
+`balanced_zipfian`, `read_heavy_zipfian`, `update_heavy_zipfian`,
+`point_read_zipfian`, `range_scan_uniform`, and `sustained_ingest`. Optional
+steady-state rows are also evaluated, but `unsupported` is allowed for them
+when both artifacts are otherwise comparable.
 
 ### Comparing `result*.json` files in the browser
 

--- a/docs/rfcs/001-steady-state-backend-comparison.md
+++ b/docs/rfcs/001-steady-state-backend-comparison.md
@@ -77,6 +77,8 @@ The MVP should implement these rows first:
 | Row | Operation mix | Key selection | Dataset | Purpose |
 |---|---:|---|---|---|
 | `balanced_zipfian` | 50% read, 50% update | scrambled Zipfian, exponent 0.99 | prepared | Primary mixed read/write gate |
+| `read_heavy_zipfian` | 95% read, 5% update | scrambled Zipfian, exponent 0.99 | prepared | Cache-heavy churn |
+| `update_heavy_zipfian` | 5% read, 95% update | scrambled Zipfian, exponent 0.99 | prepared | Write-heavy churn |
 | `point_read_zipfian` | 100% read | scrambled Zipfian, exponent 0.99 | prepared | Hot-key read throughput and latency |
 | `range_scan_uniform` | 100% scan | uniform positional start | prepared | Bounded scan throughput and count validation |
 | `sustained_ingest` | 100% create | unique sequential | fresh empty | Steady durable write path |
@@ -85,8 +87,6 @@ Later rows:
 
 | Row | Operation mix | Purpose |
 |---|---:|---|
-| `read_heavy_zipfian` | 95% read, 5% update | Cache-heavy churn |
-| `update_heavy_zipfian` | 5% read, 95% update | Write-heavy churn |
 | `point_read_missing_in_range` | 100% missing read | Negative lookup behavior |
 | `transaction_contention` | parameterized | Serializable transaction contention, only after the adapter API supports it |
 
@@ -274,7 +274,7 @@ Required JSON fields:
 }
 ```
 
-Required legacy CSV mapping:
+Required legacy CSV mapping for completed rows:
 
 ```text
 Test = [T]steady-state::<row>
@@ -284,24 +284,32 @@ OPS = throughput.ops_per_sec
 99th = latency.p99_ms
 ```
 
+Unsupported and failed steady-state rows must use the legacy CSV skip marker
+columns, even when the JSON row keeps diagnostic measurement data.
+
 Optional sidecar CSV columns:
 
 ```text
-suite,row,database,status,unsupported_reason,sync,completed_operations,
-validation_errors,drain_elapsed_ms,drain_timed_out,operation_mix,key_selection
+suite,row,database,status,unsupported_reason,failure_reason,sync,
+completed_operations,validation_errors,latency_sample_count,
+latency_sample_every,drain_elapsed_ms,drain_timed_out,operation_mix,
+key_selection
 ```
 
-Steady-state gate tools must read JSON or a required sidecar artifact for
-validation, drain, and unsupported-row state. The legacy CSV is retained for
-existing throughput and latency consumers only; it is not sufficient by itself
-to decide a steady-state gate.
+Steady-state gate tools must read the JSON artifact for throughput, latency,
+validation, drain, and unsupported-row state. The sidecar CSV is a diagnostic
+artifact for status dashboards and quick inspection; it intentionally does not
+replace JSON for gate decisions. The legacy CSV is retained for existing
+throughput and latency consumers only; it is not sufficient by itself to decide
+a steady-state gate.
 
 Allowed row statuses are `completed`, `unsupported`, and `failed`.
 Unsupported rows must set `status = "unsupported"` and a non-empty
 `unsupported_reason`. For unsupported rows, throughput, latency, validation,
 and drain fields may be absent or null, and gate tools must treat the row as
 skipped only when the gate marks that row optional. Failed rows must not be
-converted to unsupported rows.
+converted to unsupported rows. `failure_reason` is optional for completed and
+unsupported JSON rows, and required for failed rows.
 
 Gate tools must reject rows with:
 
@@ -382,12 +390,14 @@ first 1234 scheduled slots, not a rounded 617/617 split.
 
 ## 12. Gates
 
-The first ToyKV vs RocksDB gate should compare:
+The current default ToyKV vs RocksDB steady-state gate compares:
 
 1. `balanced_zipfian`;
-2. `point_read_zipfian`;
-3. `range_scan_uniform`;
-4. `sustained_ingest`.
+2. `read_heavy_zipfian`;
+3. `update_heavy_zipfian`;
+4. `point_read_zipfian`;
+5. `range_scan_uniform`;
+6. `sustained_ingest`.
 
 Acceptance for a ToyKV storage-engine performance PR:
 
@@ -434,15 +444,16 @@ the accepted benchmark priority.
 ### Phase 4: Comparison And Gate Tooling
 
 1. Run ToyKV and RocksDB smoke rows.
-2. Add `perf-gate` support for steady-state JSON or required sidecar rows.
-   Keep legacy CSV parsing for existing OPS/p95/p99 comparisons only.
+2. Add `perf-gate` support for steady-state JSON rows. Keep legacy CSV parsing
+   for existing OPS/p95/p99 comparisons only.
 3. Document the ToyKV vs RocksDB command shape.
-4. Add the resulting artifact names to the ToyKV benchmark report.
+4. Defer publishing resulting artifact names in the ToyKV benchmark report to
+   the first ToyKV-side report update that consumes these crud-bench artifacts.
 
 ### Phase 5: Follow-Up Rows
 
-1. Add `read_heavy_zipfian`.
-2. Add `update_heavy_zipfian`.
+1. Add `read_heavy_zipfian`. Done in this implementation.
+2. Add `update_heavy_zipfian`. Done in this implementation.
 3. Add `point_read_missing_in_range`.
 4. Add `transaction_contention` after the adapter API supports serializable
    transaction configuration.

--- a/docs/rfcs/001-steady-state-backend-comparison.md
+++ b/docs/rfcs/001-steady-state-backend-comparison.md
@@ -1,0 +1,498 @@
+# RFC 001: Steady-State Backend Comparison
+
+**Status:** Draft
+**Date:** 2026-08-25
+**Author:** crud-bench contributors
+
+## 1. Summary
+
+Add a steady-state comparison suite to `crud-bench` for embedded backends such
+as ToyKV, RocksDB, Fjall, Redb, and SurrealKV.
+
+The suite complements the existing fixed-count CRUD rows with time-windowed
+workloads that run against a prepared dataset, measure throughput and p95/p99
+latency, and validate that each backend actually executed the configured
+operation mix.
+
+The first target is a ToyKV vs RocksDB gate under the same adapter semantics
+already used by existing `crud-bench` rows. That means the comparison measures
+the configured adapters as they are today, including any backend-specific
+transaction wrapper or durability behavior. ToyKV currently wins or ties the
+existing durable CRUD rows, so the next comparison should answer a harder
+question: does ToyKV remain competitive under hot-key read/update churn,
+bounded scans, sustained ingest, and warm cache pressure after setup cost has
+been removed from the measured window?
+
+## 2. Motivation
+
+The current `crud-bench` rows are useful for broad backend comparison:
+
+1. create, read, update, and delete phases;
+2. batch create/read/update/delete rows;
+3. scan rows from `config/bench.toml`;
+4. CSV/JSON/HTML artifacts that downstream reports and gates already consume.
+
+Those rows are intentionally short and phase-oriented. They are weaker for
+storage-engine work where the important behavior happens after the database is
+already loaded:
+
+1. hot-key read/update churn;
+2. p95/p99 latency under concurrent writers;
+3. cache behavior after warmup;
+4. flush and compaction interference during a measurement window;
+5. durable write behavior after setup has been excluded;
+6. correctness validation for mixed workloads.
+
+ToyKV already has an in-repository `write-perf --suite steady-state` contract
+covering these shapes. `crud-bench` should adopt the same benchmark semantics
+for cross-backend comparison because it owns the backend adapters and the
+comparison artifact schema.
+
+## 3. Goals
+
+1. Add steady-state workloads to `crud-bench` without changing existing CRUD
+   row names or result semantics.
+2. Support a prepared dataset lifecycle shared by all participating backends.
+3. Measure warmup, measurement, and drain as distinct phases.
+4. Emit throughput windows plus p50/p95/p99 operation latency.
+5. Validate operation mix, completed operation count, read hit/miss
+   expectations, and scan result counts.
+6. Keep result artifacts parseable by existing comparison tooling.
+7. Make `balanced_zipfian` the primary ToyKV vs RocksDB watch row.
+8. Keep long steady-state runs out of normal CI.
+
+## 4. Non-Goals
+
+1. Replacing the existing fixed-count CRUD, batch, scan, filter, or index rows.
+2. Replacing ToyKV's `write-perf` harness.
+3. Adding a production-grade statistical framework in the first slice.
+4. Requiring every backend to support every steady-state workload.
+5. Automatically failing CI on performance regressions.
+6. Adding engine-specific optimization in this RFC.
+
+## 5. Workloads
+
+The MVP should implement these rows first:
+
+| Row | Operation mix | Key selection | Dataset | Purpose |
+|---|---:|---|---|---|
+| `balanced_zipfian` | 50% read, 50% update | scrambled Zipfian, exponent 0.99 | prepared | Primary mixed read/write gate |
+| `point_read_zipfian` | 100% read | scrambled Zipfian, exponent 0.99 | prepared | Hot-key read throughput and latency |
+| `range_scan_uniform` | 100% scan | uniform positional start | prepared | Bounded scan throughput and count validation |
+| `sustained_ingest` | 100% create | unique sequential | fresh empty | Steady durable write path |
+
+Later rows:
+
+| Row | Operation mix | Purpose |
+|---|---:|---|
+| `read_heavy_zipfian` | 95% read, 5% update | Cache-heavy churn |
+| `update_heavy_zipfian` | 5% read, 95% update | Write-heavy churn |
+| `point_read_missing_in_range` | 100% missing read | Negative lookup behavior |
+| `transaction_contention` | parameterized | Serializable transaction contention, only after the adapter API supports it |
+
+Backends that cannot support a row should report the row as skipped with a
+structured unsupported reason, not as a benchmark failure.
+
+The canonical operation names for steady-state rows are `create`, `read`,
+`update`, and `scan`. Adapter methods such as `read_*` and `update_*` map to
+those names directly. CLI `--operation-mix`, JSON `task.operation_mix`, and
+`validation.observed_mix` must use only canonical names.
+
+## 6. Dataset Contract
+
+Steady-state rows use a prepared logical keyspace:
+
+```text
+records:       preset-controlled
+key type:      integer for MVP
+value shape:   existing [value] TOML template
+durability:    follows --sync
+load phase:    excluded from timed measurement
+warmup phase:  included in setup metadata, excluded from result OPS
+```
+
+The first slice should use `crud-bench`'s existing value providers and adapter
+methods so all embedded backends keep the same datastore surface. It still
+needs a new steady-state key-selection layer above the existing `KeyProvider`:
+the current providers can generate ordered or Feistel-scrambled keys, but they
+do not express Zipfian sampling, the Zipfian exponent, per-run seeds, or the
+recorded sampler contract. The runner must expose `--seed <u64>` with default
+`1`, serialize the effective seed in every steady-state row, and derive worker
+streams as `splitmix64(seed ^ worker_index)`. ToyKV and RocksDB rows in the
+same comparison must use the same effective seed. A later compatibility slice
+may add ToyKV-compatible fixed-width byte keys if cross-harness parity with
+`write-perf` requires it.
+
+Prepared datasets must be backend-local and disposable. The runner may create a
+fresh database per backend, bulk-load it, quiesce, and then run one or more
+steady-state rows against that prepared state. Copying or checkpointing a
+prepared database is optional and backend-specific.
+
+Each measured row must start from a defined dataset state:
+
+1. prepared rows use a freshly loaded or freshly cloned dataset containing keys
+   `0..records`;
+2. mixed update rows update only keys inside `0..records`;
+3. `sustained_ingest` starts from a fresh empty dataset and creates unique keys
+   from `0` upward for the duration of the measured window;
+4. if multiple rows run in one invocation, the runner must reset, reload, or
+   clone the required starting state before each row unless a row explicitly
+   opts into reuse.
+
+## 7. Timing Model
+
+Each steady-state row has these phases:
+
+1. `prepare`: create or open the prepared dataset.
+2. `warmup`: run the configured workload without recording result OPS.
+3. `measure`: run closed-loop workers until `measurement_secs` expires.
+4. `drain`: stop workers, wait for requested backend durability or background
+   drain hooks, and record elapsed drain time.
+5. `cleanup`: remove temporary backend state unless persistence was requested.
+
+The measured row duration is time-based, not fixed-count. Workers run
+closed-loop: each worker starts the next operation only after the previous
+operation returns. This keeps latency meaningful and avoids hiding backend
+queueing behind an unbounded client-side backlog.
+
+When `measurement_secs` expires in the middle of an operation-mix period,
+workers finish only the in-flight operation and stop before starting another.
+The measurement window may therefore contain a prefix of the deterministic
+period rather than an exact number of whole periods. Operation-mix validation
+must compare observed counts against the deterministic prefix implied by the
+actual completed operation count, not against a full-period ratio.
+
+## 8. CLI
+
+Add a new suite selector while preserving the current default behavior:
+
+```bash
+cargo run --release --bin crud-bench -- \
+  --suite steady-state \
+  --database <toykv|rocksdb|fjall|redb|surrealkv> \
+  --bench balanced_zipfian \
+  --samples 1000000 \
+  --clients 4 \
+  --threads 4 \
+  --sync \
+  --warmup-secs 30 \
+  --measurement-secs 120 \
+  --latency-sample-every 100 \
+  --color never
+```
+
+New options:
+
+```text
+--suite <crud|steady-state>        default: crud
+--bench <name[,name...]>           steady-state workload selection
+--preset <smoke|default|large>     steady-state scale preset
+--warmup-secs <n>
+--measurement-secs <n>
+--latency-sample-every <n>
+--seed <u64>                         default: 1
+--zipfian-exponent <f>             default: 0.99
+--operation-mix <spec>             e.g. read=0.5,update=0.5
+--operation-mix-period <n>         default: 1000
+```
+
+Preset defaults:
+
+| Preset | Records | Clients | Warmup | Measurement | Latency sample every |
+|---|---:|---:|---:|---:|---:|
+| `smoke` | 10,000 | 1 | 0s | 1s | 1 |
+| `default` | 1,000,000 | CLI/default clients | 30s | 120s | 100 |
+| `large` | CLI-controlled | CLI/default clients | 60s | 300s | 100 |
+
+Explicit CLI values override preset values.
+
+## 9. Result Schema
+
+Existing CSV/JSON rows stay unchanged for the current CRUD suite. Steady-state
+rows add structured fields to the JSON artifact. CSV output must preserve the
+existing `result.rs` header contract (`Test`, `Total time`, `Mean`, `Max`,
+`99th`, `95th`, `OPS`, and the other current columns) so `perf-gate` and
+existing compare tools can continue to parse `Test`, `OPS`, `99th`, and `95th`.
+Any extra steady-state fields should be emitted either in JSON only or in a
+separate sidecar CSV, not by replacing the legacy CSV columns.
+
+Required JSON fields:
+
+```json
+{
+  "name": "balanced_zipfian",
+  "suite": "steady-state",
+  "database": "toykv",
+  "status": "completed",
+  "unsupported_reason": null,
+  "sync": true,
+  "task": {
+    "records": 1000000,
+    "clients": 4,
+    "threads": 4,
+    "warmup_secs": 30,
+    "measurement_secs": 120,
+    "latency_sample_every": 100,
+    "seed": 1,
+    "worker_seed_derivation": "splitmix64(seed ^ worker_index)",
+    "operation_mix": "read=0.5,update=0.5",
+    "operation_mix_period": 1000,
+    "key_selection": "scrambled_zipfian",
+    "zipfian_exponent": 0.99
+  },
+  "phases": {
+    "prepare": { "elapsed_ms": 1000.0, "status": "completed" },
+    "warmup": { "elapsed_ms": 30000.0, "status": "completed" },
+    "measure": { "elapsed_ms": 120000.0, "status": "completed" },
+    "drain": { "elapsed_ms": 25.0, "status": "completed" },
+    "cleanup": { "elapsed_ms": 10.0, "status": "completed" }
+  },
+  "throughput": {
+    "completed_operations": 123456,
+    "ops_per_sec": 1028.8,
+    "per_second_windows": [1001.0, 1030.0]
+  },
+  "latency": {
+    "sample_count": 1234,
+    "p50_ms": 0.5,
+    "p95_ms": 2.0,
+    "p99_ms": 5.0
+  },
+  "validation": {
+    "errors": 0,
+    "read_hits": 61728,
+    "read_misses": 0,
+    "updates": 61728,
+    "scan_count_errors": 0,
+    "observed_mix": "read=0.500000,update=0.500000",
+    "expected_mix_prefix": "read=61728,update=61728"
+  },
+  "drain": {
+    "elapsed_ms": 25.0,
+    "timed_out": false
+  }
+}
+```
+
+Required legacy CSV mapping:
+
+```text
+Test = [T]steady-state::<row>
+OPS = throughput.ops_per_sec
+50th = latency.p50_ms
+95th = latency.p95_ms
+99th = latency.p99_ms
+```
+
+Optional sidecar CSV columns:
+
+```text
+suite,row,database,status,unsupported_reason,sync,completed_operations,
+validation_errors,drain_elapsed_ms,drain_timed_out,operation_mix,key_selection
+```
+
+Steady-state gate tools must read JSON or a required sidecar artifact for
+validation, drain, and unsupported-row state. The legacy CSV is retained for
+existing throughput and latency consumers only; it is not sufficient by itself
+to decide a steady-state gate.
+
+Allowed row statuses are `completed`, `unsupported`, and `failed`.
+Unsupported rows must set `status = "unsupported"` and a non-empty
+`unsupported_reason`. For unsupported rows, throughput, latency, validation,
+and drain fields may be absent or null, and gate tools must treat the row as
+skipped only when the gate marks that row optional. Failed rows must not be
+converted to unsupported rows.
+
+Gate tools must reject rows with:
+
+1. `validation.errors > 0`;
+2. zero completed operations;
+3. missing latency samples when latency sampling was requested;
+4. timed-out drain when drain was requested;
+5. unsupported rows unless the gate explicitly marks them optional.
+
+## 10. Adapter API
+
+The first slice can build on the existing `BenchmarkClient` methods:
+
+1. `read_*` for point reads;
+2. `update_*` for updates;
+3. `create_*` for sustained ingest;
+4. existing scan methods for bounded range scans.
+
+The runner should add an internal steady-state execution layer rather than
+forcing the existing phase-oriented benchmark path to handle time-windowed
+workers.
+
+Optional future adapter hooks:
+
+```rust
+async fn prepare_steady_state_dataset(...);
+async fn quiesce_steady_state(...);
+async fn drain_steady_state(...);
+async fn clone_prepared_dataset(...);
+```
+
+Backends without custom hooks use the generic create/read/update/scan path.
+ToyKV can later map clone preparation to its checkpoint API, but that is not
+required for the MVP.
+
+## 11. Validation Rules
+
+`balanced_zipfian`, `read_heavy_zipfian`, and `update_heavy_zipfian` must use a
+deterministic operation-mix scheduler. For a period of 1000:
+
+```text
+balanced_zipfian:     500 read, 500 update
+read_heavy_zipfian:   950 read, 50 update
+update_heavy_zipfian: 50 read, 950 update
+```
+
+The runner must reject mixes that cannot be represented exactly by the selected
+period.
+
+`point_read_zipfian` must validate that every measured read hits.
+
+`point_read_missing_in_range` must validate that every measured read misses,
+once that row is added.
+
+`range_scan_uniform` must validate:
+
+1. expected row count per scan in the MVP, using the existing scan API;
+2. ordered keys when a later adapter API returns scan evidence;
+3. duplicate keys inside one scan result when a later adapter API returns scan
+   evidence.
+
+`sustained_ingest` must validate that completed write count matches the
+reported operation count.
+
+`range_scan_uniform` uses a prepared keyspace with `records` keys and a fixed
+MVP scan width of `100`. For each operation, the selector chooses a positional
+start in `0..=(records - scan_width)`, then creates a `Scan` with
+`start = selected_start`, `limit = scan_width`, and `expect = scan_width`.
+This intentionally matches the current ToyKV and RocksDB adapter behavior,
+where `scan_bytes` and `do_scan` iterate in key order and apply `Scan::start`
+and `Scan::limit` positionally. The MVP must include a cross-adapter test with
+keys `0..255` and identical `Scan` inputs on ToyKV and RocksDB.
+
+For mixed rows, `observed_mix` is valid when it matches the deterministic
+prefix schedule for `completed_operations`. For example, a 50/50 mix with a
+1000-operation period may stop after 1234 operations; validation checks the
+first 1234 scheduled slots, not a rounded 617/617 split.
+
+## 12. Gates
+
+The first ToyKV vs RocksDB gate should compare:
+
+1. `balanced_zipfian`;
+2. `point_read_zipfian`;
+3. `range_scan_uniform`;
+4. `sustained_ingest`.
+
+Acceptance for a ToyKV storage-engine performance PR:
+
+1. no required ToyKV steady-state row regresses by more than 5% OPS versus the
+   previous ToyKV baseline;
+2. p95 and p99 latency do not regress by more than 5% on required rows;
+3. validation errors remain zero;
+4. if RocksDB beats ToyKV by more than 10% on a row, profile that exact row
+   before choosing an engine optimization.
+
+The existing fixed-count CRUD gates remain active. A patch should not trade a
+steady-state win for a durable CRUD regression unless the PR explicitly changes
+the accepted benchmark priority.
+
+## 13. Implementation Plan
+
+### Phase 1: Schema And CLI
+
+1. Add `--suite steady-state` while keeping `crud` as default.
+2. Add steady-state CLI options and preset resolution.
+3. Resolve `--samples` as the steady-state record count for the MVP. A later
+   `--records` alias can be added only if it does not weaken existing CRUD CLI
+   behavior.
+4. Add JSON result fields while preserving the existing CSV columns.
+5. Add parse/schema tests.
+
+### Phase 2: Runner
+
+1. Add the time-windowed closed-loop worker runner.
+2. Add latency sampling and per-second throughput windows.
+3. Add warmup, measurement, drain, and cleanup phase records.
+4. Add a steady-state key-selection layer with seeded scrambled-Zipfian,
+   uniform, and unique-sequential selectors.
+5. Add deterministic operation-mix scheduling.
+
+### Phase 3: MVP Workloads
+
+1. Implement `point_read_zipfian`.
+2. Implement `balanced_zipfian`.
+3. Implement `range_scan_uniform`.
+4. Implement `sustained_ingest`.
+5. Add validation for each row.
+
+### Phase 4: Comparison And Gate Tooling
+
+1. Run ToyKV and RocksDB smoke rows.
+2. Add `perf-gate` support for steady-state JSON or required sidecar rows.
+   Keep legacy CSV parsing for existing OPS/p95/p99 comparisons only.
+3. Document the ToyKV vs RocksDB command shape.
+4. Add the resulting artifact names to the ToyKV benchmark report.
+
+### Phase 5: Follow-Up Rows
+
+1. Add `read_heavy_zipfian`.
+2. Add `update_heavy_zipfian`.
+3. Add `point_read_missing_in_range`.
+4. Add `transaction_contention` after the adapter API supports serializable
+   transaction configuration.
+
+## 14. Open Questions
+
+1. Should generic prepared datasets be rebuilt per row, or reused across rows
+   in one benchmark invocation?
+2. Should latency samples be exact by default for short smoke rows and sampled
+   by default for long rows?
+3. Should ToyKV checkpoint cloning become a generic adapter hook, or stay an
+   engine-specific optimization?
+4. Should a future scan-evidence API return keys for ordered/duplicate
+   validation, or should deeper scan correctness stay in backend-specific tests?
+
+## 15. First Acceptance Target
+
+The first useful PR does not need to make ToyKV faster. It should make this
+command produce valid, comparable ToyKV and RocksDB artifacts:
+
+```bash
+cargo run --release --bin crud-bench -- \
+  --name steady_state_smoke_toykv_balanced_zipfian \
+  --suite steady-state \
+  --preset smoke \
+  --bench balanced_zipfian \
+  --database toykv \
+  --samples 10000 \
+  --seed 1 \
+  --latency-sample-every 1 \
+  --sync \
+  --color never
+
+cargo run --release --bin crud-bench -- \
+  --name steady_state_smoke_rocksdb_balanced_zipfian \
+  --suite steady-state \
+  --preset smoke \
+  --bench balanced_zipfian \
+  --database rocksdb \
+  --samples 10000 \
+  --seed 1 \
+  --latency-sample-every 1 \
+  --sync \
+  --color never
+```
+
+Both rows must have:
+
+1. `validation.errors = 0`;
+2. non-zero completed operations;
+3. p95 and p99 latency values;
+4. a measured throughput window;
+5. clear skip/error behavior for unsupported backends.

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2026-05-28"

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -120,6 +120,10 @@ pub(crate) struct Benchmark {
 	pub(crate) privileged: bool,
 	/// The container image to use
 	pub(crate) image: Option<String>,
+	/// Whether to skip the delete phase
+	pub(crate) skip_deletes: bool,
+	/// Whether to skip all write phases (create, update, delete, batch writes)
+	pub(crate) skip_writes: bool,
 	/// The server endpoint to connect to
 	pub(crate) endpoint: Option<String>,
 	/// The number of clients to spawn
@@ -163,6 +167,8 @@ impl Benchmark {
 			pid: args.pid,
 			persisted: args.persisted,
 			optimised: args.optimised,
+			skip_deletes: args.skip_deletes,
+			skip_writes: args.skip_writes,
 			operation_timeout: Duration::from_secs(args.operation_timeout),
 			bench_ui: BenchUi::new(args.color),
 			emit_phase_markers,
@@ -235,16 +241,19 @@ impl Benchmark {
 		if self.emit_phase_markers {
 			self.bench_ui.println_plain("Benchmark starting");
 		}
-		// Run the "creates" benchmark
-		let creates = self
-			.run_operation::<C, D>(
+		// Run the "creates" benchmark (skipped if --skip-writes)
+		let creates = if self.skip_writes {
+			None
+		} else {
+			self.run_operation::<C, D>(
 				&clients,
 				BenchmarkOperation::Create,
 				kp,
 				vp.clone(),
 				self.samples,
 			)
-			.await?;
+			.await?
+		};
 		// Compact the datastore
 		self.maybe_compact_datastore::<C, E>(&engine).await?;
 		// Run the "reads" benchmark
@@ -253,16 +262,19 @@ impl Benchmark {
 			.await?;
 		// Compact the datastore
 		self.maybe_compact_datastore::<C, E>(&engine).await?;
-		// Run the "reads" benchmark
-		let updates = self
-			.run_operation::<C, D>(
+		// Run the "updates" benchmark (skipped if --skip-writes)
+		let updates = if self.skip_writes {
+			None
+		} else {
+			self.run_operation::<C, D>(
 				&clients,
 				BenchmarkOperation::Update,
 				kp,
 				vp.clone(),
 				self.samples,
 			)
-			.await?;
+			.await?
+		};
 		// Compact the datastore
 		self.maybe_compact_datastore::<C, E>(&engine).await?;
 		// Run the "scan" benchmarks
@@ -442,8 +454,10 @@ impl Benchmark {
 				});
 				// Optional mixed read+write legs on the heap path (one per `with_writes` entry)
 				for spec in write_specs {
-					let mixed_without_index = self
-						.run_operation::<C, D>(
+					let mixed_without_index = if self.skip_writes {
+						None
+					} else {
+						self.run_operation::<C, D>(
 							&clients,
 							BenchmarkOperation::ScanWithWrites(
 								scan.clone(),
@@ -454,7 +468,8 @@ impl Benchmark {
 							vp.clone(),
 							iterations,
 						)
-						.await?;
+						.await?
+					};
 					runs.push(ScanRun {
 						workload: ScanWorkload::ReadWrite {
 							write_ratio_percent: writes_ratio_percent(spec),
@@ -492,7 +507,9 @@ impl Benchmark {
 						.await?;
 					let mut iw = Vec::with_capacity(w);
 					for spec in write_specs {
-						iw.push(
+						let result = if self.skip_writes {
+							None
+						} else {
 							self.run_operation::<C, D>(
 								&clients,
 								BenchmarkOperation::ScanWithWrites(
@@ -504,8 +521,9 @@ impl Benchmark {
 								vp.clone(),
 								iterations,
 							)
-							.await?,
-						);
+							.await?
+						};
+						iw.push(result);
 					}
 					let index_remove = self
 						.run_operation::<C, D>(
@@ -579,8 +597,10 @@ impl Benchmark {
 					result: without_index,
 				});
 				for spec in write_specs {
-					let mixed_without_index = self
-						.run_operation::<C, D>(
+					let mixed_without_index = if self.skip_writes {
+						None
+					} else {
+						self.run_operation::<C, D>(
 							&clients,
 							BenchmarkOperation::ScanWithWrites(
 								scan.clone(),
@@ -591,7 +611,8 @@ impl Benchmark {
 							vp.clone(),
 							iterations,
 						)
-						.await?;
+						.await?
+					};
 					runs.push(ScanRun {
 						workload: ScanWorkload::ReadWrite {
 							write_ratio_percent: writes_ratio_percent(spec),
@@ -613,17 +634,21 @@ impl Benchmark {
 		}
 		// Compact the datastore
 		self.maybe_compact_datastore::<C, E>(&engine).await?;
-		self.bench_ui.section_header("Delete");
-		// Run the "deletes" benchmark
-		let deletes = self
-			.run_operation::<C, D>(
+		// Run the "deletes" benchmark (skipped if --skip-deletes or --skip-writes)
+		let deletes = if self.skip_deletes || self.skip_writes {
+			self.bench_ui.section_header("Delete (skipped)");
+			None
+		} else {
+			self.bench_ui.section_header("Delete");
+			self.run_operation::<C, D>(
 				&clients,
 				BenchmarkOperation::Delete,
 				kp,
 				vp.clone(),
 				self.samples,
 			)
-			.await?;
+			.await?
+		};
 		// Compact the datastore
 		self.maybe_compact_datastore::<C, E>(&engine).await?;
 		if !batches.is_empty() {
@@ -636,6 +661,17 @@ impl Benchmark {
 			let name = batch.name.clone();
 			let groups = batch.batch_size;
 			let iterations = batch.iterations.map(|s| s as u32).unwrap_or(self.samples);
+			let skip_batch = ((self.skip_deletes || self.skip_writes)
+				&& matches!(batch.operation, crate::BatchOperationType::Delete))
+				|| (self.skip_writes
+					&& matches!(
+						batch.operation,
+						crate::BatchOperationType::Create | crate::BatchOperationType::Update
+					));
+			if skip_batch {
+				batch_results.push((name, iterations, groups, None));
+				continue;
+			}
 			// Determine the batch operation type
 			let operation = match batch.operation {
 				crate::BatchOperationType::Create => BenchmarkOperation::BatchCreate(batch.clone()),

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -8,7 +8,9 @@ use crate::engine::{BenchmarkClient, BenchmarkEngine, ScanContext};
 use crate::keyprovider::KeyProvider;
 use crate::result::{
 	BenchmarkMetadata, BenchmarkResult, OperationMetric, OperationResult, ScanResult, ScanRun,
-	ScanWorkload, writes_ratio_percent,
+	ScanWorkload, SteadyStateDrain, SteadyStateLatency, SteadyStatePhase, SteadyStatePhases,
+	SteadyStateResult, SteadyStateStatus, SteadyStateTask, SteadyStateThroughput,
+	SteadyStateValidation, writes_ratio_percent,
 };
 use crate::system::SystemInfo;
 use crate::terminal::BenchUi;
@@ -18,8 +20,8 @@ use crate::valueprovider::ColumnType;
 use crate::valueprovider::ValueProvider;
 use crate::workloads;
 use crate::{
-	Args, BatchOperation, Batches, Index, Scan, ScanWithWrites, Scans, VectorHoldout,
-	VectorIndexStrategy, VectorQuerySpec,
+	Args, BatchOperation, Batches, Index, Scan, ScanWithWrites, Scans, SteadyStatePreset, Suite,
+	VectorHoldout, VectorIndexStrategy, VectorQuerySpec,
 };
 
 use anyhow::{Context, Result, bail};
@@ -32,11 +34,22 @@ use tokio::time::Instant;
 
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::time::{Duration, SystemTime};
 
 /// Maximum wait when polling until the first datastore client connects.
 const TIMEOUT: Duration = Duration::from_secs(60);
+const DEFAULT_STEADY_STATE_WORKLOADS: &[SteadyStateWorkload] = &[
+	SteadyStateWorkload::BalancedZipfian,
+	SteadyStateWorkload::ReadHeavyZipfian,
+	SteadyStateWorkload::UpdateHeavyZipfian,
+	SteadyStateWorkload::PointReadZipfian,
+	SteadyStateWorkload::PointReadMissingInRange,
+	SteadyStateWorkload::RangeScanUniform,
+	SteadyStateWorkload::SustainedIngest,
+];
+const MAX_OPERATION_MIX_PERIOD: u32 = 100_000;
 
 /// Fixed sleep between phases to let any server-side phase tail settle
 /// (open snapshots, draining tasks) before the next phase opens its
@@ -146,6 +159,16 @@ pub(crate) struct Benchmark {
 	pub(crate) bench_ui: BenchUi,
 	/// Grep-friendly `… starting` / `Benchmark starting` lines for profiling scripts
 	pub(crate) emit_phase_markers: bool,
+	pub(crate) suite: Suite,
+	pub(crate) steady_state_benches: Option<String>,
+	pub(crate) steady_state_preset: SteadyStatePreset,
+	pub(crate) warmup_secs: Option<u64>,
+	pub(crate) measurement_secs: Option<u64>,
+	pub(crate) latency_sample_every: Option<u64>,
+	pub(crate) seed: u64,
+	pub(crate) zipfian_exponent: f64,
+	pub(crate) operation_mix: Option<String>,
+	pub(crate) operation_mix_period: u32,
 }
 
 impl Benchmark {
@@ -172,6 +195,16 @@ impl Benchmark {
 			operation_timeout: Duration::from_secs(args.operation_timeout),
 			bench_ui: BenchUi::new(args.color),
 			emit_phase_markers,
+			suite: args.suite,
+			steady_state_benches: args.bench.clone(),
+			steady_state_preset: args.preset,
+			warmup_secs: args.warmup_secs,
+			measurement_secs: args.measurement_secs,
+			latency_sample_every: args.latency_sample_every,
+			seed: args.seed,
+			zipfian_exponent: args.zipfian_exponent,
+			operation_mix: args.operation_mix.clone(),
+			operation_mix_period: args.operation_mix_period,
 		}
 	}
 
@@ -240,6 +273,27 @@ impl Benchmark {
 		// Start the benchmark (optional line for log-based profiling)
 		if self.emit_phase_markers {
 			self.bench_ui.println_plain("Benchmark starting");
+		}
+		if self.suite == Suite::SteadyState {
+			let steady_state =
+				self.run_steady_state::<C>(&clients, kp, vp.clone(), database.clone()).await?;
+			if self.emit_phase_markers {
+				self.bench_ui.println_plain("Benchmark complete");
+			}
+			self.wait_for_client(&engine).await?.shutdown().await?;
+			return Ok(BenchmarkResult {
+				database,
+				system,
+				metadata,
+				creates: None,
+				reads: None,
+				updates: None,
+				scans: Vec::new(),
+				steady_state,
+				batches: Vec::new(),
+				deletes: None,
+				sample,
+			});
 		}
 		// Run the "creates" benchmark (skipped if --skip-writes)
 		let creates = if self.skip_writes {
@@ -700,10 +754,493 @@ impl Benchmark {
 			reads,
 			updates,
 			scans: scan_results,
+			steady_state: Vec::new(),
 			batches: batch_results,
 			deletes,
 			sample,
 		})
+	}
+
+	async fn run_steady_state<C>(
+		&self,
+		clients: &[Arc<C>],
+		kp: KeyProvider,
+		vp: ValueProvider,
+		database: Option<String>,
+	) -> Result<Vec<SteadyStateResult>>
+	where
+		C: BenchmarkClient + Send + Sync,
+	{
+		let config = SteadyStateConfig::from_benchmark(self)?;
+		let workloads = config.workloads()?;
+		let mut results = Vec::with_capacity(workloads.len());
+		for workload in workloads {
+			self.bench_ui.section_header(&format!("Steady-state · {}", workload.name()));
+			if let Err(e) = self
+				.reset_steady_state_row::<C>(clients, kp, &config, workload, config.records as u64)
+				.await
+			{
+				let row = if e.to_string().eq(NOT_SUPPORTED_ERROR) {
+					unsupported_steady_state_row(self, database.clone(), &config, workload, e)
+				} else {
+					failed_steady_state_row(self, database.clone(), &config, workload, e)
+				};
+				results.push(row);
+				continue;
+			}
+			let row = match self
+				.run_steady_state_row::<C>(
+					clients,
+					kp,
+					vp.clone(),
+					database.clone(),
+					&config,
+					workload,
+				)
+				.await
+			{
+				Ok(row) => row,
+				Err(e) if e.to_string().eq(NOT_SUPPORTED_ERROR) => {
+					if let Err(reset_error) = self
+						.reset_steady_state_row::<C>(
+							clients,
+							kp,
+							&config,
+							workload,
+							config.records as u64,
+						)
+						.await
+					{
+						eprintln!(
+							"steady-state error cleanup for {} failed: {reset_error:#}",
+							workload.name()
+						);
+					}
+					unsupported_steady_state_row(self, database.clone(), &config, workload, e)
+				}
+				Err(e) => {
+					if let Err(reset_error) = self
+						.reset_steady_state_row::<C>(
+							clients,
+							kp,
+							&config,
+							workload,
+							config.records as u64,
+						)
+						.await
+					{
+						eprintln!(
+							"steady-state error cleanup for {} failed: {reset_error:#}",
+							workload.name()
+						);
+					}
+					failed_steady_state_row(self, database.clone(), &config, workload, e)
+				}
+			};
+			results.push(row);
+		}
+		Ok(results)
+	}
+
+	async fn run_steady_state_row<C>(
+		&self,
+		clients: &[Arc<C>],
+		kp: KeyProvider,
+		vp: ValueProvider,
+		database: Option<String>,
+		config: &SteadyStateConfig,
+		workload: SteadyStateWorkload,
+	) -> Result<SteadyStateResult>
+	where
+		C: BenchmarkClient + Send + Sync,
+	{
+		let prepare_start = Instant::now();
+		if workload.requires_prepared_dataset() {
+			self.load_steady_state_dataset(clients, kp, vp.clone(), config.records).await?;
+		}
+		let prepare = completed_phase(prepare_start.elapsed());
+		let mut next_op_index = 0;
+
+		let warmup_start = Instant::now();
+		if config.warmup > Duration::ZERO {
+			let warmup = self
+				.run_steady_state_window::<C>(
+					clients,
+					kp,
+					vp.clone(),
+					config,
+					workload,
+					config.warmup,
+					false,
+					next_op_index,
+				)
+				.await?;
+			next_op_index += warmup.completed;
+			if let Some(reason) = warmup.failure_reason {
+				self.reset_steady_state_row(clients, kp, config, workload, warmup.cleanup_upper)
+					.await?;
+				bail!(reason);
+			}
+		}
+		let warmup = completed_phase(warmup_start.elapsed());
+
+		let measure_start = Instant::now();
+		let measurement = self
+			.run_steady_state_window::<C>(
+				clients,
+				kp,
+				vp,
+				config,
+				workload,
+				config.measurement,
+				true,
+				next_op_index,
+			)
+			.await?;
+		let measure = completed_phase(measure_start.elapsed());
+		let measurement_failure = measurement.failure_reason.clone();
+
+		let drain_start = Instant::now();
+		self.quiesce_and_mark().await;
+		let drain_elapsed = drain_start.elapsed();
+		let cleanup_start = Instant::now();
+		let cleanup_result = self
+			.reset_steady_state_row(clients, kp, config, workload, measurement.cleanup_upper)
+			.await;
+		let cleanup_elapsed = cleanup_start.elapsed();
+
+		let observed_mix = measurement.observed_mix();
+		let result = measurement.result;
+		let throughput = result.as_ref().map(|r| SteadyStateThroughput {
+			completed_operations: measurement.completed,
+			ops_per_sec: r.ops(),
+			per_second_windows: measurement
+				.per_second_windows
+				.iter()
+				.map(|count| *count as f64)
+				.collect(),
+		});
+		let latency = result.as_ref().map(|r| SteadyStateLatency {
+			sample_count: measurement.latency_samples,
+			p50_ms: r.q50() as f64 / 1000.0,
+			p95_ms: r.q95() as f64 / 1000.0,
+			p99_ms: r.q99() as f64 / 1000.0,
+		});
+		let validation = Some(SteadyStateValidation {
+			errors: measurement.errors,
+			read_hits: measurement.read_hits,
+			read_misses: measurement.read_misses,
+			updates: measurement.updates,
+			scan_count_errors: measurement.scan_count_errors,
+			observed_mix,
+			expected_mix_prefix: workload.expected_mix_prefix(config, measurement.completed),
+		});
+		let measurement_unsupported = measurement_failure.as_deref() == Some(NOT_SUPPORTED_ERROR);
+		let mut status = if measurement_unsupported {
+			SteadyStateStatus::Unsupported
+		} else if measurement_failure.is_some() {
+			SteadyStateStatus::Failed
+		} else {
+			SteadyStateStatus::Completed
+		};
+		let mut unsupported_reason =
+			measurement_unsupported.then(|| NOT_SUPPORTED_ERROR.to_string());
+		let mut failure_reason =
+			(!measurement_unsupported).then_some(measurement_failure).flatten();
+		let cleanup_status = match cleanup_result {
+			Ok(()) => SteadyStateStatus::Completed,
+			Err(e) => {
+				status = SteadyStateStatus::Failed;
+				let cleanup_failure = format!("cleanup failed: {e:#}");
+				failure_reason = Some(match failure_reason.or(unsupported_reason.take()) {
+					Some(reason) => format!("{reason}; {cleanup_failure}"),
+					None => cleanup_failure,
+				});
+				SteadyStateStatus::Failed
+			}
+		};
+		let cleanup = SteadyStatePhase {
+			elapsed_ms: cleanup_elapsed.as_secs_f64() * 1000.0,
+			status: cleanup_status,
+		};
+
+		Ok(SteadyStateResult {
+			name: workload.name().to_string(),
+			suite: "steady-state",
+			database,
+			status,
+			unsupported_reason,
+			failure_reason,
+			sync: self.sync,
+			task: workload.task(self, config),
+			phases: SteadyStatePhases {
+				prepare,
+				warmup,
+				measure,
+				drain: completed_phase(drain_elapsed),
+				cleanup,
+			},
+			throughput,
+			latency,
+			validation,
+			drain: Some(SteadyStateDrain {
+				elapsed_ms: drain_elapsed.as_secs_f64() * 1000.0,
+				timed_out: false,
+			}),
+			operation_result: result,
+		})
+	}
+
+	async fn load_steady_state_dataset<C>(
+		&self,
+		clients: &[Arc<C>],
+		kp: KeyProvider,
+		vp: ValueProvider,
+		records: u32,
+	) -> Result<()>
+	where
+		C: BenchmarkClient + Send + Sync,
+	{
+		let current = Arc::new(AtomicU32::new(0));
+		let mut tasks = JoinSet::new();
+		for client in clients {
+			for _ in 0..self.threads {
+				let client = client.clone();
+				let current = current.clone();
+				let mut kp = kp;
+				let mut vp = vp.clone();
+				tasks.spawn(async move {
+					loop {
+						let key = current.fetch_add(1, Ordering::Relaxed);
+						if key >= records {
+							break;
+						}
+						let value = vp.generate_value();
+						client.create(key, value, &mut kp).await?;
+					}
+					Ok::<_, anyhow::Error>(())
+				});
+			}
+		}
+		while let Some(result) = tasks.join_next().await {
+			result??;
+		}
+		Ok(())
+	}
+
+	#[allow(clippy::too_many_arguments)]
+	async fn run_steady_state_window<C>(
+		&self,
+		clients: &[Arc<C>],
+		kp: KeyProvider,
+		vp: ValueProvider,
+		config: &SteadyStateConfig,
+		workload: SteadyStateWorkload,
+		duration: Duration,
+		record: bool,
+		start_op_index: u64,
+	) -> Result<SteadyStateMeasurement>
+	where
+		C: BenchmarkClient + Send + Sync,
+	{
+		let window_start = Instant::now();
+		let deadline = window_start + duration;
+		let sequence = Arc::new(AtomicU64::new(0));
+		let completed = Arc::new(AtomicU64::new(0));
+		let read_hits = Arc::new(AtomicU64::new(0));
+		let read_misses = Arc::new(AtomicU64::new(0));
+		let updates = Arc::new(AtomicU64::new(0));
+		let creates = Arc::new(AtomicU64::new(0));
+		let cleanup_upper = Arc::new(AtomicU64::new(start_op_index));
+		let scans = Arc::new(AtomicU64::new(0));
+		let latency_samples = Arc::new(AtomicU64::new(0));
+		let errors = Arc::new(AtomicU64::new(0));
+		let scan_count_errors = Arc::new(AtomicU64::new(0));
+		let failure_reason = Arc::new(Mutex::new(None::<String>));
+		let windows = Arc::new(Mutex::new(Vec::<u64>::new()));
+		let metric = record.then(|| OperationMetric::new(self.pid, 0));
+		let mut tasks = JoinSet::new();
+		for (client_index, client) in clients.iter().cloned().enumerate() {
+			for thread_index in 0..self.threads {
+				let worker_index = client_index as u64 * self.threads as u64 + thread_index as u64;
+				let client = client.clone();
+				let sequence = sequence.clone();
+				let completed = completed.clone();
+				let read_hits = read_hits.clone();
+				let read_misses = read_misses.clone();
+				let updates = updates.clone();
+				let creates = creates.clone();
+				let cleanup_upper = cleanup_upper.clone();
+				let scans = scans.clone();
+				let latency_samples = latency_samples.clone();
+				let errors = errors.clone();
+				let scan_count_errors = scan_count_errors.clone();
+				let failure_reason = failure_reason.clone();
+				let windows = windows.clone();
+				let mut kp = kp;
+				let mut vp = vp.clone();
+				let config = config.clone();
+				let mut selector = KeySelector::new(&config, workload, worker_index);
+				let operation_timeout = self.operation_timeout;
+				tasks.spawn(async move {
+					let mut histogram = Histogram::new(3)?;
+					while Instant::now() < deadline {
+						let op_index = sequence.fetch_add(1, Ordering::Relaxed);
+						let op = workload.operation_at(&config, op_index);
+						let time = Instant::now();
+						let op_result = tokio::time::timeout(operation_timeout, async {
+							match op {
+								SteadyStateOperation::Create => {
+									let key_index = start_op_index
+										.checked_add(op_index)
+										.context("sustained_ingest exceeded u64 key space")?;
+									let key = u32::try_from(key_index)
+										.context("sustained_ingest exceeded u32 key space")?;
+									cleanup_upper.fetch_max(key_index + 1, Ordering::Relaxed);
+									let value = vp.generate_value();
+									client.create(key, value, &mut kp).await?;
+									creates.fetch_add(1, Ordering::Relaxed);
+									Ok(())
+								}
+								SteadyStateOperation::Read => {
+									if workload.expects_missing_reads() {
+										let key = selector.next_missing_key()?;
+										match client.read(key, &mut kp).await {
+											Ok(_) => {
+												read_hits.fetch_add(1, Ordering::Relaxed);
+												Err(anyhow::anyhow!(
+													"steady-state {} expected missing key {key}",
+													workload.name()
+												))
+											}
+											Err(_) => {
+												read_misses.fetch_add(1, Ordering::Relaxed);
+												Ok(())
+											}
+										}
+									} else {
+										let key = selector.next_key();
+										match client.read(key, &mut kp).await {
+											Ok(_) => {
+												read_hits.fetch_add(1, Ordering::Relaxed);
+												Ok(())
+											}
+											Err(e) => {
+												read_misses.fetch_add(1, Ordering::Relaxed);
+												Err(e)
+											}
+										}
+									}
+								}
+								SteadyStateOperation::Update => {
+									let key = selector.next_key();
+									let value = vp.generate_value();
+									client.update(key, value, &mut kp).await?;
+									updates.fetch_add(1, Ordering::Relaxed);
+									Ok(())
+								}
+								SteadyStateOperation::Scan => {
+									let scan = selector.next_scan();
+									client.scan(&scan, &kp, ScanContext::WithoutIndex).await?;
+									scans.fetch_add(1, Ordering::Relaxed);
+									Ok(())
+								}
+							}
+						})
+						.await;
+						let op_result = match op_result {
+							Ok(result) => result,
+							Err(_) => {
+								Err(anyhow::anyhow!("steady-state {} timed out", workload.name()))
+							}
+						};
+						if let Err(e) = op_result {
+							errors.fetch_add(1, Ordering::Relaxed);
+							if matches!(op, SteadyStateOperation::Scan) {
+								scan_count_errors.fetch_add(1, Ordering::Relaxed);
+							}
+							if let Ok(mut failure_reason) = failure_reason.lock()
+								&& failure_reason.is_none()
+							{
+								*failure_reason = Some(e.to_string());
+							}
+							break;
+						}
+						let done = completed.fetch_add(1, Ordering::Relaxed) + 1;
+						if record && op_index.is_multiple_of(config.latency_sample_every) {
+							if let Err(e) = histogram.record(time.elapsed().as_micros() as u64) {
+								errors.fetch_add(1, Ordering::Relaxed);
+								if let Ok(mut failure_reason) = failure_reason.lock()
+									&& failure_reason.is_none()
+								{
+									*failure_reason = Some(e.to_string());
+								}
+								break;
+							}
+							latency_samples.fetch_add(1, Ordering::Relaxed);
+						}
+						if record {
+							let bucket = time.duration_since(window_start).as_secs() as usize;
+							if let Ok(mut windows) = windows.lock() {
+								if windows.len() <= bucket {
+									windows.resize(bucket + 1, 0);
+								}
+								windows[bucket] += 1;
+							}
+						}
+						let _ = done;
+					}
+					Ok::<_, anyhow::Error>(histogram)
+				});
+			}
+		}
+		let mut global_histogram = Histogram::new(3)?;
+		while let Some(result) = tasks.join_next().await {
+			global_histogram.add(result??)?;
+		}
+		let completed = completed.load(Ordering::Relaxed);
+		let result = metric.map(|mut metric| {
+			metric.set_samples(completed);
+			OperationResult::new(metric, global_histogram)
+		});
+		Ok(SteadyStateMeasurement {
+			completed,
+			read_hits: read_hits.load(Ordering::Relaxed),
+			read_misses: read_misses.load(Ordering::Relaxed),
+			updates: updates.load(Ordering::Relaxed),
+			creates: creates.load(Ordering::Relaxed),
+			scans: scans.load(Ordering::Relaxed),
+			errors: errors.load(Ordering::Relaxed),
+			scan_count_errors: scan_count_errors.load(Ordering::Relaxed),
+			latency_samples: latency_samples.load(Ordering::Relaxed),
+			cleanup_upper: cleanup_upper.load(Ordering::Relaxed),
+			failure_reason: failure_reason.lock().ok().and_then(|reason| reason.clone()),
+			per_second_windows: windows.lock().map(|w| w.clone()).unwrap_or_default(),
+			result,
+		})
+	}
+
+	async fn reset_steady_state_row<C>(
+		&self,
+		clients: &[Arc<C>],
+		kp: KeyProvider,
+		config: &SteadyStateConfig,
+		workload: SteadyStateWorkload,
+		completed_operations: u64,
+	) -> Result<()>
+	where
+		C: BenchmarkClient + Send + Sync,
+	{
+		let upper = match workload {
+			SteadyStateWorkload::SustainedIngest => u32::try_from(completed_operations)
+				.context("sustained_ingest cleanup exceeded u32 key space")?,
+			_ => config.records,
+		};
+		if upper == 0 {
+			return Ok(());
+		}
+		let mut kp = kp;
+		clients[0].reset_steady_state(upper, &mut kp).await
 	}
 
 	/// Build the held-out [`VectorQuerySet`] for a vector-search scan.
@@ -850,7 +1387,7 @@ impl Benchmark {
 		// Store the worker tasks in a join set so failures can stop the operation promptly.
 		let mut tasks = JoinSet::new();
 		// Measure the starting time
-		let metric = OperationMetric::new(self.pid, samples);
+		let metric = OperationMetric::new(self.pid, samples as u64);
 		// Loop over the clients
 		for (client, _) in clients.iter().cloned().zip(1..) {
 			// Loop over the threads
@@ -1072,6 +1609,889 @@ impl Benchmark {
 			histogram.record(time.elapsed().as_micros() as u64)?;
 		}
 		Ok(histogram)
+	}
+}
+
+#[derive(Clone)]
+struct SteadyStateConfig {
+	records: u32,
+	warmup: Duration,
+	measurement: Duration,
+	latency_sample_every: u64,
+	seed: u64,
+	zipfian_exponent: f64,
+	bench_spec: Option<String>,
+	operation_mix: Option<String>,
+	operation_schedule: Option<Vec<SteadyStateOperation>>,
+	operation_mix_period: u32,
+}
+
+impl SteadyStateConfig {
+	fn from_benchmark(benchmark: &Benchmark) -> Result<Self> {
+		if benchmark.operation_mix_period == 0 {
+			bail!("--operation-mix-period must be greater than 0");
+		}
+		if benchmark.operation_mix.is_some()
+			&& benchmark.operation_mix_period > MAX_OPERATION_MIX_PERIOD
+		{
+			bail!(
+				"--operation-mix-period cannot exceed {MAX_OPERATION_MIX_PERIOD} when --operation-mix is set"
+			);
+		}
+		let (records, warmup, measurement, latency_sample_every) =
+			match benchmark.steady_state_preset {
+				SteadyStatePreset::Smoke => (benchmark.samples, 0, 1, 1),
+				SteadyStatePreset::Default => (benchmark.samples, 30, 120, 100),
+				SteadyStatePreset::Large => (benchmark.samples, 60, 300, 100),
+			};
+		let operation_schedule = benchmark
+			.operation_mix
+			.as_deref()
+			.map(|spec| parse_operation_mix(spec, benchmark.operation_mix_period))
+			.transpose()?;
+		Ok(Self {
+			records,
+			warmup: Duration::from_secs(benchmark.warmup_secs.unwrap_or(warmup)),
+			measurement: Duration::from_secs(benchmark.measurement_secs.unwrap_or(measurement)),
+			latency_sample_every: benchmark
+				.latency_sample_every
+				.unwrap_or(latency_sample_every)
+				.max(1),
+			seed: benchmark.seed,
+			zipfian_exponent: benchmark.zipfian_exponent,
+			bench_spec: benchmark.steady_state_benches.clone(),
+			operation_mix: benchmark.operation_mix.clone(),
+			operation_schedule,
+			operation_mix_period: benchmark.operation_mix_period,
+		})
+	}
+
+	fn workloads(&self) -> Result<Vec<SteadyStateWorkload>> {
+		let Some(spec) = self.bench_spec.as_deref() else {
+			return Ok(DEFAULT_STEADY_STATE_WORKLOADS.to_vec());
+		};
+		let workloads: Vec<_> = spec
+			.split(',')
+			.map(str::trim)
+			.filter(|name| !name.is_empty())
+			.map(SteadyStateWorkload::from_name)
+			.collect::<Result<_>>()?;
+		if self.operation_schedule.is_none()
+			&& workloads.contains(&SteadyStateWorkload::BalancedZipfian)
+			&& !self.operation_mix_period.is_multiple_of(2)
+		{
+			bail!(
+				"balanced_zipfian requires an even --operation-mix-period for exact read=0.5,update=0.5"
+			);
+		}
+		if self.operation_schedule.is_none()
+			&& workloads.iter().any(|workload| {
+				matches!(
+					workload,
+					SteadyStateWorkload::ReadHeavyZipfian | SteadyStateWorkload::UpdateHeavyZipfian
+				)
+			}) && !self.operation_mix_period.is_multiple_of(20)
+		{
+			bail!(
+				"read_heavy_zipfian and update_heavy_zipfian require --operation-mix-period to be a multiple of 20 for exact 95/5 mixes"
+			);
+		}
+		if self
+			.operation_schedule
+			.as_ref()
+			.is_some_and(|schedule| schedule.contains(&SteadyStateOperation::Create))
+			&& workloads.iter().any(|workload| *workload != SteadyStateWorkload::SustainedIngest)
+		{
+			bail!(
+				"custom steady-state operation mixes may include create only for sustained_ingest"
+			);
+		}
+		if let Some(schedule) = &self.operation_schedule {
+			for workload in &workloads {
+				workload.validate_operation_schedule(schedule)?;
+			}
+		}
+		Ok(workloads)
+	}
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SteadyStateWorkload {
+	BalancedZipfian,
+	ReadHeavyZipfian,
+	UpdateHeavyZipfian,
+	PointReadZipfian,
+	PointReadMissingInRange,
+	RangeScanUniform,
+	SustainedIngest,
+}
+
+impl SteadyStateWorkload {
+	fn name(self) -> &'static str {
+		match self {
+			Self::BalancedZipfian => "balanced_zipfian",
+			Self::ReadHeavyZipfian => "read_heavy_zipfian",
+			Self::UpdateHeavyZipfian => "update_heavy_zipfian",
+			Self::PointReadZipfian => "point_read_zipfian",
+			Self::PointReadMissingInRange => "point_read_missing_in_range",
+			Self::RangeScanUniform => "range_scan_uniform",
+			Self::SustainedIngest => "sustained_ingest",
+		}
+	}
+
+	fn from_name(name: &str) -> Result<Self> {
+		match name {
+			"balanced_zipfian" => Ok(Self::BalancedZipfian),
+			"read_heavy_zipfian" => Ok(Self::ReadHeavyZipfian),
+			"update_heavy_zipfian" => Ok(Self::UpdateHeavyZipfian),
+			"point_read_zipfian" => Ok(Self::PointReadZipfian),
+			"point_read_missing_in_range" => Ok(Self::PointReadMissingInRange),
+			"range_scan_uniform" => Ok(Self::RangeScanUniform),
+			"sustained_ingest" => Ok(Self::SustainedIngest),
+			other => bail!("unsupported steady-state workload `{other}`"),
+		}
+	}
+
+	fn requires_prepared_dataset(self) -> bool {
+		!matches!(self, Self::SustainedIngest)
+	}
+
+	fn operation_at(self, config: &SteadyStateConfig, op_index: u64) -> SteadyStateOperation {
+		if let Some(schedule) = &config.operation_schedule {
+			return schedule[(op_index % schedule.len() as u64) as usize];
+		}
+		match self {
+			Self::BalancedZipfian => {
+				let period_slot = op_index % u64::from(config.operation_mix_period);
+				let half = u64::from(config.operation_mix_period / 2);
+				if period_slot < half {
+					SteadyStateOperation::Read
+				} else {
+					SteadyStateOperation::Update
+				}
+			}
+			Self::ReadHeavyZipfian => {
+				let period_slot = op_index % u64::from(config.operation_mix_period);
+				let read_slots = u64::from(config.operation_mix_period) * 19 / 20;
+				if period_slot < read_slots {
+					SteadyStateOperation::Read
+				} else {
+					SteadyStateOperation::Update
+				}
+			}
+			Self::UpdateHeavyZipfian => {
+				let period_slot = op_index % u64::from(config.operation_mix_period);
+				let read_slots = u64::from(config.operation_mix_period / 20);
+				if period_slot < read_slots {
+					SteadyStateOperation::Read
+				} else {
+					SteadyStateOperation::Update
+				}
+			}
+			Self::PointReadZipfian => SteadyStateOperation::Read,
+			Self::PointReadMissingInRange => SteadyStateOperation::Read,
+			Self::RangeScanUniform => SteadyStateOperation::Scan,
+			Self::SustainedIngest => SteadyStateOperation::Create,
+		}
+	}
+
+	fn operation_mix(self, config: &SteadyStateConfig) -> String {
+		if let Some(spec) = &config.operation_mix {
+			return spec.clone();
+		}
+		match self {
+			Self::BalancedZipfian => "read=0.5,update=0.5".to_string(),
+			Self::ReadHeavyZipfian => "read=0.95,update=0.05".to_string(),
+			Self::UpdateHeavyZipfian => "read=0.05,update=0.95".to_string(),
+			Self::PointReadZipfian => "read=1.0".to_string(),
+			Self::PointReadMissingInRange => "read=1.0".to_string(),
+			Self::RangeScanUniform => "scan=1.0".to_string(),
+			Self::SustainedIngest => "create=1.0".to_string(),
+		}
+	}
+
+	fn key_selection(self) -> &'static str {
+		match self {
+			Self::PointReadMissingInRange => "scrambled_zipfian_missing_range",
+			Self::RangeScanUniform => "uniform_positional",
+			Self::SustainedIngest => "unique_sequential",
+			_ => "scrambled_zipfian",
+		}
+	}
+
+	fn validate_operation_schedule(self, schedule: &[SteadyStateOperation]) -> Result<()> {
+		let valid = match self {
+			Self::SustainedIngest => {
+				schedule.iter().all(|op| matches!(op, SteadyStateOperation::Create))
+			}
+			Self::RangeScanUniform => {
+				schedule.iter().all(|op| matches!(op, SteadyStateOperation::Scan))
+			}
+			Self::BalancedZipfian
+			| Self::ReadHeavyZipfian
+			| Self::UpdateHeavyZipfian
+			| Self::PointReadZipfian => schedule
+				.iter()
+				.all(|op| matches!(op, SteadyStateOperation::Read | SteadyStateOperation::Update)),
+			Self::PointReadMissingInRange => {
+				schedule.iter().all(|op| matches!(op, SteadyStateOperation::Read))
+			}
+		};
+		if !valid {
+			bail!(
+				"custom steady-state operation mix is incompatible with {} key-selection contract",
+				self.name()
+			);
+		}
+		Ok(())
+	}
+
+	fn task(self, benchmark: &Benchmark, config: &SteadyStateConfig) -> SteadyStateTask {
+		SteadyStateTask {
+			records: config.records,
+			clients: benchmark.clients,
+			threads: benchmark.threads,
+			warmup_secs: config.warmup.as_secs(),
+			measurement_secs: config.measurement.as_secs(),
+			latency_sample_every: config.latency_sample_every,
+			seed: config.seed,
+			worker_seed_derivation: "splitmix64(seed ^ worker_index)",
+			operation_mix: self.operation_mix(config),
+			operation_mix_period: config.operation_mix_period,
+			key_selection: self.key_selection(),
+			zipfian_exponent: config.zipfian_exponent,
+		}
+	}
+
+	fn expected_mix_prefix(self, config: &SteadyStateConfig, completed: u64) -> String {
+		let mut counts = SteadyStateCounts::default();
+		for idx in 0..completed {
+			counts.add(self.operation_at(config, idx));
+		}
+		counts.to_mix_string()
+	}
+
+	fn expects_missing_reads(self) -> bool {
+		matches!(self, Self::PointReadMissingInRange)
+	}
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SteadyStateOperation {
+	Create,
+	Read,
+	Update,
+	Scan,
+}
+
+#[derive(Default)]
+struct SteadyStateCounts {
+	creates: u64,
+	reads: u64,
+	updates: u64,
+	scans: u64,
+}
+
+impl SteadyStateCounts {
+	fn add(&mut self, op: SteadyStateOperation) {
+		match op {
+			SteadyStateOperation::Create => self.creates += 1,
+			SteadyStateOperation::Read => self.reads += 1,
+			SteadyStateOperation::Update => self.updates += 1,
+			SteadyStateOperation::Scan => self.scans += 1,
+		}
+	}
+
+	fn to_mix_string(&self) -> String {
+		let mut parts = Vec::new();
+		if self.creates > 0 {
+			parts.push(format!("create={}", self.creates));
+		}
+		if self.reads > 0 {
+			parts.push(format!("read={}", self.reads));
+		}
+		if self.updates > 0 {
+			parts.push(format!("update={}", self.updates));
+		}
+		if self.scans > 0 {
+			parts.push(format!("scan={}", self.scans));
+		}
+		parts.join(",")
+	}
+}
+
+#[derive(Default)]
+struct SteadyStateMeasurement {
+	completed: u64,
+	read_hits: u64,
+	read_misses: u64,
+	updates: u64,
+	creates: u64,
+	scans: u64,
+	errors: u64,
+	scan_count_errors: u64,
+	latency_samples: u64,
+	cleanup_upper: u64,
+	failure_reason: Option<String>,
+	per_second_windows: Vec<u64>,
+	result: Option<OperationResult>,
+}
+
+impl SteadyStateMeasurement {
+	fn observed_mix(&self) -> String {
+		SteadyStateCounts {
+			creates: self.creates,
+			reads: self.read_hits + self.read_misses,
+			updates: self.updates,
+			scans: self.scans,
+		}
+		.to_mix_string()
+	}
+}
+
+struct KeySelector {
+	records: u32,
+	scan_width: usize,
+	rng: u64,
+	zipf_cdf: Vec<f64>,
+	scrambled_keys: Vec<u32>,
+}
+
+impl KeySelector {
+	fn new(config: &SteadyStateConfig, workload: SteadyStateWorkload, worker_index: u64) -> Self {
+		let rng = splitmix64(config.seed ^ worker_index);
+		let uses_zipfian = matches!(
+			workload,
+			SteadyStateWorkload::BalancedZipfian
+				| SteadyStateWorkload::ReadHeavyZipfian
+				| SteadyStateWorkload::UpdateHeavyZipfian
+				| SteadyStateWorkload::PointReadZipfian
+				| SteadyStateWorkload::PointReadMissingInRange
+		);
+		let zipf_cdf = if uses_zipfian {
+			build_zipf_cdf(config.records, config.zipfian_exponent)
+		} else {
+			Vec::new()
+		};
+		let scrambled_keys = if uses_zipfian {
+			build_scrambled_keys(config.records, config.seed)
+		} else {
+			Vec::new()
+		};
+		Self {
+			records: config.records,
+			scan_width: 100,
+			rng,
+			zipf_cdf,
+			scrambled_keys,
+		}
+	}
+
+	fn next_key(&mut self) -> u32 {
+		let rank = if self.zipf_cdf.is_empty() {
+			self.uniform_u32(self.records.max(1))
+		} else {
+			let sample = self.uniform_f64();
+			self.zipf_cdf
+				.partition_point(|p| *p < sample)
+				.min(self.zipf_cdf.len().saturating_sub(1)) as u32
+		};
+		if self.scrambled_keys.is_empty() {
+			rank.min(self.records.saturating_sub(1))
+		} else {
+			self.scrambled_keys[rank as usize]
+		}
+	}
+
+	fn next_missing_key(&mut self) -> Result<u32> {
+		self.records
+			.checked_add(self.next_key())
+			.context("missing-read key range exceeded u32 key space")
+	}
+
+	fn next_scan(&mut self) -> Scan {
+		let max_start = self.records.saturating_sub(self.scan_width as u32);
+		let start = self.uniform_u32(max_start.saturating_add(1)) as usize;
+		Scan {
+			id: "range_scan_uniform".to_string(),
+			spec_group: 0,
+			multi_run_spec: false,
+			name: "range_scan_uniform".to_string(),
+			iterations: None,
+			condition: None,
+			order_by: None,
+			start: Some(start),
+			limit: Some(self.scan_width),
+			expect: Some(self.scan_width.min(self.records as usize)),
+			projection: Some("ID".to_string()),
+			with_index: None,
+			with_writes: Vec::new(),
+			vector_query: None,
+		}
+	}
+
+	fn uniform_u32(&mut self, upper: u32) -> u32 {
+		if upper == 0 {
+			return 0;
+		}
+		(self.next_u64() % upper as u64) as u32
+	}
+
+	fn uniform_f64(&mut self) -> f64 {
+		const DENOMINATOR: f64 = u64::MAX as f64;
+		self.next_u64() as f64 / DENOMINATOR
+	}
+
+	fn next_u64(&mut self) -> u64 {
+		self.rng = splitmix64(self.rng);
+		self.rng
+	}
+}
+
+fn build_zipf_cdf(records: u32, exponent: f64) -> Vec<f64> {
+	let records = records.max(1) as usize;
+	let mut weights = Vec::with_capacity(records);
+	let mut total = 0.0;
+	for rank in 1..=records {
+		let weight = 1.0 / (rank as f64).powf(exponent);
+		total += weight;
+		weights.push(total);
+	}
+	for value in &mut weights {
+		*value /= total;
+	}
+	weights
+}
+
+fn build_scrambled_keys(records: u32, seed: u64) -> Vec<u32> {
+	let records = records.max(1);
+	let mut keys: Vec<_> = (0..records).collect();
+	let mut rng = splitmix64(seed ^ 0xD1B5_4A32_D192_ED03);
+	for i in (1..keys.len()).rev() {
+		rng = splitmix64(rng);
+		keys.swap(i, (rng as usize) % (i + 1));
+	}
+	if keys.len() > 1 && keys[0] == 0 {
+		keys.swap(0, 1);
+	}
+	keys
+}
+
+fn splitmix64(mut value: u64) -> u64 {
+	value = value.wrapping_add(0x9E37_79B9_7F4A_7C15);
+	let mut z = value;
+	z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+	z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+	z ^ (z >> 31)
+}
+
+fn parse_operation_mix(spec: &str, period: u32) -> Result<Vec<SteadyStateOperation>> {
+	if period > MAX_OPERATION_MIX_PERIOD {
+		bail!("operation mix period cannot exceed {MAX_OPERATION_MIX_PERIOD}");
+	}
+	let mut total = 0.0;
+	let mut schedule = Vec::new();
+	for part in spec.split(',') {
+		let Some((name, value)) = part.split_once('=') else {
+			bail!("operation mix part `{part}` must use name=value");
+		};
+		let op = match name {
+			"read" => SteadyStateOperation::Read,
+			"update" => SteadyStateOperation::Update,
+			"create" => SteadyStateOperation::Create,
+			"scan" => SteadyStateOperation::Scan,
+			other => bail!("unsupported operation `{other}` in operation mix"),
+		};
+		let ratio = value.parse::<f64>()?;
+		if !ratio.is_finite() || ratio <= 0.0 {
+			bail!("operation mix part `{part}` must be a positive finite ratio");
+		}
+		total += ratio;
+		let count = ratio * period as f64;
+		if (count.round() - count).abs() > 0.000_001 {
+			bail!("operation mix part `{part}` cannot be represented exactly by period {period}");
+		}
+		schedule.extend(std::iter::repeat_n(op, count.round() as usize));
+	}
+	if (total - 1.0).abs() > 0.000_001 {
+		bail!("operation mix must sum to 1.0");
+	}
+	if schedule.len() != period as usize {
+		bail!("operation mix expands to {} slots, expected {period}", schedule.len());
+	}
+	Ok(schedule)
+}
+
+fn completed_phase(elapsed: Duration) -> SteadyStatePhase {
+	SteadyStatePhase {
+		elapsed_ms: elapsed.as_secs_f64() * 1000.0,
+		status: SteadyStateStatus::Completed,
+	}
+}
+
+fn unsupported_steady_state_row(
+	benchmark: &Benchmark,
+	database: Option<String>,
+	config: &SteadyStateConfig,
+	workload: SteadyStateWorkload,
+	error: anyhow::Error,
+) -> SteadyStateResult {
+	let phase = SteadyStatePhase {
+		elapsed_ms: 0.0,
+		status: SteadyStateStatus::Unsupported,
+	};
+	SteadyStateResult {
+		name: workload.name().to_string(),
+		suite: "steady-state",
+		database,
+		status: SteadyStateStatus::Unsupported,
+		unsupported_reason: Some(error.to_string()),
+		failure_reason: None,
+		sync: benchmark.sync,
+		task: workload.task(benchmark, config),
+		phases: SteadyStatePhases {
+			prepare: phase.clone(),
+			warmup: phase.clone(),
+			measure: phase.clone(),
+			drain: phase.clone(),
+			cleanup: phase,
+		},
+		throughput: None,
+		latency: None,
+		validation: None,
+		drain: None,
+		operation_result: None,
+	}
+}
+
+fn failed_steady_state_row(
+	benchmark: &Benchmark,
+	database: Option<String>,
+	config: &SteadyStateConfig,
+	workload: SteadyStateWorkload,
+	error: anyhow::Error,
+) -> SteadyStateResult {
+	let phase = SteadyStatePhase {
+		elapsed_ms: 0.0,
+		status: SteadyStateStatus::Failed,
+	};
+	SteadyStateResult {
+		name: workload.name().to_string(),
+		suite: "steady-state",
+		database,
+		status: SteadyStateStatus::Failed,
+		unsupported_reason: None,
+		failure_reason: Some(error.to_string()),
+		sync: benchmark.sync,
+		task: workload.task(benchmark, config),
+		phases: SteadyStatePhases {
+			prepare: phase.clone(),
+			warmup: phase.clone(),
+			measure: phase.clone(),
+			drain: phase.clone(),
+			cleanup: phase,
+		},
+		throughput: None,
+		latency: None,
+		validation: Some(SteadyStateValidation {
+			errors: 1,
+			read_hits: 0,
+			read_misses: 0,
+			updates: 0,
+			scan_count_errors: 0,
+			observed_mix: String::new(),
+			expected_mix_prefix: workload.expected_mix_prefix(config, 0),
+		}),
+		drain: None,
+		operation_result: None,
+	}
+}
+
+#[cfg(test)]
+mod steady_state_tests {
+	use super::*;
+
+	#[test]
+	fn operation_mix_requires_exact_period() {
+		let err = parse_operation_mix("read=0.333,update=0.667", 100).unwrap_err();
+		assert!(err.to_string().contains("cannot be represented exactly"));
+	}
+
+	#[test]
+	fn operation_mix_builds_canonical_schedule() -> Result<()> {
+		let schedule = parse_operation_mix("read=0.5,update=0.5", 10)?;
+		assert!(matches!(schedule[0], SteadyStateOperation::Read));
+		assert!(matches!(schedule[4], SteadyStateOperation::Read));
+		assert!(matches!(schedule[5], SteadyStateOperation::Update));
+		assert!(matches!(schedule[9], SteadyStateOperation::Update));
+		Ok(())
+	}
+
+	#[test]
+	fn operation_mix_rejects_invalid_ratios() {
+		for spec in ["read=NaN,update=1.0", "read=inf", "read=-1.0,update=2.0", "read=0.0"] {
+			let err = parse_operation_mix(spec, 10).expect_err("invalid ratio fails");
+			assert!(err.to_string().contains("positive finite ratio"));
+		}
+	}
+
+	#[test]
+	fn operation_mix_rejects_huge_period() {
+		let err = parse_operation_mix("read=1.0", MAX_OPERATION_MIX_PERIOD + 1)
+			.expect_err("huge period fails");
+
+		assert!(err.to_string().contains("cannot exceed"));
+	}
+
+	#[test]
+	fn expected_mix_uses_partial_prefix() {
+		let config = SteadyStateConfig {
+			records: 100,
+			warmup: Duration::ZERO,
+			measurement: Duration::from_secs(1),
+			latency_sample_every: 1,
+			seed: 1,
+			zipfian_exponent: 0.99,
+			bench_spec: None,
+			operation_mix: None,
+			operation_schedule: None,
+			operation_mix_period: 10,
+		};
+		let prefix = SteadyStateWorkload::BalancedZipfian.expected_mix_prefix(&config, 13);
+		assert_eq!(prefix, "read=8,update=5");
+	}
+
+	#[test]
+	fn balanced_zipfian_rejects_odd_period() {
+		let config = SteadyStateConfig {
+			records: 100,
+			warmup: Duration::ZERO,
+			measurement: Duration::from_secs(1),
+			latency_sample_every: 1,
+			seed: 1,
+			zipfian_exponent: 0.99,
+			bench_spec: Some("balanced_zipfian".to_string()),
+			operation_mix: None,
+			operation_schedule: None,
+			operation_mix_period: 999,
+		};
+		let err = config.workloads().unwrap_err();
+		assert!(err.to_string().contains("requires an even"));
+	}
+
+	#[test]
+	fn default_steady_state_rows_match_gateable_rows() -> Result<()> {
+		let config = SteadyStateConfig {
+			records: 100,
+			warmup: Duration::ZERO,
+			measurement: Duration::from_secs(1),
+			latency_sample_every: 1,
+			seed: 1,
+			zipfian_exponent: 0.99,
+			bench_spec: None,
+			operation_mix: None,
+			operation_schedule: None,
+			operation_mix_period: 1000,
+		};
+		let rows: Vec<_> = config.workloads()?.into_iter().map(SteadyStateWorkload::name).collect();
+
+		assert_eq!(
+			rows,
+			vec![
+				"balanced_zipfian",
+				"read_heavy_zipfian",
+				"update_heavy_zipfian",
+				"point_read_zipfian",
+				"point_read_missing_in_range",
+				"range_scan_uniform",
+				"sustained_ingest"
+			]
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn multi_row_steady_state_is_allowed() -> Result<()> {
+		let config = SteadyStateConfig {
+			records: 100,
+			warmup: Duration::ZERO,
+			measurement: Duration::from_secs(1),
+			latency_sample_every: 1,
+			seed: 1,
+			zipfian_exponent: 0.99,
+			bench_spec: Some("balanced_zipfian,point_read_zipfian".to_string()),
+			operation_mix: None,
+			operation_schedule: None,
+			operation_mix_period: 1000,
+		};
+		let workloads = config.workloads()?;
+		assert_eq!(
+			workloads,
+			vec![SteadyStateWorkload::BalancedZipfian, SteadyStateWorkload::PointReadZipfian]
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn follow_up_zipfian_rows_are_allowed() -> Result<()> {
+		let config = SteadyStateConfig {
+			records: 100,
+			warmup: Duration::ZERO,
+			measurement: Duration::from_secs(1),
+			latency_sample_every: 1,
+			seed: 1,
+			zipfian_exponent: 0.99,
+			bench_spec: Some("read_heavy_zipfian,update_heavy_zipfian".to_string()),
+			operation_mix: None,
+			operation_schedule: None,
+			operation_mix_period: 1000,
+		};
+		let workloads = config.workloads()?;
+
+		assert_eq!(
+			workloads,
+			vec![SteadyStateWorkload::ReadHeavyZipfian, SteadyStateWorkload::UpdateHeavyZipfian]
+		);
+		assert_eq!(
+			SteadyStateWorkload::ReadHeavyZipfian.expected_mix_prefix(&config, 1000),
+			"read=950,update=50"
+		);
+		assert_eq!(
+			SteadyStateWorkload::UpdateHeavyZipfian.expected_mix_prefix(&config, 1000),
+			"read=50,update=950"
+		);
+		Ok(())
+	}
+
+	#[test]
+	fn follow_up_zipfian_rows_use_zipfian_selector() {
+		let config = SteadyStateConfig {
+			records: 100,
+			warmup: Duration::ZERO,
+			measurement: Duration::from_secs(1),
+			latency_sample_every: 1,
+			seed: 1,
+			zipfian_exponent: 0.99,
+			bench_spec: None,
+			operation_mix: None,
+			operation_schedule: None,
+			operation_mix_period: 1000,
+		};
+
+		let read_heavy = KeySelector::new(&config, SteadyStateWorkload::ReadHeavyZipfian, 0);
+		let update_heavy = KeySelector::new(&config, SteadyStateWorkload::UpdateHeavyZipfian, 0);
+
+		assert!(!read_heavy.zipf_cdf.is_empty());
+		assert!(!update_heavy.zipf_cdf.is_empty());
+		assert!(!read_heavy.scrambled_keys.is_empty());
+		assert_ne!(read_heavy.scrambled_keys[0], 0);
+	}
+
+	#[test]
+	fn follow_up_zipfian_rows_reject_inexact_period() {
+		let config = SteadyStateConfig {
+			records: 100,
+			warmup: Duration::ZERO,
+			measurement: Duration::from_secs(1),
+			latency_sample_every: 1,
+			seed: 1,
+			zipfian_exponent: 0.99,
+			bench_spec: Some("read_heavy_zipfian".to_string()),
+			operation_mix: None,
+			operation_schedule: None,
+			operation_mix_period: 999,
+		};
+
+		let err = config.workloads().unwrap_err();
+
+		assert!(err.to_string().contains("multiple of 20"));
+	}
+
+	#[test]
+	fn sustained_ingest_rejects_non_create_custom_mix() -> Result<()> {
+		let config = SteadyStateConfig {
+			records: 100,
+			warmup: Duration::ZERO,
+			measurement: Duration::from_secs(1),
+			latency_sample_every: 1,
+			seed: 1,
+			zipfian_exponent: 0.99,
+			bench_spec: Some("sustained_ingest".to_string()),
+			operation_mix: Some("read=1.0".to_string()),
+			operation_schedule: Some(parse_operation_mix("read=1.0", 10)?),
+			operation_mix_period: 10,
+		};
+
+		let err = config.workloads().expect_err("sustained ingest rejects reads");
+
+		assert!(err.to_string().contains("incompatible with sustained_ingest"));
+		Ok(())
+	}
+
+	#[test]
+	fn zipfian_rows_reject_scan_custom_mix() -> Result<()> {
+		let config = SteadyStateConfig {
+			records: 100,
+			warmup: Duration::ZERO,
+			measurement: Duration::from_secs(1),
+			latency_sample_every: 1,
+			seed: 1,
+			zipfian_exponent: 0.99,
+			bench_spec: Some("balanced_zipfian".to_string()),
+			operation_mix: Some("scan=1.0".to_string()),
+			operation_schedule: Some(parse_operation_mix("scan=1.0", 10)?),
+			operation_mix_period: 10,
+		};
+
+		let err = config.workloads().expect_err("zipfian rows reject scans");
+
+		assert!(err.to_string().contains("incompatible with balanced_zipfian"));
+		Ok(())
+	}
+
+	#[test]
+	fn prepared_workload_rejects_custom_create_mix() -> Result<()> {
+		let config = SteadyStateConfig {
+			records: 100,
+			warmup: Duration::ZERO,
+			measurement: Duration::from_secs(1),
+			latency_sample_every: 1,
+			seed: 1,
+			zipfian_exponent: 0.99,
+			bench_spec: Some("balanced_zipfian".to_string()),
+			operation_mix: Some("create=1.0".to_string()),
+			operation_schedule: Some(parse_operation_mix("create=1.0", 10)?),
+			operation_mix_period: 10,
+		};
+
+		let err = config.workloads().expect_err("prepared workloads reject creates");
+
+		assert!(err.to_string().contains("may include create only for sustained_ingest"));
+		Ok(())
+	}
+
+	#[test]
+	fn sustained_ingest_offsets_create_keys_after_warmup() {
+		let config = SteadyStateConfig {
+			records: 100,
+			warmup: Duration::from_secs(1),
+			measurement: Duration::from_secs(1),
+			latency_sample_every: 1,
+			seed: 1,
+			zipfian_exponent: 0.99,
+			bench_spec: Some("sustained_ingest".to_string()),
+			operation_mix: None,
+			operation_schedule: None,
+			operation_mix_period: 1000,
+		};
+		assert!(matches!(
+			SteadyStateWorkload::SustainedIngest.operation_at(&config, 0),
+			SteadyStateOperation::Create
+		));
+		assert_eq!(
+			SteadyStateWorkload::SustainedIngest.expected_mix_prefix(&config, 5),
+			"create=5"
+		);
 	}
 }
 

--- a/src/bin/perf-gate.rs
+++ b/src/bin/perf-gate.rs
@@ -1,0 +1,738 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use anyhow::{Context, Result, anyhow, bail};
+use clap::Parser;
+
+const DEFAULT_ROWS: &[&str] =
+	&["put_c", "batch_create_100", "batch_create_1000", "batch_delete_100", "batch_delete_1000"];
+const DEFAULT_RATIO_ROWS: &[&str] = &["put_c", "batch_create_1000", "batch_delete_1000"];
+
+#[derive(Parser, Debug)]
+#[command(name = "perf-gate")]
+#[command(about = "Check crud-bench sync performance gates for ToyKV artifacts")]
+struct Args {
+	/// Previous ToyKV --sync crud-bench CSV.
+	#[arg(long)]
+	baseline_sync: PathBuf,
+	/// Current ToyKV --sync crud-bench CSV.
+	#[arg(long)]
+	current_sync: PathBuf,
+	/// Previous ToyKV no-sync crud-bench CSV.
+	#[arg(long)]
+	baseline_nosync: PathBuf,
+	/// Current ToyKV no-sync crud-bench CSV.
+	#[arg(long)]
+	current_nosync: PathBuf,
+	/// Current Fjall --sync crud-bench CSV. When present, ToyKV must stay at or above Fjall on
+	/// gated rows.
+	#[arg(long)]
+	fjall_sync: Option<PathBuf>,
+	/// Previous single-client ToyKV --sync CSV for latency checks.
+	#[arg(long, requires = "current_latency_sync")]
+	baseline_latency_sync: Option<PathBuf>,
+	/// Current single-client ToyKV --sync CSV for latency checks.
+	#[arg(long, requires = "baseline_latency_sync")]
+	current_latency_sync: Option<PathBuf>,
+	/// Rows to gate. Uses stable aliases such as put_c and batch_create_1000.
+	#[arg(long = "row")]
+	rows: Vec<String>,
+	/// Rows where sync/no-sync ratio must improve. Defaults to put_c, batch_create_1000,
+	/// batch_delete_1000.
+	#[arg(long = "ratio-row")]
+	ratio_rows: Vec<String>,
+	/// Maximum allowed current-sync OPS regression versus baseline sync.
+	#[arg(long, default_value_t = 5.0)]
+	max_sync_regression_pct: f64,
+	/// Minimum number of ratio rows that must improve.
+	#[arg(long, default_value_t = 2)]
+	min_ratio_improvements: usize,
+	/// Maximum allowed p95/p99 latency regression when latency CSVs are supplied.
+	#[arg(long, default_value_t = 5.0)]
+	max_latency_regression_pct: f64,
+}
+
+#[derive(Clone, Debug)]
+struct BenchRow {
+	ops: f64,
+	p95_ms: f64,
+	p99_ms: f64,
+}
+
+#[derive(Debug)]
+struct GateConfig {
+	rows: Vec<String>,
+	ratio_rows: Vec<String>,
+	max_sync_regression_pct: f64,
+	min_ratio_improvements: usize,
+	max_latency_regression_pct: f64,
+}
+
+#[derive(Debug)]
+struct GateInputs {
+	baseline_sync: BenchCsv,
+	current_sync: BenchCsv,
+	baseline_nosync: BenchCsv,
+	current_nosync: BenchCsv,
+	fjall_sync: Option<BenchCsv>,
+	baseline_latency_sync: Option<BenchCsv>,
+	current_latency_sync: Option<BenchCsv>,
+}
+
+struct Evaluation {
+	report: String,
+	passed: bool,
+}
+
+type BenchCsv = HashMap<String, BenchRow>;
+
+fn main() -> Result<ExitCode> {
+	let args = Args::parse();
+	let rows = if args.rows.is_empty() {
+		DEFAULT_ROWS.iter().map(|row| row.to_string()).collect()
+	} else {
+		args.rows
+	};
+	let ratio_rows = if args.ratio_rows.is_empty() {
+		DEFAULT_RATIO_ROWS.iter().map(|row| row.to_string()).collect()
+	} else {
+		args.ratio_rows
+	};
+	let cfg = GateConfig {
+		rows,
+		ratio_rows,
+		max_sync_regression_pct: args.max_sync_regression_pct,
+		min_ratio_improvements: args.min_ratio_improvements,
+		max_latency_regression_pct: args.max_latency_regression_pct,
+	};
+	validate_config(&cfg)?;
+	let inputs = GateInputs {
+		baseline_sync: read_crud_bench_csv(&args.baseline_sync)?,
+		current_sync: read_crud_bench_csv(&args.current_sync)?,
+		baseline_nosync: read_crud_bench_csv(&args.baseline_nosync)?,
+		current_nosync: read_crud_bench_csv(&args.current_nosync)?,
+		fjall_sync: args.fjall_sync.as_deref().map(read_crud_bench_csv).transpose()?,
+		baseline_latency_sync: args
+			.baseline_latency_sync
+			.as_deref()
+			.map(read_crud_bench_csv)
+			.transpose()?,
+		current_latency_sync: args
+			.current_latency_sync
+			.as_deref()
+			.map(read_crud_bench_csv)
+			.transpose()?,
+	};
+
+	let eval = evaluate(&cfg, &inputs)?;
+	print!("{}", eval.report);
+	if !eval.passed {
+		return Ok(ExitCode::FAILURE);
+	}
+	Ok(ExitCode::SUCCESS)
+}
+
+fn read_crud_bench_csv(path: &Path) -> Result<BenchCsv> {
+	let file = File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+	parse_crud_bench_csv(file).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn parse_crud_bench_csv<R: Read>(reader: R) -> Result<BenchCsv> {
+	let mut reader = csv::Reader::from_reader(reader);
+	let header = reader.headers().context("missing CSV header")?.clone();
+	let test_idx = column_index(&header, "Test")?;
+	let ops_idx = column_index(&header, "OPS")?;
+	let p99_idx = column_index(&header, "99th")?;
+	let p95_idx = column_index(&header, "95th")?;
+	let mut rows = HashMap::new();
+
+	for (line_no, result) in reader.records().enumerate() {
+		let record = result?;
+		if record.len() <= test_idx
+			|| record.len() <= ops_idx
+			|| record.len() <= p95_idx
+			|| record.len() <= p99_idx
+		{
+			bail!("CSV row {} has too few columns", line_no + 2);
+		}
+		if record[ops_idx].trim() == "-" {
+			continue;
+		}
+		let label = record[test_idx].trim().to_string();
+		let row = BenchRow {
+			ops: parse_number(&record[ops_idx], "OPS")?,
+			p95_ms: parse_duration_ms(&record[p95_idx])?,
+			p99_ms: parse_duration_ms(&record[p99_idx])?,
+		};
+		if rows.insert(label.clone(), row).is_some() {
+			bail!("duplicate row {label:?} found in CSV");
+		}
+	}
+
+	Ok(rows)
+}
+
+fn column_index(header: &csv::StringRecord, name: &str) -> Result<usize> {
+	header.iter().position(|col| col == name).ok_or_else(|| anyhow!("missing CSV column {name:?}"))
+}
+
+fn parse_number(cell: &str, label: &str) -> Result<f64> {
+	let value =
+		cell.trim().parse::<f64>().with_context(|| format!("invalid {label} value {cell:?}"))?;
+	if !value.is_finite() || value < 0.0 {
+		bail!("invalid {label} value {cell:?}: must be a non-negative number");
+	}
+	Ok(value)
+}
+
+fn parse_duration_ms(cell: &str) -> Result<f64> {
+	let trimmed = cell.trim();
+	if trimmed == "-" {
+		return Ok(0.0);
+	}
+	let Some(value) = trimmed.strip_suffix("ms") else {
+		bail!("expected duration in ms, got {cell:?}");
+	};
+	parse_number(value.trim(), "duration")
+}
+
+fn row_alias(label: &str) -> String {
+	let label = label.trim();
+	if label == "[C]reate" {
+		return "put_c".to_string();
+	}
+	if label == "[R]eads" || label == "[R]ead" {
+		return "get_c".to_string();
+	}
+	if label == "[U]pdate" {
+		return "update_c".to_string();
+	}
+	if label == "[D]elete" {
+		return "delete_c".to_string();
+	}
+	if let Some(rest) = label.strip_prefix("[B]atch::") {
+		let name = rest.split_whitespace().next().unwrap_or(rest);
+		return name.to_string();
+	}
+	label.to_string()
+}
+
+fn evaluate(cfg: &GateConfig, inputs: &GateInputs) -> Result<Evaluation> {
+	validate_config(cfg)?;
+
+	let mut failures = Vec::new();
+	let mut output = String::from("ToyKV sync perf gate\n\n");
+	output.push_str("Sync OPS regression gate:\n");
+
+	for row in &cfg.rows {
+		let baseline = required_row(&inputs.baseline_sync, row, "baseline sync")?;
+		let current = required_row(&inputs.current_sync, row, "current sync")?;
+		let delta = percent_change(current.ops, baseline.ops);
+		output.push_str(&format!(
+			"- {row}: {:.2} -> {:.2} OPS ({:+.2}%)\n",
+			baseline.ops, current.ops, delta
+		));
+		if delta < -cfg.max_sync_regression_pct {
+			failures.push(format!(
+				"{row} sync OPS regressed {delta:.2}%, below -{:.2}%",
+				cfg.max_sync_regression_pct
+			));
+		}
+	}
+
+	output.push_str("\nSync/no-sync ratio gate:\n");
+	let mut improved = 0usize;
+	for row in &cfg.ratio_rows {
+		let baseline_sync = required_row(&inputs.baseline_sync, row, "baseline sync")?;
+		let current_sync = required_row(&inputs.current_sync, row, "current sync")?;
+		let baseline_nosync = required_row(&inputs.baseline_nosync, row, "baseline no-sync")?;
+		let current_nosync = required_row(&inputs.current_nosync, row, "current no-sync")?;
+		let baseline_ratio = ratio(baseline_sync.ops, baseline_nosync.ops)?;
+		let current_ratio = ratio(current_sync.ops, current_nosync.ops)?;
+		let delta = percent_change(current_ratio, baseline_ratio);
+		if current_ratio > baseline_ratio {
+			improved += 1;
+		}
+		output.push_str(&format!(
+			"- {row}: {:.2}% -> {:.2}% ({:+.2}%)\n",
+			baseline_ratio * 100.0,
+			current_ratio * 100.0,
+			delta
+		));
+	}
+	if improved < cfg.min_ratio_improvements {
+		failures.push(format!(
+			"only {improved} sync/no-sync ratio rows improved; need {}",
+			cfg.min_ratio_improvements
+		));
+	}
+
+	if let Some(fjall) = &inputs.fjall_sync {
+		output.push_str("\nFjall-relative sync OPS gate:\n");
+		for row in &cfg.rows {
+			let current = required_row(&inputs.current_sync, row, "current sync")?;
+			let fjall_row = required_row(fjall, row, "Fjall sync")?;
+			let delta = percent_change(current.ops, fjall_row.ops);
+			output.push_str(&format!(
+				"- {row}: ToyKV {:.2} / Fjall {:.2} OPS ({:+.2}%)\n",
+				current.ops, fjall_row.ops, delta
+			));
+			if delta < -cfg.max_sync_regression_pct {
+				failures.push(format!(
+					"{row} current sync OPS is below Fjall by {delta:.2}%, below -{:.2}%",
+					cfg.max_sync_regression_pct
+				));
+			}
+		}
+	}
+
+	match (&inputs.baseline_latency_sync, &inputs.current_latency_sync) {
+		(Some(baseline), Some(current)) => {
+			output.push_str("\nSingle-client p95/p99 latency gate:\n");
+			for row in &cfg.rows {
+				let baseline = required_row(baseline, row, "baseline latency sync")?;
+				let current = required_row(current, row, "current latency sync")?;
+				let p95_delta = percent_change(current.p95_ms, baseline.p95_ms);
+				let p99_delta = percent_change(current.p99_ms, baseline.p99_ms);
+				output.push_str(&format!(
+					"- {row}: p95 {:.2} -> {:.2} ms ({:+.2}%), p99 {:.2} -> {:.2} ms ({:+.2}%)\n",
+					baseline.p95_ms,
+					current.p95_ms,
+					p95_delta,
+					baseline.p99_ms,
+					current.p99_ms,
+					p99_delta
+				));
+				if p95_delta > cfg.max_latency_regression_pct {
+					failures.push(format!(
+						"{row} p95 regressed {p95_delta:.2}%, above {:.2}%",
+						cfg.max_latency_regression_pct
+					));
+				}
+				if p99_delta > cfg.max_latency_regression_pct {
+					failures.push(format!(
+						"{row} p99 regressed {p99_delta:.2}%, above {:.2}%",
+						cfg.max_latency_regression_pct
+					));
+				}
+			}
+		}
+		(None, None) => {
+			output.push_str(
+				"\nSingle-client p95/p99 latency gate: skipped; no latency CSVs supplied.\n",
+			);
+		}
+		_ => bail!("latency gate requires both --baseline-latency-sync and --current-latency-sync"),
+	}
+
+	if failures.is_empty() {
+		output.push_str("\nResult: PASS\n");
+		Ok(Evaluation {
+			report: output,
+			passed: true,
+		})
+	} else {
+		output.push_str("\nResult: FAIL\n");
+		for failure in &failures {
+			output.push_str(&format!("- {failure}\n"));
+		}
+		Ok(Evaluation {
+			report: output,
+			passed: false,
+		})
+	}
+}
+
+fn validate_config(cfg: &GateConfig) -> Result<()> {
+	if cfg.max_sync_regression_pct < 0.0 {
+		bail!("--max-sync-regression-pct cannot be negative");
+	}
+	if cfg.max_latency_regression_pct < 0.0 {
+		bail!("--max-latency-regression-pct cannot be negative");
+	}
+	if cfg.min_ratio_improvements > cfg.ratio_rows.len() {
+		bail!(
+			"--min-ratio-improvements ({}) cannot be greater than the number of ratio rows ({})",
+			cfg.min_ratio_improvements,
+			cfg.ratio_rows.len()
+		);
+	}
+	Ok(())
+}
+
+fn required_row<'a>(rows: &'a BenchCsv, row: &str, source: &str) -> Result<&'a BenchRow> {
+	if let Some(r) = rows.get(row) {
+		return Ok(r);
+	}
+
+	let matches: Vec<_> = rows.iter().filter(|(label, _)| row_alias(label) == row).collect();
+	match matches.as_slice() {
+		[(_, r)] => Ok(r),
+		[] => bail!("missing row {row:?} in {source} CSV"),
+		_ => bail!("ambiguous row {row:?} in {source} CSV: multiple matches found"),
+	}
+}
+
+fn ratio(numerator: f64, denominator: f64) -> Result<f64> {
+	if denominator <= 0.0 {
+		bail!("cannot compute ratio against non-positive no-sync OPS {denominator}");
+	}
+	Ok(numerator / denominator)
+}
+
+fn percent_change(current: f64, baseline: f64) -> f64 {
+	if baseline == 0.0 {
+		if current > 0.0 {
+			return f64::INFINITY;
+		}
+		return 0.0;
+	}
+	(current - baseline) * 100.0 / baseline
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	const CSV: &str = "\
+Test,Total time,Mean,Max,99th,95th,75th,50th,25th,1st,Min,IQR,OPS,CPU_avg,CPU_min,CPU_max,Memory_peak,Memory_avg,Reads,Writes,System load,System load (1m/5m/15m)
+[C]reate,1s,1.00 ms,2.00 ms,1.90 ms,1.80 ms,1.50 ms,1.00 ms,0.50 ms,0.10 ms,0.01 ms,1.00 ms,1000.00,0,0,0,0,0,0,0,0,0/0/0
+[B]atch::batch_create_1000 (100 batches of 1000),1s,1.00 ms,2.00 ms,1.90 ms,1.80 ms,1.50 ms,1.00 ms,0.50 ms,0.10 ms,0.01 ms,1.00 ms,500.00,0,0,0,0,0,0,0,0,0/0/0
+";
+
+	#[test]
+	fn parses_crud_bench_csv_aliases() {
+		let rows = parse_crud_bench_csv(CSV.as_bytes()).expect("parse CSV");
+
+		assert_eq!(required_row(&rows, "put_c", "test").unwrap().ops, 1000.0);
+		assert_eq!(required_row(&rows, "put_c", "test").unwrap().p95_ms, 1.8);
+		assert_eq!(required_row(&rows, "batch_create_1000", "test").unwrap().ops, 500.0);
+	}
+
+	#[test]
+	fn parses_quoted_csv_fields() {
+		let csv = "\
+Test,Total time,Mean,Max,99th,95th,75th,50th,25th,1st,Min,IQR,OPS,CPU_avg,CPU_min,CPU_max,Memory_peak,Memory_avg,Reads,Writes,System load,System load (1m/5m/15m)
+\"[B]atch::batch_create_1000 (100 batches, of \"\"1000\"\")\",1s,1.00 ms,2.00 ms,1.90 ms,1.80 ms,1.50 ms,1.00 ms,0.50 ms,0.10 ms,0.01 ms,1.00 ms,500.00,0,0,0,0,0,0,0,0,0/0/0
+";
+
+		let rows = parse_crud_bench_csv(csv.as_bytes()).expect("parse CSV");
+
+		assert_eq!(required_row(&rows, "batch_create_1000", "test").unwrap().ops, 500.0);
+	}
+
+	#[test]
+	fn parses_placeholder_latency_as_zero() {
+		let csv = "\
+Test,Total time,Mean,Max,99th,95th,75th,50th,25th,1st,Min,IQR,OPS,CPU_avg,CPU_min,CPU_max,Memory_peak,Memory_avg,Reads,Writes,System load,System load (1m/5m/15m)
+[C]reate,1s,1.00 ms,2.00 ms,-,-,1.50 ms,1.00 ms,0.50 ms,0.10 ms,0.01 ms,1.00 ms,1000.00,0,0,0,0,0,0,0,0,0/0/0
+";
+
+		let rows = parse_crud_bench_csv(csv.as_bytes()).expect("parse CSV");
+
+		assert_eq!(required_row(&rows, "put_c", "test").unwrap().p95_ms, 0.0);
+		assert_eq!(required_row(&rows, "put_c", "test").unwrap().p99_ms, 0.0);
+	}
+
+	#[test]
+	fn parses_duration_with_variable_spacing() {
+		assert_eq!(parse_duration_ms("1.25ms").unwrap(), 1.25);
+		assert_eq!(parse_duration_ms("1.25 ms").unwrap(), 1.25);
+		assert_eq!(parse_duration_ms("1.25   ms").unwrap(), 1.25);
+	}
+
+	#[test]
+	fn rejects_invalid_numeric_values() {
+		for ops in ["NaN", "-1.0"] {
+			let csv = format!(
+				"\
+Test,Total time,Mean,Max,99th,95th,75th,50th,25th,1st,Min,IQR,OPS,CPU_avg,CPU_min,CPU_max,Memory_peak,Memory_avg,Reads,Writes,System load,System load (1m/5m/15m)
+[C]reate,1s,1.00 ms,2.00 ms,1.90 ms,1.80 ms,1.50 ms,1.00 ms,0.50 ms,0.10 ms,0.01 ms,1.00 ms,{ops},0,0,0,0,0,0,0,0,0/0/0
+"
+			);
+
+			let err =
+				parse_crud_bench_csv(csv.as_bytes()).expect_err("invalid numeric value fails");
+
+			assert!(err.to_string().contains("must be a non-negative number"));
+		}
+	}
+
+	#[test]
+	fn skips_rows_with_placeholder_ops() {
+		let csv = "\
+Test,Total time,Mean,Max,99th,95th,75th,50th,25th,1st,Min,IQR,OPS,CPU_avg,CPU_min,CPU_max,Memory_peak,Memory_avg,Reads,Writes,System load,System load (1m/5m/15m)
+[C]reate,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-,-
+";
+
+		let rows = parse_crud_bench_csv(csv.as_bytes()).expect("parse CSV");
+
+		assert!(required_row(&rows, "put_c", "test").is_err());
+	}
+
+	#[test]
+	fn rejects_duplicate_rows() {
+		let csv = "\
+Test,Total time,Mean,Max,99th,95th,75th,50th,25th,1st,Min,IQR,OPS,CPU_avg,CPU_min,CPU_max,Memory_peak,Memory_avg,Reads,Writes,System load,System load (1m/5m/15m)
+[C]reate,1s,1.00 ms,2.00 ms,1.90 ms,1.80 ms,1.50 ms,1.00 ms,0.50 ms,0.10 ms,0.01 ms,1.00 ms,1000.00,0,0,0,0,0,0,0,0,0/0/0
+[C]reate,1s,1.00 ms,2.00 ms,1.90 ms,1.80 ms,1.50 ms,1.00 ms,0.50 ms,0.10 ms,0.01 ms,1.00 ms,900.00,0,0,0,0,0,0,0,0,0/0/0
+";
+
+		let err = parse_crud_bench_csv(csv.as_bytes()).expect_err("duplicate row fails");
+
+		assert!(err.to_string().contains("duplicate row"));
+	}
+
+	#[test]
+	fn detects_ambiguous_row_aliases() {
+		let csv = "\
+Test,Total time,Mean,Max,99th,95th,75th,50th,25th,1st,Min,IQR,OPS,CPU_avg,CPU_min,CPU_max,Memory_peak,Memory_avg,Reads,Writes,System load,System load (1m/5m/15m)
+[B]atch::batch_create_1000 (100 batches of 1000),1s,1.00 ms,2.00 ms,1.90 ms,1.80 ms,1.50 ms,1.00 ms,0.50 ms,0.10 ms,0.01 ms,1.00 ms,500.00,0,0,0,0,0,0,0,0,0/0/0
+[B]atch::batch_create_1000 (500 batches of 1000),1s,1.00 ms,2.00 ms,1.90 ms,1.80 ms,1.50 ms,1.00 ms,0.50 ms,0.10 ms,0.01 ms,1.00 ms,600.00,0,0,0,0,0,0,0,0,0/0/0
+";
+
+		let rows = parse_crud_bench_csv(csv.as_bytes()).expect("parse CSV");
+		let err =
+			required_row(&rows, "batch_create_1000", "test").expect_err("ambiguous lookup fails");
+
+		assert!(err.to_string().contains("ambiguous row"));
+	}
+
+	#[test]
+	fn requires_latency_csvs_as_a_pair() {
+		let err = Args::try_parse_from([
+			"perf-gate",
+			"--baseline-sync",
+			"baseline-sync.csv",
+			"--current-sync",
+			"current-sync.csv",
+			"--baseline-nosync",
+			"baseline-nosync.csv",
+			"--current-nosync",
+			"current-nosync.csv",
+			"--baseline-latency-sync",
+			"baseline-latency-sync.csv",
+		])
+		.expect_err("missing current latency CSV fails");
+
+		assert!(err.to_string().contains("--current-latency-sync"));
+	}
+
+	#[test]
+	fn passes_when_ops_and_ratio_gates_hold() {
+		let baseline_sync = parse_crud_bench_csv(CSV.as_bytes()).expect("parse baseline sync");
+		let current_sync = rows_with_ops(&[("put_c", 1100.0), ("batch_create_1000", 550.0)]);
+		let baseline_nosync = rows_with_ops(&[("put_c", 2000.0), ("batch_create_1000", 1000.0)]);
+		let current_nosync = rows_with_ops(&[("put_c", 1900.0), ("batch_create_1000", 950.0)]);
+		let cfg = GateConfig {
+			rows: vec!["put_c".into(), "batch_create_1000".into()],
+			ratio_rows: vec!["put_c".into(), "batch_create_1000".into()],
+			max_sync_regression_pct: 5.0,
+			min_ratio_improvements: 2,
+			max_latency_regression_pct: 5.0,
+		};
+		let inputs = GateInputs {
+			baseline_sync,
+			current_sync,
+			baseline_nosync,
+			current_nosync,
+			fjall_sync: None,
+			baseline_latency_sync: None,
+			current_latency_sync: None,
+		};
+
+		let eval = evaluate(&cfg, &inputs).expect("gate evaluates");
+		assert!(eval.passed);
+		assert!(eval.report.contains("Result: PASS"));
+	}
+
+	#[test]
+	fn fails_when_sync_regresses_too_much() {
+		let cfg = GateConfig {
+			rows: vec!["put_c".into()],
+			ratio_rows: vec!["put_c".into()],
+			max_sync_regression_pct: 5.0,
+			min_ratio_improvements: 0,
+			max_latency_regression_pct: 5.0,
+		};
+		let inputs = GateInputs {
+			baseline_sync: rows_with_ops(&[("put_c", 1000.0)]),
+			current_sync: rows_with_ops(&[("put_c", 900.0)]),
+			baseline_nosync: rows_with_ops(&[("put_c", 2000.0)]),
+			current_nosync: rows_with_ops(&[("put_c", 2000.0)]),
+			fjall_sync: None,
+			baseline_latency_sync: None,
+			current_latency_sync: None,
+		};
+
+		let eval = evaluate(&cfg, &inputs).expect("gate evaluates");
+		assert!(!eval.passed);
+		assert!(eval.report.contains("regressed -10.00%"));
+	}
+
+	#[test]
+	fn rejects_impossible_min_ratio_improvements() {
+		let cfg = GateConfig {
+			rows: vec!["put_c".into()],
+			ratio_rows: vec!["put_c".into()],
+			max_sync_regression_pct: 5.0,
+			min_ratio_improvements: 2,
+			max_latency_regression_pct: 5.0,
+		};
+
+		let err = validate_config(&cfg).expect_err("config fails");
+
+		assert!(err.to_string().contains("cannot be greater than the number of ratio rows"));
+	}
+
+	#[test]
+	fn rejects_negative_regression_thresholds() {
+		let mut cfg = GateConfig {
+			rows: vec!["put_c".into()],
+			ratio_rows: vec!["put_c".into()],
+			max_sync_regression_pct: -1.0,
+			min_ratio_improvements: 0,
+			max_latency_regression_pct: 5.0,
+		};
+
+		let err = validate_config(&cfg).expect_err("negative sync threshold fails");
+		assert!(err.to_string().contains("--max-sync-regression-pct cannot be negative"));
+
+		cfg.max_sync_regression_pct = 5.0;
+		cfg.max_latency_regression_pct = -1.0;
+
+		let err = validate_config(&cfg).expect_err("negative latency threshold fails");
+		assert!(err.to_string().contains("--max-latency-regression-pct cannot be negative"));
+	}
+
+	#[test]
+	fn allows_fjall_relative_difference_within_tolerance() {
+		let cfg = GateConfig {
+			rows: vec!["put_c".into()],
+			ratio_rows: vec!["put_c".into()],
+			max_sync_regression_pct: 5.0,
+			min_ratio_improvements: 0,
+			max_latency_regression_pct: 5.0,
+		};
+		let inputs = GateInputs {
+			baseline_sync: rows_with_ops(&[("put_c", 100.0)]),
+			current_sync: rows_with_ops(&[("put_c", 96.0)]),
+			baseline_nosync: rows_with_ops(&[("put_c", 2000.0)]),
+			current_nosync: rows_with_ops(&[("put_c", 2000.0)]),
+			fjall_sync: Some(rows_with_ops(&[("put_c", 100.0)])),
+			baseline_latency_sync: None,
+			current_latency_sync: None,
+		};
+
+		let eval = evaluate(&cfg, &inputs).expect("gate evaluates");
+
+		assert!(eval.passed);
+		assert!(eval.report.contains("Result: PASS"));
+	}
+
+	#[test]
+	fn fails_when_fjall_relative_difference_exceeds_tolerance() {
+		let cfg = GateConfig {
+			rows: vec!["put_c".into()],
+			ratio_rows: vec!["put_c".into()],
+			max_sync_regression_pct: 5.0,
+			min_ratio_improvements: 0,
+			max_latency_regression_pct: 5.0,
+		};
+		let inputs = GateInputs {
+			baseline_sync: rows_with_ops(&[("put_c", 1000.0)]),
+			current_sync: rows_with_ops(&[("put_c", 94.0)]),
+			baseline_nosync: rows_with_ops(&[("put_c", 2000.0)]),
+			current_nosync: rows_with_ops(&[("put_c", 2000.0)]),
+			fjall_sync: Some(rows_with_ops(&[("put_c", 100.0)])),
+			baseline_latency_sync: None,
+			current_latency_sync: None,
+		};
+
+		let eval = evaluate(&cfg, &inputs).expect("gate evaluates");
+
+		assert!(!eval.passed);
+		assert!(eval.report.contains("below -5.00%"));
+	}
+
+	#[test]
+	fn fails_when_latency_regresses_too_much() {
+		let cfg = GateConfig {
+			rows: vec!["put_c".into()],
+			ratio_rows: vec!["put_c".into()],
+			max_sync_regression_pct: 5.0,
+			min_ratio_improvements: 0,
+			max_latency_regression_pct: 5.0,
+		};
+		let inputs = GateInputs {
+			baseline_sync: rows_with_ops(&[("put_c", 1000.0)]),
+			current_sync: rows_with_ops(&[("put_c", 1000.0)]),
+			baseline_nosync: rows_with_ops(&[("put_c", 2000.0)]),
+			current_nosync: rows_with_ops(&[("put_c", 1900.0)]),
+			fjall_sync: None,
+			baseline_latency_sync: Some(rows_with_latency(&[("put_c", 1.0, 2.0)])),
+			current_latency_sync: Some(rows_with_latency(&[("put_c", 1.2, 2.3)])),
+		};
+
+		let eval = evaluate(&cfg, &inputs).expect("gate evaluates");
+		assert!(!eval.passed);
+		assert!(eval.report.contains("p95 regressed 20.00%"));
+	}
+
+	#[test]
+	fn fails_when_latency_baseline_placeholder_becomes_measured() {
+		let cfg = GateConfig {
+			rows: vec!["put_c".into()],
+			ratio_rows: vec!["put_c".into()],
+			max_sync_regression_pct: 5.0,
+			min_ratio_improvements: 0,
+			max_latency_regression_pct: 5.0,
+		};
+		let inputs = GateInputs {
+			baseline_sync: rows_with_ops(&[("put_c", 1000.0)]),
+			current_sync: rows_with_ops(&[("put_c", 1000.0)]),
+			baseline_nosync: rows_with_ops(&[("put_c", 2000.0)]),
+			current_nosync: rows_with_ops(&[("put_c", 1900.0)]),
+			fjall_sync: None,
+			baseline_latency_sync: Some(rows_with_latency(&[("put_c", 0.0, 0.0)])),
+			current_latency_sync: Some(rows_with_latency(&[("put_c", 1.0, 2.0)])),
+		};
+
+		let eval = evaluate(&cfg, &inputs).expect("gate evaluates");
+		assert!(!eval.passed);
+		assert!(eval.report.contains("p95 regressed inf%"));
+	}
+
+	fn rows_with_ops(rows: &[(&str, f64)]) -> BenchCsv {
+		rows.iter()
+			.map(|(name, ops)| {
+				(
+					(*name).to_string(),
+					BenchRow {
+						ops: *ops,
+						p95_ms: 1.0,
+						p99_ms: 2.0,
+					},
+				)
+			})
+			.collect()
+	}
+
+	fn rows_with_latency(rows: &[(&str, f64, f64)]) -> BenchCsv {
+		rows.iter()
+			.map(|(name, p95_ms, p99_ms)| {
+				(
+					(*name).to_string(),
+					BenchRow {
+						ops: 1.0,
+						p95_ms: *p95_ms,
+						p99_ms: *p99_ms,
+					},
+				)
+			})
+			.collect()
+	}
+}

--- a/src/bin/perf-gate.rs
+++ b/src/bin/perf-gate.rs
@@ -6,10 +6,20 @@ use std::process::ExitCode;
 
 use anyhow::{Context, Result, anyhow, bail};
 use clap::Parser;
+use serde::Deserialize;
 
 const DEFAULT_ROWS: &[&str] =
 	&["put_c", "batch_create_100", "batch_create_1000", "batch_delete_100", "batch_delete_1000"];
 const DEFAULT_RATIO_ROWS: &[&str] = &["put_c", "batch_create_1000", "batch_delete_1000"];
+const DEFAULT_STEADY_STATE_ROWS: &[&str] = &[
+	"balanced_zipfian",
+	"read_heavy_zipfian",
+	"update_heavy_zipfian",
+	"point_read_zipfian",
+	"point_read_missing_in_range",
+	"range_scan_uniform",
+	"sustained_ingest",
+];
 
 #[derive(Parser, Debug)]
 #[command(name = "perf-gate")]
@@ -17,16 +27,28 @@ const DEFAULT_RATIO_ROWS: &[&str] = &["put_c", "batch_create_1000", "batch_delet
 struct Args {
 	/// Previous ToyKV --sync crud-bench CSV.
 	#[arg(long)]
-	baseline_sync: PathBuf,
+	baseline_sync: Option<PathBuf>,
 	/// Current ToyKV --sync crud-bench CSV.
 	#[arg(long)]
-	current_sync: PathBuf,
+	current_sync: Option<PathBuf>,
 	/// Previous ToyKV no-sync crud-bench CSV.
 	#[arg(long)]
-	baseline_nosync: PathBuf,
+	baseline_nosync: Option<PathBuf>,
 	/// Current ToyKV no-sync crud-bench CSV.
 	#[arg(long)]
-	current_nosync: PathBuf,
+	current_nosync: Option<PathBuf>,
+	/// Previous steady-state JSON artifact.
+	#[arg(long)]
+	baseline_steady_state_json: Option<PathBuf>,
+	/// Current steady-state JSON artifact.
+	#[arg(long)]
+	current_steady_state_json: Option<PathBuf>,
+	/// Required steady-state row. Defaults to the RFC MVP rows in steady-state mode.
+	#[arg(long = "steady-state-row")]
+	steady_state_rows: Vec<String>,
+	/// Optional steady-state row; unsupported rows with these names are skipped.
+	#[arg(long = "optional-steady-state-row")]
+	optional_steady_state_rows: Vec<String>,
 	/// Current Fjall --sync crud-bench CSV. When present, ToyKV must stay at or above Fjall on
 	/// gated rows.
 	#[arg(long)]
@@ -82,15 +104,166 @@ struct GateInputs {
 	current_latency_sync: Option<BenchCsv>,
 }
 
+#[derive(Debug)]
+struct SteadyStateGateConfig {
+	rows: Vec<String>,
+	optional_rows: Vec<String>,
+	max_ops_regression_pct: f64,
+	max_latency_regression_pct: f64,
+}
+
+#[derive(Debug)]
+struct SteadyStateGateInputs {
+	baseline: SteadyStateRows,
+	current: SteadyStateRows,
+}
+
 struct Evaluation {
 	report: String,
 	passed: bool,
 }
 
 type BenchCsv = HashMap<String, BenchRow>;
+type SteadyStateRows = HashMap<String, SteadyStateRow>;
+
+#[derive(Clone, Debug, Deserialize)]
+struct SteadyStateArtifact {
+	#[serde(default)]
+	steady_state: Vec<SteadyStateRow>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct SteadyStateRow {
+	name: String,
+	suite: String,
+	database: serde_json::Value,
+	status: String,
+	#[serde(default)]
+	unsupported_reason: Option<String>,
+	#[serde(default)]
+	failure_reason: Option<String>,
+	sync: bool,
+	task: SteadyStateTask,
+	phases: SteadyStatePhases,
+	#[serde(default)]
+	throughput: Option<SteadyStateThroughput>,
+	#[serde(default)]
+	latency: Option<SteadyStateLatency>,
+	#[serde(default)]
+	validation: Option<SteadyStateValidation>,
+	#[serde(default)]
+	drain: Option<SteadyStateDrain>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+struct SteadyStateTask {
+	records: u32,
+	clients: u32,
+	threads: u32,
+	warmup_secs: u64,
+	measurement_secs: u64,
+	latency_sample_every: u64,
+	seed: u64,
+	worker_seed_derivation: String,
+	operation_mix: String,
+	operation_mix_period: u32,
+	key_selection: String,
+	zipfian_exponent: f64,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct SteadyStatePhases {
+	prepare: SteadyStatePhase,
+	warmup: SteadyStatePhase,
+	measure: SteadyStatePhase,
+	drain: SteadyStatePhase,
+	cleanup: SteadyStatePhase,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct SteadyStatePhase {
+	elapsed_ms: f64,
+	status: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct SteadyStateThroughput {
+	completed_operations: u64,
+	ops_per_sec: f64,
+	#[serde(default)]
+	per_second_windows: Vec<f64>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct SteadyStateLatency {
+	sample_count: u64,
+	p50_ms: f64,
+	p95_ms: f64,
+	p99_ms: f64,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct SteadyStateValidation {
+	errors: u64,
+	read_hits: u64,
+	read_misses: u64,
+	updates: u64,
+	scan_count_errors: u64,
+	observed_mix: String,
+	expected_mix_prefix: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct SteadyStateDrain {
+	elapsed_ms: f64,
+	timed_out: bool,
+}
 
 fn main() -> Result<ExitCode> {
 	let args = Args::parse();
+	let steady_state_mode = uses_steady_state_mode(&args);
+	if steady_state_mode {
+		let baseline = args
+			.baseline_steady_state_json
+			.as_deref()
+			.context("--baseline-steady-state-json is required for steady-state mode")?;
+		let current = args
+			.current_steady_state_json
+			.as_deref()
+			.context("--current-steady-state-json is required for steady-state mode")?;
+		if args.baseline_sync.is_some()
+			|| args.current_sync.is_some()
+			|| args.baseline_nosync.is_some()
+			|| args.current_nosync.is_some()
+			|| args.fjall_sync.is_some()
+			|| args.baseline_latency_sync.is_some()
+			|| args.current_latency_sync.is_some()
+			|| !args.rows.is_empty()
+			|| !args.ratio_rows.is_empty()
+		{
+			bail!("steady-state mode cannot be combined with legacy CRUD CSV inputs");
+		}
+		let rows =
+			steady_state_rows_to_evaluate(args.steady_state_rows, &args.optional_steady_state_rows);
+		let cfg = SteadyStateGateConfig {
+			rows,
+			optional_rows: args.optional_steady_state_rows,
+			max_ops_regression_pct: args.max_sync_regression_pct,
+			max_latency_regression_pct: args.max_latency_regression_pct,
+		};
+		let inputs = SteadyStateGateInputs {
+			baseline: read_steady_state_json(baseline)?,
+			current: read_steady_state_json(current)?,
+		};
+		let eval = evaluate_steady_state(&cfg, &inputs)?;
+		print!("{}", eval.report);
+		return Ok(if eval.passed {
+			ExitCode::SUCCESS
+		} else {
+			ExitCode::FAILURE
+		});
+	}
+
 	let rows = if args.rows.is_empty() {
 		DEFAULT_ROWS.iter().map(|row| row.to_string()).collect()
 	} else {
@@ -110,10 +283,18 @@ fn main() -> Result<ExitCode> {
 	};
 	validate_config(&cfg)?;
 	let inputs = GateInputs {
-		baseline_sync: read_crud_bench_csv(&args.baseline_sync)?,
-		current_sync: read_crud_bench_csv(&args.current_sync)?,
-		baseline_nosync: read_crud_bench_csv(&args.baseline_nosync)?,
-		current_nosync: read_crud_bench_csv(&args.current_nosync)?,
+		baseline_sync: read_crud_bench_csv(
+			args.baseline_sync.as_deref().context("--baseline-sync is required")?,
+		)?,
+		current_sync: read_crud_bench_csv(
+			args.current_sync.as_deref().context("--current-sync is required")?,
+		)?,
+		baseline_nosync: read_crud_bench_csv(
+			args.baseline_nosync.as_deref().context("--baseline-nosync is required")?,
+		)?,
+		current_nosync: read_crud_bench_csv(
+			args.current_nosync.as_deref().context("--current-nosync is required")?,
+		)?,
 		fjall_sync: args.fjall_sync.as_deref().map(read_crud_bench_csv).transpose()?,
 		baseline_latency_sync: args
 			.baseline_latency_sync
@@ -135,9 +316,49 @@ fn main() -> Result<ExitCode> {
 	Ok(ExitCode::SUCCESS)
 }
 
+fn uses_steady_state_mode(args: &Args) -> bool {
+	args.baseline_steady_state_json.is_some()
+		|| args.current_steady_state_json.is_some()
+		|| !args.steady_state_rows.is_empty()
+		|| !args.optional_steady_state_rows.is_empty()
+}
+
+fn steady_state_rows_to_evaluate(
+	required_rows: Vec<String>,
+	optional_rows: &[String],
+) -> Vec<String> {
+	let mut rows: Vec<_> = if required_rows.is_empty() {
+		DEFAULT_STEADY_STATE_ROWS.iter().map(|row| row.to_string()).collect()
+	} else {
+		required_rows
+	};
+	for row in optional_rows {
+		if !rows.contains(row) {
+			rows.push(row.clone());
+		}
+	}
+	rows
+}
+
 fn read_crud_bench_csv(path: &Path) -> Result<BenchCsv> {
 	let file = File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
 	parse_crud_bench_csv(file).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn read_steady_state_json(path: &Path) -> Result<SteadyStateRows> {
+	let file = File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+	parse_steady_state_json(file).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn parse_steady_state_json<R: Read>(reader: R) -> Result<SteadyStateRows> {
+	let artifact: SteadyStateArtifact = serde_json::from_reader(reader)?;
+	let mut rows = HashMap::new();
+	for row in artifact.steady_state {
+		if rows.insert(row.name.clone(), row).is_some() {
+			bail!("duplicate steady-state row found");
+		}
+	}
+	Ok(rows)
 }
 
 fn parse_crud_bench_csv<R: Read>(reader: R) -> Result<BenchCsv> {
@@ -346,7 +567,298 @@ fn evaluate(cfg: &GateConfig, inputs: &GateInputs) -> Result<Evaluation> {
 	}
 }
 
+fn evaluate_steady_state(
+	cfg: &SteadyStateGateConfig,
+	inputs: &SteadyStateGateInputs,
+) -> Result<Evaluation> {
+	validate_steady_state_config(cfg)?;
+
+	let mut failures = Vec::new();
+	let mut output = String::from("ToyKV steady-state perf gate\n\n");
+	output.push_str("Steady-state row gate:\n");
+
+	for row_name in &cfg.rows {
+		let baseline = required_steady_state_row(&inputs.baseline, row_name, "baseline")?;
+		let current = required_steady_state_row(&inputs.current, row_name, "current")?;
+		validate_steady_state_row(row_name, baseline, "baseline", cfg, &mut failures);
+		validate_steady_state_row(row_name, current, "current", cfg, &mut failures);
+		let baseline_optional_unsupported =
+			is_optional_unsupported(row_name, &baseline.status, cfg);
+		let current_optional_unsupported = is_optional_unsupported(row_name, &current.status, cfg);
+		validate_steady_state_comparable(row_name, baseline, current, &mut failures);
+
+		if baseline.status == "completed" && current.status == "completed" {
+			let Some(baseline_throughput) = &baseline.throughput else {
+				continue;
+			};
+			let Some(current_throughput) = &current.throughput else {
+				continue;
+			};
+			let Some(baseline_latency) = &baseline.latency else {
+				continue;
+			};
+			let Some(current_latency) = &current.latency else {
+				continue;
+			};
+			let ops_delta =
+				percent_change(current_throughput.ops_per_sec, baseline_throughput.ops_per_sec);
+			let p95_delta = percent_change(current_latency.p95_ms, baseline_latency.p95_ms);
+			let p99_delta = percent_change(current_latency.p99_ms, baseline_latency.p99_ms);
+			output.push_str(&format!(
+				"- {row_name}: OPS {:.2} -> {:.2} ({:+.2}%), p95 {:.2} -> {:.2} ms ({:+.2}%), p99 {:.2} -> {:.2} ms ({:+.2}%)\n",
+				baseline_throughput.ops_per_sec,
+				current_throughput.ops_per_sec,
+				ops_delta,
+				baseline_latency.p95_ms,
+				current_latency.p95_ms,
+				p95_delta,
+				baseline_latency.p99_ms,
+				current_latency.p99_ms,
+				p99_delta
+			));
+			if ops_delta < -cfg.max_ops_regression_pct {
+				failures.push(format!(
+					"{row_name} OPS regressed {ops_delta:.2}%, below -{:.2}%",
+					cfg.max_ops_regression_pct
+				));
+			}
+			if p95_delta > cfg.max_latency_regression_pct {
+				failures.push(format!(
+					"{row_name} p95 regressed {p95_delta:.2}%, above {:.2}%",
+					cfg.max_latency_regression_pct
+				));
+			}
+			if p99_delta > cfg.max_latency_regression_pct {
+				failures.push(format!(
+					"{row_name} p99 regressed {p99_delta:.2}%, above {:.2}%",
+					cfg.max_latency_regression_pct
+				));
+			}
+		} else if baseline_optional_unsupported && current_optional_unsupported {
+			output.push_str(&format!("- {row_name}: optional unsupported; skipped\n"));
+		} else {
+			output.push_str(&format!(
+				"- {row_name}: baseline status={}, current status={}\n",
+				baseline.status, current.status
+			));
+			if baseline_optional_unsupported != current_optional_unsupported {
+				failures.push(format!(
+					"{row_name} optional unsupported state differs: baseline={}, current={}",
+					baseline.status, current.status
+				));
+			}
+		}
+	}
+
+	if failures.is_empty() {
+		output.push_str("\nResult: PASS\n");
+		Ok(Evaluation {
+			report: output,
+			passed: true,
+		})
+	} else {
+		output.push_str("\nResult: FAIL\n");
+		for failure in &failures {
+			output.push_str(&format!("- {failure}\n"));
+		}
+		Ok(Evaluation {
+			report: output,
+			passed: false,
+		})
+	}
+}
+
+fn validate_steady_state_row(
+	row_name: &str,
+	row: &SteadyStateRow,
+	source: &str,
+	cfg: &SteadyStateGateConfig,
+	failures: &mut Vec<String>,
+) {
+	if row.suite != "steady-state" {
+		failures.push(format!("{source} {row_name} has invalid suite {:?}", row.suite));
+	}
+	if row.database.as_str().is_none_or(|database| database.trim().is_empty()) {
+		failures.push(format!("{source} {row_name} has invalid database field"));
+	}
+	validate_steady_state_task(row_name, &row.task, source, failures);
+	validate_steady_state_phases(row_name, row, source, failures);
+	match row.status.as_str() {
+		"completed" => {}
+		"unsupported" if cfg.optional_rows.iter().any(|optional| optional == row_name) => {
+			if row.unsupported_reason.as_deref().is_none_or(str::is_empty) {
+				failures.push(format!("{source} {row_name} is unsupported without a reason"));
+			}
+			return;
+		}
+		"unsupported" => {
+			failures.push(format!(
+				"{source} {row_name} is unsupported: {}",
+				row.unsupported_reason.as_deref().unwrap_or("missing reason")
+			));
+			return;
+		}
+		"failed" => {
+			failures.push(format!(
+				"{source} {row_name} failed: {}",
+				row.failure_reason.as_deref().unwrap_or("missing reason")
+			));
+			return;
+		}
+		other => {
+			failures.push(format!("{source} {row_name} has unknown status {other:?}"));
+			return;
+		}
+	}
+	let Some(throughput) = &row.throughput else {
+		failures.push(format!("{source} {row_name} is missing throughput"));
+		return;
+	};
+	if throughput.completed_operations == 0 {
+		failures.push(format!("{source} {row_name} completed zero operations"));
+	}
+	if throughput.ops_per_sec <= 0.0 || !throughput.ops_per_sec.is_finite() {
+		failures.push(format!("{source} {row_name} has invalid OPS"));
+	}
+	if throughput.per_second_windows.is_empty() {
+		failures.push(format!("{source} {row_name} is missing throughput windows"));
+	}
+	if throughput.per_second_windows.iter().any(|window| *window < 0.0 || !window.is_finite()) {
+		failures.push(format!("{source} {row_name} has invalid throughput windows"));
+	}
+	let Some(validation) = &row.validation else {
+		failures.push(format!("{source} {row_name} is missing validation"));
+		return;
+	};
+	if validation.errors > 0 {
+		failures.push(format!("{source} {row_name} has {} validation errors", validation.errors));
+	}
+	if validation.observed_mix.is_empty() || validation.expected_mix_prefix.is_empty() {
+		failures.push(format!("{source} {row_name} is missing validation mix details"));
+	}
+	let _ = (
+		validation.read_hits,
+		validation.read_misses,
+		validation.updates,
+		validation.scan_count_errors,
+	);
+	let Some(latency) = &row.latency else {
+		failures.push(format!("{source} {row_name} is missing latency"));
+		return;
+	};
+	if row.task.latency_sample_every > 0 && latency.sample_count == 0 {
+		failures.push(format!("{source} {row_name} is missing latency samples"));
+	}
+	if latency.p50_ms < 0.0
+		|| latency.p95_ms < 0.0
+		|| latency.p99_ms < 0.0
+		|| !latency.p50_ms.is_finite()
+		|| !latency.p95_ms.is_finite()
+		|| !latency.p99_ms.is_finite()
+	{
+		failures.push(format!("{source} {row_name} has invalid latency"));
+	}
+	if latency.p50_ms > latency.p95_ms || latency.p95_ms > latency.p99_ms {
+		failures.push(format!("{source} {row_name} has unordered latency quantiles"));
+	}
+	let Some(drain) = &row.drain else {
+		failures.push(format!("{source} {row_name} is missing drain"));
+		return;
+	};
+	if drain.elapsed_ms < 0.0 || !drain.elapsed_ms.is_finite() {
+		failures.push(format!("{source} {row_name} has invalid drain elapsed time"));
+	}
+	if drain.timed_out {
+		failures.push(format!("{source} {row_name} drain timed out"));
+	}
+}
+
+fn validate_steady_state_task(
+	row_name: &str,
+	task: &SteadyStateTask,
+	source: &str,
+	failures: &mut Vec<String>,
+) {
+	if task.records == 0 {
+		failures.push(format!("{source} {row_name} has zero records"));
+	}
+	if task.clients == 0 || task.threads == 0 {
+		failures.push(format!("{source} {row_name} has invalid concurrency"));
+	}
+	if task.measurement_secs == 0 {
+		failures.push(format!("{source} {row_name} has zero measurement duration"));
+	}
+	if task.worker_seed_derivation.is_empty()
+		|| task.operation_mix.is_empty()
+		|| task.key_selection.is_empty()
+	{
+		failures.push(format!("{source} {row_name} is missing task metadata"));
+	}
+	if task.operation_mix_period == 0 {
+		failures.push(format!("{source} {row_name} has zero operation mix period"));
+	}
+	if task.zipfian_exponent < 0.0 || !task.zipfian_exponent.is_finite() {
+		failures.push(format!("{source} {row_name} has invalid Zipfian exponent"));
+	}
+	let _ = (task.warmup_secs, task.latency_sample_every, task.seed);
+}
+
+fn validate_steady_state_comparable(
+	row_name: &str,
+	baseline: &SteadyStateRow,
+	current: &SteadyStateRow,
+	failures: &mut Vec<String>,
+) {
+	if baseline.database != current.database {
+		failures.push(format!("{row_name} database differs between baseline and current"));
+	}
+	if baseline.sync != current.sync {
+		failures.push(format!("{row_name} sync setting differs between baseline and current"));
+	}
+	if baseline.task != current.task {
+		failures.push(format!("{row_name} task metadata differs between baseline and current"));
+	}
+}
+
+fn validate_steady_state_phases(
+	row_name: &str,
+	row: &SteadyStateRow,
+	source: &str,
+	failures: &mut Vec<String>,
+) {
+	let phases = &row.phases;
+	for (phase_name, phase) in [
+		("prepare", &phases.prepare),
+		("warmup", &phases.warmup),
+		("measure", &phases.measure),
+		("drain", &phases.drain),
+		("cleanup", &phases.cleanup),
+	] {
+		if phase.elapsed_ms < 0.0 || !phase.elapsed_ms.is_finite() {
+			failures.push(format!("{source} {row_name} has invalid {phase_name} phase time"));
+		}
+		if !matches!(phase.status.as_str(), "completed" | "unsupported" | "failed") {
+			failures.push(format!(
+				"{source} {row_name} has invalid {phase_name} phase status {:?}",
+				phase.status
+			));
+		}
+		if row.status == "completed" && phase.status != "completed" {
+			failures.push(format!(
+				"{source} {row_name} completed row has non-completed {phase_name} phase"
+			));
+		}
+	}
+}
+
 fn validate_config(cfg: &GateConfig) -> Result<()> {
+	for row in cfg.rows.iter().chain(cfg.ratio_rows.iter()) {
+		if is_steady_state_row(row) {
+			bail!(
+				"steady-state row {row:?} requires a steady-state JSON or sidecar gate, not the legacy CSV-only perf-gate"
+			);
+		}
+	}
 	if cfg.max_sync_regression_pct < 0.0 {
 		bail!("--max-sync-regression-pct cannot be negative");
 	}
@@ -361,6 +873,47 @@ fn validate_config(cfg: &GateConfig) -> Result<()> {
 		);
 	}
 	Ok(())
+}
+
+fn validate_steady_state_config(cfg: &SteadyStateGateConfig) -> Result<()> {
+	if cfg.max_ops_regression_pct < 0.0 {
+		bail!("--max-sync-regression-pct cannot be negative");
+	}
+	if cfg.max_latency_regression_pct < 0.0 {
+		bail!("--max-latency-regression-pct cannot be negative");
+	}
+	if cfg.rows.is_empty() {
+		bail!("at least one steady-state row is required");
+	}
+	Ok(())
+}
+
+fn is_optional_unsupported(row_name: &str, status: &str, cfg: &SteadyStateGateConfig) -> bool {
+	status == "unsupported" && cfg.optional_rows.iter().any(|optional| optional == row_name)
+}
+
+fn is_steady_state_row(row: &str) -> bool {
+	row == "steady-state"
+		|| row.starts_with("[T]steady-state::")
+		|| row.starts_with("steady-state::")
+		|| matches!(
+			row,
+			"balanced_zipfian"
+				| "read_heavy_zipfian"
+				| "update_heavy_zipfian"
+				| "point_read_zipfian"
+				| "point_read_missing_in_range"
+				| "range_scan_uniform"
+				| "sustained_ingest"
+		)
+}
+
+fn required_steady_state_row<'a>(
+	rows: &'a SteadyStateRows,
+	row: &str,
+	source: &str,
+) -> Result<&'a SteadyStateRow> {
+	rows.get(row).ok_or_else(|| anyhow!("missing steady-state row {row:?} in {source} JSON"))
 }
 
 fn required_row<'a>(rows: &'a BenchCsv, row: &str, source: &str) -> Result<&'a BenchRow> {
@@ -402,6 +955,55 @@ Test,Total time,Mean,Max,99th,95th,75th,50th,25th,1st,Min,IQR,OPS,CPU_avg,CPU_mi
 [C]reate,1s,1.00 ms,2.00 ms,1.90 ms,1.80 ms,1.50 ms,1.00 ms,0.50 ms,0.10 ms,0.01 ms,1.00 ms,1000.00,0,0,0,0,0,0,0,0,0/0/0
 [B]atch::batch_create_1000 (100 batches of 1000),1s,1.00 ms,2.00 ms,1.90 ms,1.80 ms,1.50 ms,1.00 ms,0.50 ms,0.10 ms,0.01 ms,1.00 ms,500.00,0,0,0,0,0,0,0,0,0/0/0
 ";
+	const STEADY_STATE_JSON: &str = r#"{
+  "steady_state": [
+    {
+      "name": "balanced_zipfian",
+      "suite": "steady-state",
+      "database": "toykv",
+      "status": "completed",
+      "unsupported_reason": null,
+      "sync": true,
+      "task": {
+        "records": 100,
+        "clients": 1,
+        "threads": 1,
+        "warmup_secs": 0,
+        "measurement_secs": 1,
+        "latency_sample_every": 1,
+        "seed": 1,
+        "worker_seed_derivation": "splitmix64(seed ^ worker_index)",
+        "operation_mix": "read=1.000000",
+        "operation_mix_period": 1000,
+        "key_selection": "scrambled_zipfian",
+        "zipfian_exponent": 0.99
+      },
+      "phases": {
+        "prepare": { "elapsed_ms": 1.0, "status": "completed" },
+        "warmup": { "elapsed_ms": 0.0, "status": "completed" },
+        "measure": { "elapsed_ms": 1000.0, "status": "completed" },
+        "drain": { "elapsed_ms": 1.0, "status": "completed" },
+        "cleanup": { "elapsed_ms": 1.0, "status": "completed" }
+      },
+      "throughput": {
+        "completed_operations": 100,
+        "ops_per_sec": 1000.0,
+        "per_second_windows": [1000.0]
+      },
+      "latency": { "sample_count": 100, "p50_ms": 1.0, "p95_ms": 2.0, "p99_ms": 4.0 },
+      "validation": {
+        "errors": 0,
+        "read_hits": 100,
+        "read_misses": 0,
+        "updates": 0,
+        "scan_count_errors": 0,
+        "observed_mix": "read=1.000000",
+        "expected_mix_prefix": "read=100"
+      },
+      "drain": { "elapsed_ms": 1.0, "timed_out": false }
+    }
+  ]
+}"#;
 
 	#[test]
 	fn parses_crud_bench_csv_aliases() {
@@ -519,6 +1121,314 @@ Test,Total time,Mean,Max,99th,95th,75th,50th,25th,1st,Min,IQR,OPS,CPU_avg,CPU_mi
 		.expect_err("missing current latency CSV fails");
 
 		assert!(err.to_string().contains("--current-latency-sync"));
+	}
+
+	#[test]
+	fn rejects_steady_state_rows_in_legacy_gate() {
+		for row in ["balanced_zipfian", "read_heavy_zipfian", "update_heavy_zipfian"] {
+			let cfg = GateConfig {
+				rows: vec![row.into()],
+				ratio_rows: Vec::new(),
+				max_sync_regression_pct: 5.0,
+				min_ratio_improvements: 0,
+				max_latency_regression_pct: 5.0,
+			};
+
+			let err =
+				validate_config(&cfg).expect_err("steady-state rows need a steady-state gate");
+
+			assert!(err.to_string().contains("steady-state row"));
+		}
+	}
+
+	#[test]
+	fn default_steady_state_gate_includes_phase5_rows() {
+		let rows = steady_state_rows_to_evaluate(Vec::new(), &[]);
+
+		assert!(rows.contains(&"read_heavy_zipfian".to_string()));
+		assert!(rows.contains(&"update_heavy_zipfian".to_string()));
+	}
+
+	#[test]
+	fn optional_steady_state_rows_are_evaluated() {
+		let rows = steady_state_rows_to_evaluate(
+			vec!["balanced_zipfian".to_string()],
+			&["read_heavy_zipfian".to_string()],
+		);
+
+		assert_eq!(rows, vec!["balanced_zipfian", "read_heavy_zipfian"]);
+	}
+
+	#[test]
+	fn parses_steady_state_json_rows() {
+		let rows = parse_steady_state_json(STEADY_STATE_JSON.as_bytes()).expect("parse JSON");
+		let row = required_steady_state_row(&rows, "balanced_zipfian", "test").unwrap();
+
+		assert_eq!(row.status, "completed");
+		assert_eq!(row.throughput.as_ref().unwrap().completed_operations, 100);
+		assert_eq!(row.latency.as_ref().unwrap().sample_count, 100);
+	}
+
+	#[test]
+	fn passes_valid_steady_state_gate() {
+		let cfg = steady_state_cfg(&["balanced_zipfian"]);
+		let inputs = SteadyStateGateInputs {
+			baseline: steady_state_rows(&[steady_state_row("balanced_zipfian", 1000.0, 2.0, 4.0)]),
+			current: steady_state_rows(&[steady_state_row("balanced_zipfian", 980.0, 2.05, 4.1)]),
+		};
+
+		let eval = evaluate_steady_state(&cfg, &inputs).expect("gate evaluates");
+
+		assert!(eval.passed);
+		assert!(eval.report.contains("Result: PASS"));
+	}
+
+	#[test]
+	fn fails_invalid_steady_state_gate() {
+		let cfg = steady_state_cfg(&["balanced_zipfian"]);
+		let mut current = steady_state_row("balanced_zipfian", 900.0, 2.3, 4.5);
+		current.validation.as_mut().unwrap().errors = 1;
+		current.latency.as_mut().unwrap().sample_count = 0;
+		current.drain.as_mut().unwrap().timed_out = true;
+		let inputs = SteadyStateGateInputs {
+			baseline: steady_state_rows(&[steady_state_row("balanced_zipfian", 1000.0, 2.0, 4.0)]),
+			current: steady_state_rows(&[current]),
+		};
+
+		let eval = evaluate_steady_state(&cfg, &inputs).expect("gate evaluates");
+
+		assert!(!eval.passed);
+		assert!(eval.report.contains("validation errors"));
+		assert!(eval.report.contains("missing latency samples"));
+		assert!(eval.report.contains("drain timed out"));
+		assert!(eval.report.contains("OPS regressed -10.00%"));
+	}
+
+	#[test]
+	fn optional_unsupported_steady_state_row_is_skipped() {
+		let mut cfg = steady_state_cfg(&["range_scan_uniform"]);
+		cfg.optional_rows = vec!["range_scan_uniform".into()];
+		let row = unsupported_steady_state_row("range_scan_uniform", Some("NotSupported"));
+		let inputs = SteadyStateGateInputs {
+			baseline: steady_state_rows(std::slice::from_ref(&row)),
+			current: steady_state_rows(&[row]),
+		};
+
+		let eval = evaluate_steady_state(&cfg, &inputs).expect("gate evaluates");
+
+		assert!(eval.passed);
+	}
+
+	#[test]
+	fn optional_unsupported_steady_state_row_requires_reason() {
+		let mut cfg = steady_state_cfg(&["range_scan_uniform"]);
+		cfg.optional_rows = vec!["range_scan_uniform".into()];
+		let row = unsupported_steady_state_row("range_scan_uniform", None);
+		let inputs = SteadyStateGateInputs {
+			baseline: steady_state_rows(std::slice::from_ref(&row)),
+			current: steady_state_rows(&[row]),
+		};
+
+		let eval = evaluate_steady_state(&cfg, &inputs).expect("gate evaluates");
+
+		assert!(!eval.passed);
+		assert!(eval.report.contains("unsupported without a reason"));
+	}
+
+	#[test]
+	fn optional_unsupported_steady_state_row_must_match_both_artifacts() {
+		let mut cfg = steady_state_cfg(&["range_scan_uniform"]);
+		cfg.optional_rows = vec!["range_scan_uniform".into()];
+		let unsupported = unsupported_steady_state_row("range_scan_uniform", Some("NotSupported"));
+		let inputs = SteadyStateGateInputs {
+			baseline: steady_state_rows(&[steady_state_row(
+				"range_scan_uniform",
+				1000.0,
+				2.0,
+				4.0,
+			)]),
+			current: steady_state_rows(&[unsupported]),
+		};
+
+		let eval = evaluate_steady_state(&cfg, &inputs).expect("gate evaluates");
+
+		assert!(!eval.passed);
+		assert!(eval.report.contains("optional unsupported state differs"));
+	}
+
+	#[test]
+	fn rejects_negative_steady_state_latency() {
+		let cfg = steady_state_cfg(&["balanced_zipfian"]);
+		let inputs = SteadyStateGateInputs {
+			baseline: steady_state_rows(&[steady_state_row("balanced_zipfian", 1000.0, 2.0, 4.0)]),
+			current: steady_state_rows(&[steady_state_row("balanced_zipfian", 1000.0, -1.0, 4.0)]),
+		};
+
+		let eval = evaluate_steady_state(&cfg, &inputs).expect("gate evaluates");
+
+		assert!(!eval.passed);
+		assert!(eval.report.contains("invalid latency"));
+	}
+
+	#[test]
+	fn rejects_unordered_steady_state_latency() {
+		let cfg = steady_state_cfg(&["balanced_zipfian"]);
+		let inputs = SteadyStateGateInputs {
+			baseline: steady_state_rows(&[steady_state_row("balanced_zipfian", 1000.0, 2.0, 4.0)]),
+			current: steady_state_rows(&[steady_state_row("balanced_zipfian", 1000.0, 10.0, 4.0)]),
+		};
+
+		let eval = evaluate_steady_state(&cfg, &inputs).expect("gate evaluates");
+
+		assert!(!eval.passed);
+		assert!(eval.report.contains("unordered latency quantiles"));
+	}
+
+	#[test]
+	fn rejects_invalid_steady_state_throughput_windows() {
+		let cfg = steady_state_cfg(&["balanced_zipfian"]);
+		let mut current = steady_state_row("balanced_zipfian", 1000.0, 2.0, 4.0);
+		current.throughput.as_mut().unwrap().per_second_windows = vec![-1.0];
+		let inputs = SteadyStateGateInputs {
+			baseline: steady_state_rows(&[steady_state_row("balanced_zipfian", 1000.0, 2.0, 4.0)]),
+			current: steady_state_rows(&[current]),
+		};
+
+		let eval = evaluate_steady_state(&cfg, &inputs).expect("gate evaluates");
+
+		assert!(!eval.passed);
+		assert!(eval.report.contains("invalid throughput windows"));
+	}
+
+	#[test]
+	fn rejects_mismatched_steady_state_metadata() {
+		let cfg = steady_state_cfg(&["balanced_zipfian"]);
+		let baseline = steady_state_row("balanced_zipfian", 1000.0, 2.0, 4.0);
+		let mut current = steady_state_row("balanced_zipfian", 1000.0, 2.0, 4.0);
+		current.database = serde_json::Value::String("rocksdb".into());
+		current.sync = false;
+		current.task.measurement_secs = 2;
+		let inputs = SteadyStateGateInputs {
+			baseline: steady_state_rows(&[baseline]),
+			current: steady_state_rows(&[current]),
+		};
+
+		let eval = evaluate_steady_state(&cfg, &inputs).expect("gate evaluates");
+
+		assert!(!eval.passed);
+		assert!(eval.report.contains("database differs"));
+		assert!(eval.report.contains("sync setting differs"));
+		assert!(eval.report.contains("task metadata differs"));
+	}
+
+	#[test]
+	fn rejects_empty_steady_state_database() {
+		let cfg = steady_state_cfg(&["balanced_zipfian"]);
+		let mut current = steady_state_row("balanced_zipfian", 1000.0, 2.0, 4.0);
+		current.database = serde_json::Value::String(String::new());
+		let inputs = SteadyStateGateInputs {
+			baseline: steady_state_rows(&[steady_state_row("balanced_zipfian", 1000.0, 2.0, 4.0)]),
+			current: steady_state_rows(&[current]),
+		};
+
+		let eval = evaluate_steady_state(&cfg, &inputs).expect("gate evaluates");
+
+		assert!(!eval.passed);
+		assert!(eval.report.contains("invalid database field"));
+	}
+
+	#[test]
+	fn rejects_whitespace_steady_state_database() {
+		let cfg = steady_state_cfg(&["balanced_zipfian"]);
+		let mut current = steady_state_row("balanced_zipfian", 1000.0, 2.0, 4.0);
+		current.database = serde_json::Value::String("   ".into());
+		let inputs = SteadyStateGateInputs {
+			baseline: steady_state_rows(&[steady_state_row("balanced_zipfian", 1000.0, 2.0, 4.0)]),
+			current: steady_state_rows(&[current]),
+		};
+
+		let eval = evaluate_steady_state(&cfg, &inputs).expect("gate evaluates");
+
+		assert!(!eval.passed);
+		assert!(eval.report.contains("invalid database field"));
+	}
+
+	#[test]
+	fn optional_unsupported_rows_must_be_comparable() {
+		let mut cfg = steady_state_cfg(&["range_scan_uniform"]);
+		cfg.optional_rows = vec!["range_scan_uniform".into()];
+		let baseline = unsupported_steady_state_row("range_scan_uniform", Some("NotSupported"));
+		let mut current = unsupported_steady_state_row("range_scan_uniform", Some("NotSupported"));
+		current.database = serde_json::Value::String("rocksdb".into());
+		current.task.records = 999;
+		let inputs = SteadyStateGateInputs {
+			baseline: steady_state_rows(&[baseline]),
+			current: steady_state_rows(&[current]),
+		};
+
+		let eval = evaluate_steady_state(&cfg, &inputs).expect("gate evaluates");
+
+		assert!(!eval.passed);
+		assert!(eval.report.contains("database differs"));
+		assert!(eval.report.contains("task metadata differs"));
+	}
+
+	#[test]
+	fn rejects_completed_row_with_failed_phase() {
+		let cfg = steady_state_cfg(&["balanced_zipfian"]);
+		let mut current = steady_state_row("balanced_zipfian", 1000.0, 2.0, 4.0);
+		current.phases.cleanup.status = "failed".into();
+		let inputs = SteadyStateGateInputs {
+			baseline: steady_state_rows(&[steady_state_row("balanced_zipfian", 1000.0, 2.0, 4.0)]),
+			current: steady_state_rows(&[current]),
+		};
+
+		let eval = evaluate_steady_state(&cfg, &inputs).expect("gate evaluates");
+
+		assert!(!eval.passed);
+		assert!(eval.report.contains("completed row has non-completed cleanup phase"));
+	}
+
+	#[test]
+	fn rejects_partial_steady_state_json_schema() {
+		let json = r#"{
+  "steady_state": [
+    {
+      "name": "balanced_zipfian",
+      "status": "completed",
+      "task": { "latency_sample_every": 1 },
+      "throughput": {
+        "completed_operations": 100,
+        "ops_per_sec": 1000.0,
+        "per_second_windows": [1000.0]
+      },
+      "latency": { "sample_count": 100, "p95_ms": 2.0, "p99_ms": 4.0 },
+      "validation": { "errors": 0 },
+      "drain": { "timed_out": false }
+    }
+  ]
+}"#;
+
+		let err = parse_steady_state_json(json.as_bytes()).expect_err("partial schema fails");
+
+		assert!(err.to_string().contains("missing field"));
+	}
+
+	#[test]
+	fn steady_state_mode_requires_json_pair() {
+		let err =
+			Args::try_parse_from(["perf-gate", "--baseline-steady-state-json", "baseline.json"])
+				.expect("clap accepts partial steady-state mode");
+		assert!(err.baseline_steady_state_json.is_some());
+		assert!(err.current_steady_state_json.is_none());
+	}
+
+	#[test]
+	fn steady_state_row_flag_selects_steady_state_mode() {
+		let args = Args::try_parse_from(["perf-gate", "--steady-state-row", "balanced_zipfian"])
+			.expect("steady-state row flag parses");
+
+		assert!(uses_steady_state_mode(&args));
 	}
 
 	#[test]
@@ -734,5 +1644,114 @@ Test,Total time,Mean,Max,99th,95th,75th,50th,25th,1st,Min,IQR,OPS,CPU_avg,CPU_mi
 				)
 			})
 			.collect()
+	}
+
+	fn steady_state_cfg(rows: &[&str]) -> SteadyStateGateConfig {
+		SteadyStateGateConfig {
+			rows: rows.iter().map(|row| (*row).to_string()).collect(),
+			optional_rows: Vec::new(),
+			max_ops_regression_pct: 5.0,
+			max_latency_regression_pct: 5.0,
+		}
+	}
+
+	fn steady_state_rows(rows: &[SteadyStateRow]) -> SteadyStateRows {
+		rows.iter().cloned().map(|row| (row.name.clone(), row)).collect()
+	}
+
+	fn steady_state_row(name: &str, ops: f64, p95_ms: f64, p99_ms: f64) -> SteadyStateRow {
+		SteadyStateRow {
+			name: name.into(),
+			suite: "steady-state".into(),
+			database: serde_json::Value::String("toykv".into()),
+			status: "completed".into(),
+			unsupported_reason: None,
+			failure_reason: None,
+			sync: true,
+			task: SteadyStateTask {
+				records: 100,
+				clients: 1,
+				threads: 1,
+				warmup_secs: 0,
+				measurement_secs: 1,
+				latency_sample_every: 1,
+				seed: 1,
+				worker_seed_derivation: "splitmix64(seed ^ worker_index)".into(),
+				operation_mix: "read=1.000000".into(),
+				operation_mix_period: 1000,
+				key_selection: "scrambled_zipfian".into(),
+				zipfian_exponent: 0.99,
+			},
+			phases: completed_steady_state_phases(),
+			throughput: Some(SteadyStateThroughput {
+				completed_operations: 100,
+				ops_per_sec: ops,
+				per_second_windows: vec![ops],
+			}),
+			latency: Some(SteadyStateLatency {
+				sample_count: 100,
+				p50_ms: p95_ms / 2.0,
+				p95_ms,
+				p99_ms,
+			}),
+			validation: Some(SteadyStateValidation {
+				errors: 0,
+				read_hits: 100,
+				read_misses: 0,
+				updates: 0,
+				scan_count_errors: 0,
+				observed_mix: "read=1.000000".into(),
+				expected_mix_prefix: "read=100".into(),
+			}),
+			drain: Some(SteadyStateDrain {
+				elapsed_ms: 1.0,
+				timed_out: false,
+			}),
+		}
+	}
+
+	fn unsupported_steady_state_row(name: &str, reason: Option<&str>) -> SteadyStateRow {
+		SteadyStateRow {
+			name: name.into(),
+			suite: "steady-state".into(),
+			database: serde_json::Value::String("toykv".into()),
+			status: "unsupported".into(),
+			unsupported_reason: reason.map(str::to_string),
+			failure_reason: None,
+			sync: true,
+			task: SteadyStateTask {
+				records: 100,
+				clients: 1,
+				threads: 1,
+				warmup_secs: 0,
+				measurement_secs: 1,
+				latency_sample_every: 1,
+				seed: 1,
+				worker_seed_derivation: "splitmix64(seed ^ worker_index)".into(),
+				operation_mix: "scan=1.000000".into(),
+				operation_mix_period: 1000,
+				key_selection: "uniform".into(),
+				zipfian_exponent: 0.99,
+			},
+			phases: completed_steady_state_phases(),
+			throughput: None,
+			latency: None,
+			validation: None,
+			drain: None,
+		}
+	}
+
+	fn completed_steady_state_phases() -> SteadyStatePhases {
+		let phase = SteadyStatePhase {
+			elapsed_ms: 1.0,
+			status: "completed".into(),
+		};
+		SteadyStatePhases {
+			prepare: phase.clone(),
+			warmup: phase.clone(),
+			measure: phase.clone(),
+			drain: phase.clone(),
+			cleanup: phase,
+		}
 	}
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -66,6 +66,8 @@ pub(crate) enum Database {
 	Surrealkv,
 	#[cfg(feature = "surrealmx")]
 	Surrealmx,
+	#[cfg(feature = "toykv")]
+	Toykv,
 	/// SurrealDS - Multi-instance distributed SurrealDB benchmarking.
 	///
 	/// This option enables benchmarking against multiple SurrealDB instances simultaneously
@@ -546,6 +548,22 @@ impl Database {
 					)
 					.await
 			}
+			#[cfg(feature = "toykv")]
+			Database::Toykv => {
+				benchmark
+					.run::<_, DefaultDialect, _>(
+						crate::toykv::ToyKvClientProvider::setup(kt, vp.columns(), benchmark)
+							.await?,
+						kp,
+						vp,
+						scans,
+						batches,
+						database.clone(),
+						system.clone(),
+						metadata.clone(),
+					)
+					.await
+			}
 		}
 	}
 
@@ -591,6 +609,8 @@ impl Database {
 			Database::Surrealkv => "SurrealKV",
 			#[cfg(feature = "surrealmx")]
 			Database::Surrealmx => "SurrealMX",
+			#[cfg(feature = "toykv")]
+			Database::Toykv => "ToyKV",
 			#[cfg(feature = "surrealdb")]
 			Database::Surrealdb => "SurrealDB",
 			#[cfg(feature = "surrealdb2")]

--- a/src/database.rs
+++ b/src/database.rs
@@ -2,6 +2,7 @@ use crate::BatchOperation;
 use crate::KeyType;
 use crate::Scan;
 use crate::benchmark::Benchmark;
+#[allow(unused_imports)]
 use crate::dialect::{
 	AnsiSqlDialect, ArangoDBDialect, DefaultDialect, MariaDBDialect, MongoDBDialect, MySqlDialect,
 	Neo4jDialect, SurrealDBDialect,
@@ -93,6 +94,7 @@ impl Database {
 	}
 
 	/// Start the Docker container if necessary
+	#[allow(unreachable_code, unused_variables)]
 	pub(crate) fn start_docker(&self, options: &Benchmark) -> Option<Container> {
 		// Get any pre-defined Docker configuration
 		let params: DockerParams = match self {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -57,6 +57,11 @@ pub(crate) trait BenchmarkClient: Sync + Send + 'static {
 		Ok(())
 	}
 
+	/// Best-effort removal of steady-state benchmark keys in `[0, upper)`.
+	async fn reset_steady_state(&self, _upper: u32, _kp: &mut KeyProvider) -> Result<()> {
+		bail!(NOT_SUPPORTED_ERROR)
+	}
+
 	/// Create a single entry with the current client
 	fn create(
 		&self,

--- a/src/fjall.rs
+++ b/src/fjall.rs
@@ -17,6 +17,18 @@ use std::time::Duration;
 
 const DATABASE_DIR: &str = "fjall";
 
+fn reads_only() -> bool {
+	std::env::var("READS_ONLY").is_ok()
+}
+
+fn preserve_db() -> bool {
+	std::env::var("PRESERVE_DB").is_ok()
+}
+
+fn load_only() -> bool {
+	std::env::var("LOAD_ONLY").is_ok()
+}
+
 /// Calculate Fjall specific memory allocation
 fn calculate_fjall_memory() -> u64 {
 	// Load the system memory
@@ -40,8 +52,10 @@ impl BenchmarkEngine<FjallClient> for FjallClientProvider {
 	}
 	/// Initiates a new datastore benchmarking engine
 	async fn setup(_kt: KeyType, _columns: Columns, options: &Benchmark) -> Result<Self> {
-		// Cleanup the data directory
-		std::fs::remove_dir_all(DATABASE_DIR).ok();
+		// Cleanup the data directory (skip if READS_ONLY or PRESERVE_DB to reuse existing data)
+		if !reads_only() && !preserve_db() {
+			std::fs::remove_dir_all(DATABASE_DIR).ok();
+		}
 		// Calculate memory allocation
 		let memory = calculate_fjall_memory();
 		// Configure and create the database
@@ -99,7 +113,9 @@ impl BenchmarkClient for FjallClient {
 
 	async fn shutdown(&self) -> Result<()> {
 		// Cleanup the data directory
-		std::fs::remove_dir_all(DATABASE_DIR).ok();
+		if !reads_only() && !preserve_db() {
+			std::fs::remove_dir_all(DATABASE_DIR).ok();
+		}
 		// Ok
 		Ok(())
 	}
@@ -211,6 +227,9 @@ impl BenchmarkClient for FjallClient {
 
 impl FjallClient {
 	async fn create_bytes(&self, key: &[u8], val: BenchValue) -> Result<()> {
+		if reads_only() {
+			return Ok(());
+		}
 		// Serialise the value
 		let val = val.encode()?;
 		// Set the transaction durability
@@ -241,6 +260,9 @@ impl FjallClient {
 	}
 
 	async fn update_bytes(&self, key: &[u8], val: BenchValue) -> Result<()> {
+		if reads_only() {
+			return Ok(());
+		}
 		// Serialise the value
 		let val = val.encode()?;
 		// Set the transaction durability
@@ -258,6 +280,9 @@ impl FjallClient {
 	}
 
 	async fn delete_bytes(&self, key: &[u8]) -> Result<()> {
+		if reads_only() || load_only() {
+			return Ok(());
+		}
 		// Set the transaction durability
 		let durability = if self.sync {
 			Some(PersistMode::SyncData)
@@ -276,6 +301,9 @@ impl FjallClient {
 		&self,
 		key_vals: impl Iterator<Item = Result<(Vec<u8>, Vec<u8>)>>,
 	) -> Result<()> {
+		if reads_only() {
+			return Ok(());
+		}
 		// Set the transaction durability
 		let durability = if self.sync {
 			Some(PersistMode::SyncData)
@@ -316,6 +344,9 @@ impl FjallClient {
 		&self,
 		key_vals: impl Iterator<Item = Result<(Vec<u8>, Vec<u8>)>>,
 	) -> Result<()> {
+		if reads_only() {
+			return Ok(());
+		}
 		// Set the transaction durability
 		let durability = if self.sync {
 			Some(PersistMode::SyncData)
@@ -335,6 +366,9 @@ impl FjallClient {
 	}
 
 	async fn batch_delete_bytes(&self, keys: impl Iterator<Item = Vec<u8>>) -> Result<()> {
+		if reads_only() || load_only() {
+			return Ok(());
+		}
 		// Set the transaction durability
 		let durability = if self.sync {
 			Some(PersistMode::SyncData)

--- a/src/main.rs
+++ b/src/main.rs
@@ -845,7 +845,8 @@ fn run(args: Args) -> Result<()> {
 				#[cfg(feature = "surrealdb")]
 				{
 					match runtime.block_on(async {
-						let client = storage::StorageClient::connect(&args.storage_endpoint).await?;
+						let client =
+							storage::StorageClient::connect(&args.storage_endpoint).await?;
 						client.store_result(&res).await
 					}) {
 						Ok(_) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,6 @@ mod keyprovider;
 mod memory;
 mod profiling;
 mod result;
-mod storage;
 mod system;
 mod terminal;
 mod util;
@@ -58,11 +57,15 @@ mod rocksdb;
 mod scylladb;
 mod slatedb;
 mod sqlite;
+#[cfg(feature = "surrealdb")]
+mod storage;
+#[cfg(feature = "surrealdb")]
 mod surrealdb;
 mod surrealdb2;
 mod surrealds;
 mod surrealkv;
 mod surrealmx;
+mod toykv;
 
 /// Command-line interface for a single benchmark run.
 #[derive(Parser, Debug)]
@@ -163,6 +166,14 @@ pub(crate) struct Args {
 	/// Skip all batch benchmarks
 	#[arg(long, default_value = "false")]
 	pub(crate) skip_batches: bool,
+
+	/// Skip the delete phase (preserve data for subsequent read-only runs)
+	#[arg(long, default_value = "false")]
+	pub(crate) skip_deletes: bool,
+
+	/// Skip write phases (create, update, delete, batch create/update/delete) — read-only benchmark
+	#[arg(long, default_value = "false")]
+	pub(crate) skip_writes: bool,
 
 	/// Skip index operations, but still table scan queries
 	#[arg(long, default_value = "false")]
@@ -829,16 +840,23 @@ fn run(args: Args) -> Result<()> {
 			res.to_html_charts(&result_html_name, &name)?;
 			println!("📊 Interactive charts saved to: {}", result_html_name);
 
-			// Store results in SurrealDB if requested
+			// Store results in SurrealDB if requested and available in this build.
 			if args.store_results {
-				match runtime.block_on(async {
-					let client = storage::StorageClient::connect(&args.storage_endpoint).await?;
-					client.store_result(&res).await
-				}) {
-					Ok(_) => {
-						println!("💾 Results stored in SurrealDB at: {}", args.storage_endpoint)
+				#[cfg(feature = "surrealdb")]
+				{
+					match runtime.block_on(async {
+						let client = storage::StorageClient::connect(&args.storage_endpoint).await?;
+						client.store_result(&res).await
+					}) {
+						Ok(_) => {
+							println!("💾 Results stored in SurrealDB at: {}", args.storage_endpoint)
+						}
+						Err(e) => eprintln!("⚠️ Failed to store results in SurrealDB: {e}"),
 					}
-					Err(e) => eprintln!("⚠️ Failed to store results in SurrealDB: {e}"),
+				}
+				#[cfg(not(feature = "surrealdb"))]
+				{
+					eprintln!("⚠️ Result storage requires the `surrealdb` feature");
 				}
 			}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,34 @@
 //!
 //! Datastore implementations live in sibling modules; workload loading uses [`crate::config`].
 
+#![cfg_attr(
+	not(any(
+		feature = "arangodb",
+		feature = "dragonfly",
+		feature = "fjall",
+		feature = "keydb",
+		feature = "lmdb",
+		feature = "mariadb",
+		feature = "mdbx",
+		feature = "mongodb",
+		feature = "mysql",
+		feature = "neo4j",
+		feature = "postgres",
+		feature = "redb",
+		feature = "redis",
+		feature = "rocksdb",
+		feature = "scylladb",
+		feature = "slatedb",
+		feature = "sqlite",
+		feature = "surrealdb",
+		feature = "surrealdb2",
+		feature = "surrealkv",
+		feature = "surrealmx",
+		feature = "toykv"
+	)),
+	allow(dead_code)
+)]
+
 use crate::benchmark::Benchmark;
 use crate::config::load_bench_toml;
 use crate::database::Database;
@@ -119,6 +147,46 @@ pub(crate) struct Args {
 	#[arg(long, default_value = "false")]
 	pub(crate) sync: bool,
 
+	/// Benchmark suite to run
+	#[arg(long, value_enum, default_value_t = Suite::Crud)]
+	pub(crate) suite: Suite,
+
+	/// Steady-state workload name, or comma-separated workload names
+	#[arg(long)]
+	pub(crate) bench: Option<String>,
+
+	/// Steady-state scale preset
+	#[arg(long, value_enum, default_value_t = SteadyStatePreset::Default)]
+	pub(crate) preset: SteadyStatePreset,
+
+	/// Steady-state warmup duration in seconds
+	#[arg(long)]
+	pub(crate) warmup_secs: Option<u64>,
+
+	/// Steady-state measurement duration in seconds
+	#[arg(long)]
+	pub(crate) measurement_secs: Option<u64>,
+
+	/// Record one latency sample every N completed operations in steady-state runs
+	#[arg(long)]
+	pub(crate) latency_sample_every: Option<u64>,
+
+	/// Steady-state workload seed
+	#[arg(long, default_value_t = 1)]
+	pub(crate) seed: u64,
+
+	/// Zipfian exponent for steady-state Zipfian workloads
+	#[arg(long, default_value_t = 0.99)]
+	pub(crate) zipfian_exponent: f64,
+
+	/// Steady-state operation mix, e.g. read=0.5,update=0.5
+	#[arg(long)]
+	pub(crate) operation_mix: Option<String>,
+
+	/// Deterministic operation-mix scheduler period
+	#[arg(long, default_value_t = 1000)]
+	pub(crate) operation_mix_period: u32,
+
 	/// Per-operation timeout in seconds
 	#[arg(long, env = "CRUD_BENCH_OPERATION_TIMEOUT", default_value = "1800", value_parser=clap::value_parser!(u64).range(1..))]
 	pub(crate) operation_timeout: u64,
@@ -199,6 +267,19 @@ pub(crate) enum KeyType {
 	String506,
 	/// UUID type 7
 	Uuid,
+}
+
+#[derive(Debug, ValueEnum, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Suite {
+	Crud,
+	SteadyState,
+}
+
+#[derive(Debug, ValueEnum, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SteadyStatePreset {
+	Smoke,
+	Default,
+	Large,
 }
 
 /// Expanded scan benchmarks ready to execute (one [`Scan`] per row after multi-run expansion).
@@ -830,6 +911,14 @@ fn run(args: Args) -> Result<()> {
 				.map(|s| format!("result-{s}.csv"))
 				.unwrap_or_else(|| "result.csv".to_string());
 			res.to_csv(&result_csv_name)?;
+			if !res.steady_state.is_empty() {
+				let sidecar_name = args
+					.name
+					.as_ref()
+					.map(|s| format!("result-{s}-steady-state.csv"))
+					.unwrap_or_else(|| "result-steady-state.csv".to_string());
+				res.to_steady_state_sidecar_csv(&sidecar_name)?;
+			}
 
 			// Write the HTML chart file
 			let result_html_name = args
@@ -889,7 +978,7 @@ fn run(args: Args) -> Result<()> {
 /// Unit and integration-style tests for scan expansion and CLI wiring.
 mod test {
 	use crate::terminal::ColorChoice;
-	use crate::{Args, Database, KeyType, run};
+	use crate::{Args, Database, KeyType, SteadyStatePreset, Suite, run};
 	use anyhow::Result;
 	use serial_test::serial;
 
@@ -906,6 +995,16 @@ mod test {
 			threads: 2,
 			samples: 10000,
 			sync: false,
+			suite: Suite::Crud,
+			bench: None,
+			preset: SteadyStatePreset::Default,
+			warmup_secs: None,
+			measurement_secs: None,
+			latency_sample_every: None,
+			seed: 1,
+			zipfian_exponent: 0.99,
+			operation_mix: None,
+			operation_mix_period: 1000,
 			operation_timeout: 300,
 			persisted: false,
 			optimised: false,
@@ -919,6 +1018,8 @@ mod test {
 			storage_endpoint: "ws://localhost:8000".to_string(),
 			skip_scans: false,
 			skip_batches: false,
+			skip_deletes: false,
+			skip_writes: false,
 			skip_indexes: false,
 			emit_phase_markers: false,
 		})

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,5 +1,6 @@
 use crate::benchmark::NOT_SUPPORTED_ERROR;
 use crate::engine::{BenchmarkClient, BenchmarkEngine, ScanContext};
+use crate::keyprovider::{IntegerKeyProvider, KeyProvider, StringKeyProvider};
 use crate::value::BenchValue;
 use crate::valueprovider::Columns;
 use crate::{Benchmark, KeyType, Projection, Scan};
@@ -50,6 +51,32 @@ pub(crate) struct MapClient(MapDatabase);
 impl BenchmarkClient for MapClient {
 	// The return type when reading a row
 	type ReadRow = BenchValue;
+
+	async fn reset_steady_state(&self, upper: u32, kp: &mut KeyProvider) -> Result<()> {
+		match &self.0 {
+			MapDatabase::Integer(m) => {
+				for n in 0..upper {
+					let key = match kp {
+						KeyProvider::OrderedInteger(p) => p.key(n),
+						KeyProvider::UnorderedInteger(p) => p.key(n),
+						_ => bail!("Invalid KeyProvider variant"),
+					};
+					m.remove(&key);
+				}
+			}
+			MapDatabase::String(m) => {
+				for n in 0..upper {
+					let key = match kp {
+						KeyProvider::OrderedString(p) => p.key(n),
+						KeyProvider::UnorderedString(p) => p.key(n),
+						_ => bail!("Invalid KeyProvider variant"),
+					};
+					m.remove(&key);
+				}
+			}
+		}
+		Ok(())
+	}
 
 	async fn create_u32(&self, key: u32, val: BenchValue) -> Result<()> {
 		if let MapDatabase::Integer(m) = &self.0 {

--- a/src/result.rs
+++ b/src/result.rs
@@ -58,6 +58,9 @@ pub(crate) struct BenchmarkResult {
 	pub(crate) updates: Option<OperationResult>,
 	/// One entry per configured scan id (possibly multiple timed legs inside [`ScanResult::runs`]).
 	pub(crate) scans: Vec<ScanResult>,
+	/// Time-windowed steady-state rows.
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub(crate) steady_state: Vec<SteadyStateResult>,
 	/// `(batch_case_name, timed_iterations, records_per_batch, histogram_metrics_or_skip)`.
 	pub(crate) batches: Vec<(String, u32, usize, Option<OperationResult>)>,
 	/// Single-record delete phase.
@@ -65,6 +68,102 @@ pub(crate) struct BenchmarkResult {
 	/// Example document produced by the value template (for inspection / stored results).
 	#[serde(serialize_with = "serialize_sample")]
 	pub(crate) sample: BenchValue,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)]
+pub(crate) enum SteadyStateStatus {
+	Completed,
+	Unsupported,
+	Failed,
+}
+
+#[derive(Clone, Serialize)]
+pub(crate) struct SteadyStateTask {
+	pub(crate) records: u32,
+	pub(crate) clients: u32,
+	pub(crate) threads: u32,
+	pub(crate) warmup_secs: u64,
+	pub(crate) measurement_secs: u64,
+	pub(crate) latency_sample_every: u64,
+	pub(crate) seed: u64,
+	pub(crate) worker_seed_derivation: &'static str,
+	pub(crate) operation_mix: String,
+	pub(crate) operation_mix_period: u32,
+	pub(crate) key_selection: &'static str,
+	pub(crate) zipfian_exponent: f64,
+}
+
+#[derive(Clone, Serialize)]
+pub(crate) struct SteadyStatePhase {
+	pub(crate) elapsed_ms: f64,
+	pub(crate) status: SteadyStateStatus,
+}
+
+#[derive(Clone, Serialize)]
+pub(crate) struct SteadyStatePhases {
+	pub(crate) prepare: SteadyStatePhase,
+	pub(crate) warmup: SteadyStatePhase,
+	pub(crate) measure: SteadyStatePhase,
+	pub(crate) drain: SteadyStatePhase,
+	pub(crate) cleanup: SteadyStatePhase,
+}
+
+#[derive(Clone, Serialize)]
+pub(crate) struct SteadyStateThroughput {
+	pub(crate) completed_operations: u64,
+	pub(crate) ops_per_sec: f64,
+	pub(crate) per_second_windows: Vec<f64>,
+}
+
+#[derive(Clone, Serialize)]
+pub(crate) struct SteadyStateLatency {
+	pub(crate) sample_count: u64,
+	pub(crate) p50_ms: f64,
+	pub(crate) p95_ms: f64,
+	pub(crate) p99_ms: f64,
+}
+
+#[derive(Clone, Serialize)]
+pub(crate) struct SteadyStateValidation {
+	pub(crate) errors: u64,
+	pub(crate) read_hits: u64,
+	pub(crate) read_misses: u64,
+	pub(crate) updates: u64,
+	pub(crate) scan_count_errors: u64,
+	pub(crate) observed_mix: String,
+	pub(crate) expected_mix_prefix: String,
+}
+
+#[derive(Clone, Serialize)]
+pub(crate) struct SteadyStateDrain {
+	pub(crate) elapsed_ms: f64,
+	pub(crate) timed_out: bool,
+}
+
+#[derive(Serialize)]
+pub(crate) struct SteadyStateResult {
+	pub(crate) name: String,
+	pub(crate) suite: &'static str,
+	pub(crate) database: Option<String>,
+	pub(crate) status: SteadyStateStatus,
+	pub(crate) unsupported_reason: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub(crate) failure_reason: Option<String>,
+	pub(crate) sync: bool,
+	pub(crate) task: SteadyStateTask,
+	pub(crate) phases: SteadyStatePhases,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub(crate) throughput: Option<SteadyStateThroughput>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub(crate) latency: Option<SteadyStateLatency>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub(crate) validation: Option<SteadyStateValidation>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub(crate) drain: Option<SteadyStateDrain>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub(crate) operation_result: Option<OperationResult>,
 }
 
 /// Serialise a [`BenchValue`] through its JSON adapter so JSON consumers see the
@@ -283,6 +382,18 @@ impl Display for BenchmarkResult {
 				table.add_row(cells);
 			}
 		}
+		for row in &self.steady_state {
+			let label = format!("[T]steady-state::{}", row.name);
+			if row.status == SteadyStateStatus::Completed
+				&& let Some(res) = &row.operation_result
+			{
+				table.add_row(res.output(label));
+			} else {
+				let mut cells = vec![label];
+				cells.extend(SKIP.iter().map(|s| s.to_string()));
+				table.add_row(cells);
+			}
+		}
 		// Right align the `CPU` column
 		let column = table.column_mut(8).expect("The table needs at least 9 columns");
 		column.set_cell_alignment(CellAlignment::Right);
@@ -376,7 +487,78 @@ impl BenchmarkResult {
 				w.write_record(cells)?;
 			}
 		}
+		for row in &self.steady_state {
+			let label = format!("[T]steady-state::{}", row.name);
+			if row.status == SteadyStateStatus::Completed
+				&& let Some(res) = &row.operation_result
+			{
+				w.write_record(res.output_csv(label))?;
+			} else {
+				let mut cells = vec![label];
+				cells.extend(CSV_SKIP.iter().map(|s| s.to_string()));
+				w.write_record(cells)?;
+			}
+		}
 		// Ensure all data is flushed to the file
+		w.flush()?;
+		Ok(())
+	}
+
+	pub(crate) fn to_steady_state_sidecar_csv(&self, path: &str) -> Result<(), csv::Error> {
+		let mut w = Writer::from_path(path)?;
+		w.write_record([
+			"suite",
+			"row",
+			"database",
+			"status",
+			"unsupported_reason",
+			"failure_reason",
+			"sync",
+			"completed_operations",
+			"validation_errors",
+			"latency_sample_count",
+			"latency_sample_every",
+			"drain_elapsed_ms",
+			"drain_timed_out",
+			"operation_mix",
+			"key_selection",
+		])?;
+		for row in &self.steady_state {
+			let completed = row
+				.throughput
+				.as_ref()
+				.map(|t| t.completed_operations.to_string())
+				.unwrap_or_default();
+			let validation_errors =
+				row.validation.as_ref().map(|v| v.errors.to_string()).unwrap_or_default();
+			let latency_sample_count =
+				row.latency.as_ref().map(|l| l.sample_count.to_string()).unwrap_or_default();
+			let drain_elapsed =
+				row.drain.as_ref().map(|d| format!("{:.3}", d.elapsed_ms)).unwrap_or_default();
+			let drain_timed_out =
+				row.drain.as_ref().map(|d| d.timed_out.to_string()).unwrap_or_default();
+			w.write_record([
+				row.suite.to_string(),
+				row.name.clone(),
+				row.database.clone().unwrap_or_default(),
+				match row.status {
+					SteadyStateStatus::Completed => "completed".to_string(),
+					SteadyStateStatus::Unsupported => "unsupported".to_string(),
+					SteadyStateStatus::Failed => "failed".to_string(),
+				},
+				row.unsupported_reason.clone().unwrap_or_default(),
+				row.failure_reason.clone().unwrap_or_default(),
+				row.sync.to_string(),
+				completed,
+				validation_errors,
+				latency_sample_count,
+				row.task.latency_sample_every.to_string(),
+				drain_elapsed,
+				drain_timed_out,
+				row.task.operation_mix.clone(),
+				row.task.key_selection.to_string(),
+			])?;
+		}
 		w.flush()?;
 		Ok(())
 	}
@@ -481,13 +663,13 @@ impl StatsCollector {
 }
 
 /// Live [`sysinfo`] handle plus background polling used to build an [`OperationResult`].
-pub(super) struct OperationMetric {
+pub(crate) struct OperationMetric {
 	/// Shared system state for synchronous refresh calls.
 	system: System,
 	/// Process under test (benchmark worker or explicit `--pid`).
 	pid: Pid,
 	/// Logical operation count for OPS calculation.
-	samples: u32,
+	samples: u64,
 	/// Wall-clock start for elapsed time.
 	start_time: Instant,
 	/// Disk counters before the phase (subtracted for delta I/O).
@@ -502,7 +684,7 @@ pub(super) struct OperationMetric {
 
 impl OperationMetric {
 	/// Starts periodic polling for the given PID (defaults to current process).
-	pub(super) fn new(pid: Option<u32>, samples: u32) -> Self {
+	pub(crate) fn new(pid: Option<u32>, samples: u64) -> Self {
 		// We collect the PID
 		let pid = Pid::from(pid.unwrap_or_else(process::id) as usize);
 		let refresh_kind = ProcessRefreshKind::nothing().with_memory().with_cpu().with_disk_usage();
@@ -539,6 +721,10 @@ impl OperationMetric {
 		metric.monitor_handle = Some(monitor_handle);
 
 		metric
+	}
+
+	pub(crate) fn set_samples(&mut self, samples: u64) {
+		self.samples = samples;
 	}
 
 	/// Refreshes and returns the watched [`Process`], if still alive.
@@ -620,7 +806,7 @@ pub(crate) struct OperationResult {
 	/// Wall-clock duration of the whole phase.
 	elapsed: Duration,
 	/// Number of logical iterations aggregated into `histogram`.
-	samples: u32,
+	samples: u64,
 	/// Snapshot CPU at end of phase (normalised by core count).
 	cpu_usage: f32,
 	/// Min / max / avg from polled samples when available.

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -2,6 +2,7 @@
 
 use crate::benchmark::NOT_SUPPORTED_ERROR;
 use crate::engine::{BenchmarkClient, BenchmarkEngine, ScanContext};
+use crate::keyprovider::{IntegerKeyProvider, KeyProvider, StringKeyProvider};
 use crate::memory::Config;
 use crate::value::BenchValue;
 use crate::valueprovider::Columns;
@@ -206,6 +207,30 @@ impl BenchmarkClient for RocksDBClient {
 		// Wait for compaction to complete
 		self.db.wait_for_compact(&opts)?;
 		// Ok
+		Ok(())
+	}
+
+	async fn reset_steady_state(&self, upper: u32, kp: &mut KeyProvider) -> Result<()> {
+		for n in 0..upper {
+			match kp {
+				KeyProvider::OrderedInteger(p) => {
+					let key = p.key(n).to_ne_bytes();
+					self.delete_bytes(&key).await?;
+				}
+				KeyProvider::UnorderedInteger(p) => {
+					let key = p.key(n).to_ne_bytes();
+					self.delete_bytes(&key).await?;
+				}
+				KeyProvider::OrderedString(p) => {
+					let key = p.key(n).into_bytes();
+					self.delete_bytes(&key).await?;
+				}
+				KeyProvider::UnorderedString(p) => {
+					let key = p.key(n).into_bytes();
+					self.delete_bytes(&key).await?;
+				}
+			}
+		}
 		Ok(())
 	}
 

--- a/src/toykv.rs
+++ b/src/toykv.rs
@@ -1,0 +1,311 @@
+#![cfg(feature = "toykv")]
+
+use crate::benchmark::NOT_SUPPORTED_ERROR;
+use crate::engine::{BenchmarkClient, BenchmarkEngine, ScanContext};
+use crate::value::BenchValue;
+use crate::valueprovider::Columns;
+use crate::{Benchmark, KeyType, Projection, Scan};
+use anyhow::{Result, anyhow, bail};
+use std::hint::black_box;
+use std::sync::Arc;
+use std::time::Duration;
+use toykv::compact::{CompactionOptions, LeveledCompactionOptions};
+use toykv::lsm_storage::{KvEngine, LsmStorageOptions, WriteBatchRecord};
+use toykv::vlog::ValueSeparationOptions;
+
+const DATABASE_DIR: &str = "toykv_data";
+
+fn env_flag(name: &str) -> bool {
+	std::env::var(name).is_ok()
+}
+
+pub(crate) struct ToyKvClientProvider {
+	engine: Arc<KvEngine>,
+	reads_only: bool,
+	preserve_db: bool,
+	load_only: bool,
+}
+
+impl BenchmarkEngine<ToyKvClient> for ToyKvClientProvider {
+	fn wait_timeout(&self) -> Option<Duration> {
+		None
+	}
+
+	async fn setup(_kt: KeyType, _columns: Columns, options: &Benchmark) -> Result<Self> {
+		let reads_only = env_flag("READS_ONLY");
+		let preserve_db = env_flag("PRESERVE_DB");
+		let load_only = env_flag("LOAD_ONLY");
+
+		// Cleanup the data directory (skip if READS_ONLY or PRESERVE_DB to reuse existing data)
+		if !reads_only && !preserve_db {
+			std::fs::remove_dir_all(DATABASE_DIR).ok();
+		}
+
+		let compaction_opts = CompactionOptions::Leveled(LeveledCompactionOptions {
+			level0_file_num_compaction_trigger: 2,
+			max_levels: 4,
+			base_level_size_mb: 128,
+			level_size_multiplier: 2,
+		});
+
+		let storage_opts = LsmStorageOptions {
+			block_size: 64 * 1024,      // 64KB — match Fjall
+			target_sst_size: 256 << 20, // 256MB — match Fjall
+			num_memtable_limit: 50,
+			compaction_options: compaction_opts,
+			enable_wal: options.sync,
+			serializable: false,
+			value_separation: Some(ValueSeparationOptions {
+				enabled: true,
+				min_value_size: 4 * 1024, // 4KB — match Fjall
+				..Default::default()
+			}),
+			manifest_snapshot_threshold_bytes: 4 * 1024 * 1024,
+			block_cache_capacity: 524_288, // ~32GB with 64KB blocks, close to Fjall's ~46GB
+			enable_cache_backfill: true,
+			prefix_bloom: Default::default(),
+		};
+
+		let engine = KvEngine::open(DATABASE_DIR, storage_opts)?;
+
+		Ok(Self {
+			engine,
+			reads_only,
+			preserve_db,
+			load_only,
+		})
+	}
+
+	async fn create_client(&self) -> Result<ToyKvClient> {
+		Ok(ToyKvClient {
+			engine: self.engine.clone(),
+			reads_only: self.reads_only,
+			preserve_db: self.preserve_db,
+			load_only: self.load_only,
+		})
+	}
+}
+
+pub(crate) struct ToyKvClient {
+	engine: Arc<KvEngine>,
+	reads_only: bool,
+	preserve_db: bool,
+	load_only: bool,
+}
+
+impl BenchmarkClient for ToyKvClient {
+	type ReadRow = BenchValue;
+
+	async fn shutdown(&self) -> Result<()> {
+		self.engine.close()?;
+		if !self.reads_only && !self.preserve_db {
+			std::fs::remove_dir_all(DATABASE_DIR).ok();
+		}
+		Ok(())
+	}
+
+	async fn create_u32(&self, key: u32, val: BenchValue) -> Result<()> {
+		if self.reads_only {
+			return Ok(());
+		}
+		let encoded = val.encode()?;
+		self.engine.put(&key.to_ne_bytes(), &encoded)?;
+		Ok(())
+	}
+
+	async fn create_string(&self, key: String, val: BenchValue) -> Result<()> {
+		if self.reads_only {
+			return Ok(());
+		}
+		let encoded = val.encode()?;
+		self.engine.put(key.as_bytes(), &encoded)?;
+		Ok(())
+	}
+
+	async fn read_u32(&self, key: u32) -> Result<BenchValue> {
+		let res = self.engine.get(&key.to_ne_bytes())?;
+		let bytes = res.ok_or_else(|| anyhow!("key should exist"))?;
+		let val = BenchValue::decode(&bytes)?;
+		Ok(black_box(val))
+	}
+
+	async fn read_string(&self, key: String) -> Result<BenchValue> {
+		let res = self.engine.get(key.as_bytes())?;
+		let bytes = res.ok_or_else(|| anyhow!("key should exist"))?;
+		let val = BenchValue::decode(&bytes)?;
+		Ok(black_box(val))
+	}
+
+	async fn update_u32(&self, key: u32, val: BenchValue) -> Result<()> {
+		if self.reads_only {
+			return Ok(());
+		}
+		let encoded = val.encode()?;
+		self.engine.put(&key.to_ne_bytes(), &encoded)?;
+		Ok(())
+	}
+
+	async fn update_string(&self, key: String, val: BenchValue) -> Result<()> {
+		if self.reads_only {
+			return Ok(());
+		}
+		let encoded = val.encode()?;
+		self.engine.put(key.as_bytes(), &encoded)?;
+		Ok(())
+	}
+
+	async fn delete_u32(&self, key: u32) -> Result<()> {
+		if self.reads_only || self.load_only {
+			return Ok(());
+		}
+		self.engine.delete(&key.to_ne_bytes())?;
+		Ok(())
+	}
+
+	async fn delete_string(&self, key: String) -> Result<()> {
+		if self.reads_only || self.load_only {
+			return Ok(());
+		}
+		self.engine.delete(key.as_bytes())?;
+		Ok(())
+	}
+
+	async fn scan_u32(&self, scan: &Scan, _ctx: ScanContext) -> Result<usize> {
+		if scan.condition.is_some() {
+			bail!(NOT_SUPPORTED_ERROR);
+		}
+		self.do_scan(scan)
+	}
+
+	async fn scan_string(&self, scan: &Scan, _ctx: ScanContext) -> Result<usize> {
+		if scan.condition.is_some() {
+			bail!(NOT_SUPPORTED_ERROR);
+		}
+		self.do_scan(scan)
+	}
+
+	async fn batch_create_u32(
+		&self,
+		key_vals: impl Iterator<Item = (u32, BenchValue)> + Send,
+	) -> Result<()> {
+		if self.reads_only {
+			return Ok(());
+		}
+		let batch: Vec<WriteBatchRecord<Vec<u8>>> = key_vals
+			.map(|(k, v)| Ok(WriteBatchRecord::Put(k.to_ne_bytes().to_vec(), v.encode()?)))
+			.collect::<Result<_>>()?;
+		self.engine.write_batch(&batch)?;
+		Ok(())
+	}
+
+	async fn batch_create_string(
+		&self,
+		key_vals: impl Iterator<Item = (String, BenchValue)> + Send,
+	) -> Result<()> {
+		if self.reads_only {
+			return Ok(());
+		}
+		let batch: Vec<WriteBatchRecord<Vec<u8>>> = key_vals
+			.map(|(k, v)| Ok(WriteBatchRecord::Put(k.into_bytes(), v.encode()?)))
+			.collect::<Result<_>>()?;
+		self.engine.write_batch(&batch)?;
+		Ok(())
+	}
+
+	async fn batch_read_u32(&self, keys: impl Iterator<Item = u32> + Send) -> Result<()> {
+		let key_bytes: Vec<[u8; 4]> = keys.map(|k| k.to_ne_bytes()).collect();
+		let key_refs: Vec<&[u8]> = key_bytes.iter().map(|k| k.as_slice()).collect();
+		let results = self.engine.batch_get(&key_refs);
+		for res in results {
+			let bytes = res?.ok_or_else(|| anyhow!("key should exist"))?;
+			let val = BenchValue::decode(&bytes)?;
+			black_box(val);
+		}
+		Ok(())
+	}
+
+	async fn batch_read_string(&self, keys: impl Iterator<Item = String> + Send) -> Result<()> {
+		let key_owned: Vec<String> = keys.collect();
+		let key_refs: Vec<&[u8]> = key_owned.iter().map(|k| k.as_bytes()).collect();
+		let results = self.engine.batch_get(&key_refs);
+		for res in results {
+			let bytes = res?.ok_or_else(|| anyhow!("key should exist"))?;
+			let val = BenchValue::decode(&bytes)?;
+			black_box(val);
+		}
+		Ok(())
+	}
+
+	async fn batch_update_u32(
+		&self,
+		key_vals: impl Iterator<Item = (u32, BenchValue)> + Send,
+	) -> Result<()> {
+		if self.reads_only {
+			return Ok(());
+		}
+		let batch: Vec<WriteBatchRecord<Vec<u8>>> = key_vals
+			.map(|(k, v)| Ok(WriteBatchRecord::Put(k.to_ne_bytes().to_vec(), v.encode()?)))
+			.collect::<Result<_>>()?;
+		self.engine.write_batch(&batch)?;
+		Ok(())
+	}
+
+	async fn batch_update_string(
+		&self,
+		key_vals: impl Iterator<Item = (String, BenchValue)> + Send,
+	) -> Result<()> {
+		if self.reads_only {
+			return Ok(());
+		}
+		let batch: Vec<WriteBatchRecord<Vec<u8>>> = key_vals
+			.map(|(k, v)| Ok(WriteBatchRecord::Put(k.into_bytes(), v.encode()?)))
+			.collect::<Result<_>>()?;
+		self.engine.write_batch(&batch)?;
+		Ok(())
+	}
+
+	async fn batch_delete_u32(&self, keys: impl Iterator<Item = u32> + Send) -> Result<()> {
+		if self.reads_only || self.load_only {
+			return Ok(());
+		}
+		let batch: Vec<WriteBatchRecord<Vec<u8>>> =
+			keys.map(|k| WriteBatchRecord::Del(k.to_ne_bytes().to_vec())).collect();
+		self.engine.write_batch(&batch)?;
+		Ok(())
+	}
+
+	async fn batch_delete_string(&self, keys: impl Iterator<Item = String> + Send) -> Result<()> {
+		if self.reads_only || self.load_only {
+			return Ok(());
+		}
+		let batch: Vec<WriteBatchRecord<Vec<u8>>> =
+			keys.map(|k| WriteBatchRecord::Del(k.into_bytes())).collect();
+		self.engine.write_batch(&batch)?;
+		Ok(())
+	}
+}
+
+impl ToyKvClient {
+	fn do_scan(&self, scan: &Scan) -> Result<usize> {
+		let s = scan.start.unwrap_or(0);
+		let l = scan.limit.unwrap_or(usize::MAX);
+		let p = scan.projection()?;
+
+		// Full range scan
+		let mut iter = self.engine.scan(std::ops::Bound::Unbounded, std::ops::Bound::Unbounded)?;
+
+		if iter.skip_entries(s)? < s {
+			return Ok(0);
+		}
+
+		match p {
+			Projection::Id => iter.visit_keys(l, |key| {
+				black_box(key);
+			}),
+			Projection::Full => iter.visit_values(l, |value| {
+				black_box(value);
+			}),
+			Projection::Count => iter.count_entries(l),
+		}
+	}
+}

--- a/src/toykv.rs
+++ b/src/toykv.rs
@@ -2,6 +2,7 @@
 
 use crate::benchmark::NOT_SUPPORTED_ERROR;
 use crate::engine::{BenchmarkClient, BenchmarkEngine, ScanContext};
+use crate::keyprovider::{IntegerKeyProvider, KeyProvider, StringKeyProvider};
 use crate::value::BenchValue;
 use crate::valueprovider::Columns;
 use crate::{Benchmark, KeyType, Projection, Scan};
@@ -100,6 +101,29 @@ impl BenchmarkClient for ToyKvClient {
 		self.engine.close()?;
 		if !self.reads_only && !self.preserve_db {
 			std::fs::remove_dir_all(DATABASE_DIR).ok();
+		}
+		Ok(())
+	}
+
+	async fn reset_steady_state(&self, upper: u32, kp: &mut KeyProvider) -> Result<()> {
+		if self.reads_only || self.load_only {
+			bail!(NOT_SUPPORTED_ERROR);
+		}
+		for n in 0..upper {
+			match kp {
+				KeyProvider::OrderedInteger(p) => {
+					self.engine.delete(&p.key(n).to_ne_bytes())?;
+				}
+				KeyProvider::UnorderedInteger(p) => {
+					self.engine.delete(&p.key(n).to_ne_bytes())?;
+				}
+				KeyProvider::OrderedString(p) => {
+					self.engine.delete(p.key(n).as_bytes())?;
+				}
+				KeyProvider::UnorderedString(p) => {
+					self.engine.delete(p.key(n).as_bytes())?;
+				}
+			}
 		}
 		Ok(())
 	}


### PR DESCRIPTION
## Summary

Implement the steady-state backend comparison RFC across crud-bench, including ToyKV integration and a machine-readable performance gate.

## Changes

- Add steady-state workload scheduling for read, mixed, scan, ingest, and follow-up rows.
- Add ToyKV adapter support for the RFC 018 write-perf JSON output.
- Add steady-state result, CSV, and benchmark metadata surfaces.
- Add strict perf-gate validation for paired baseline/current artifacts, throughput, latency, metadata, and unsupported rows.
- Update README and RFC documentation with the runnable workflow and gate contract.
- Include the corrected default workload regression test and the rand_chacha lockfile entry.

The ToyKV side is implemented in ben1009/toy-kv-engine#235.

## Verification

- cargo fmt --all --check
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- cargo test --workspace --all-features

All local checks pass: 58 main tests and 37 perf-gate tests.