### PR TITLE
Add recall@k to the vector benchmark, scored against a shared exact oracle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,7 +487,12 @@ jobs:
           DOCKER_POST_ARGS: ${{ matrix.DOCKER_POST_ARGS || '' }}
 
       - name: Run benchmarks (10,000 samples / 12 clients / 4 threads / key string26 / random)
-        timeout-minutes: 5
+        # Raised from 5 while surrealdb 3.2.4 is pinned: it regresses full-table
+        # COUNT scans on embedded RocksDB by ~11x with string keys (2m 33s against
+        # 13s on 3.0.5), which alone consumes half the original budget. See #286.
+        # The regression is visible in the benchmark's own reported numbers; this
+        # timeout only exists to catch hangs. Revert to 5 once 3.3.0-beta.4 lands.
+        timeout-minutes: 10
         if: ${{ matrix.enabled && (success() || failure()) }}
         run: |
           # Kill and remove any existing crud-bench container
@@ -509,7 +514,12 @@ jobs:
           DOCKER_POST_ARGS: ${{ matrix.DOCKER_POST_ARGS || '' }}
 
       - name: Run benchmarks (10,000 samples / 12 clients / 4 threads / key string90 / random)
-        timeout-minutes: 5
+        # Raised from 5 while surrealdb 3.2.4 is pinned: it regresses full-table
+        # COUNT scans on embedded RocksDB by ~11x with string keys (2m 33s against
+        # 13s on 3.0.5), which alone consumes half the original budget. See #286.
+        # The regression is visible in the benchmark's own reported numbers; this
+        # timeout only exists to catch hangs. Revert to 5 once 3.3.0-beta.4 lands.
+        timeout-minutes: 10
         if: ${{ matrix.enabled && (success() || failure()) }}
         run: |
           # Kill and remove any existing crud-bench container

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,11 @@ result.html
 result-*.csv
 result-*.json
 result-*.html
+
+# -----------------------------------
+# crud-bench
+# -----------------------------------
+
+# Cached vector-search ground truth (a pure function of the corpus and query
+# seeds, so it is always reproducible and never worth committing)
+.crud-bench-gt/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,17 +61,19 @@ dependencies = [
 
 [[package]]
 name = "affinitypool"
-version = "0.8.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a487a26c23775316bc010e9425fd7cf046c384ab37efbb2cfd4ba87a58f68c6d"
+checksum = "c4a46f56d354df11b6bcd8ca4f84fa03ac816cc41c72568a1b337d8f7e5af90e"
 dependencies = [
  "arc-swap",
  "async-task",
  "crossbeam-deque",
  "crossbeam-utils",
+ "libc",
  "num_cpus",
  "parking_lot",
  "thiserror 2.0.18",
+ "winapi",
 ]
 
 [[package]]
@@ -438,6 +440,28 @@ dependencies = [
  "rustix",
  "slab",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1584,7 +1608,7 @@ dependencies = [
  "serial_test",
  "slatedb",
  "surrealdb 2.6.5",
- "surrealdb 3.3.0-beta.3",
+ "surrealdb 3.2.4",
  "surrealdb-rocksdb",
  "surrealkv 0.21.4",
  "surrealmx 0.18.0",
@@ -1968,9 +1992,9 @@ dependencies = [
 
 [[package]]
 name = "diskann"
-version = "0.55.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31a7680a192e1abc16cb70415cb6c1aa4c4cf3269294ce2583c5d81763ee9762"
+checksum = "421c6cf955c6cb1451d36c8a3740ab2a22880265d0fa93d8ea22cbc425c90479"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1988,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "diskann-utils"
-version = "0.55.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e2d755436dbe7141db9d2311ba99e885126003251d9392d5e41768548df777a"
+checksum = "7cdf7d491910fbff13338e07460c9197a3c172268cfd4d8f8e69e5cec5a256d9"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -2005,9 +2029,9 @@ dependencies = [
 
 [[package]]
 name = "diskann-vector"
-version = "0.55.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf19284b35e697b4c49e71306425490b526ebe70b5602eb06d19c3013fb5138c"
+checksum = "de1643bbece645f03527ef120bc7dd5e4e40557980dbe52ee51129adfb58a851"
 dependencies = [
  "cfg-if",
  "diskann-wide",
@@ -2016,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "diskann-wide"
-version = "0.55.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3f814c2b66a98968630b7ad31afbb3c5e62b94b26f80542878eb7440aa8e5d"
+checksum = "421f02c42e57a2153dc65b66b4b95fe2be56e14bf9f95253b663abcac8521166"
 dependencies = [
  "cfg-if",
  "half",
@@ -2904,6 +2928,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3901269ec6d4f6068d3f09e5f02f995bd076398dcd1dfec407cd230b02d11b"
 dependencies = [
+ "earcutr",
  "float_next_after",
  "geo-types",
  "geographiclib-rs",
@@ -2915,6 +2940,7 @@ dependencies = [
  "rstar 0.12.2",
  "serde",
  "sif-itree",
+ "spade",
 ]
 
 [[package]]
@@ -2925,6 +2951,7 @@ checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
 dependencies = [
  "approx 0.5.1",
  "num-traits",
+ "rayon",
  "rstar 0.10.0",
  "rstar 0.11.0",
  "rstar 0.12.2",
@@ -3480,7 +3507,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs 0.8.3",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -3566,6 +3592,7 @@ dependencies = [
  "i_key_sort",
  "i_shape",
  "i_tree",
+ "rayon",
 ]
 
 [[package]]
@@ -4266,38 +4293,6 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
-
-[[package]]
-name = "logos"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
-dependencies = [
- "logos-derive",
-]
-
-[[package]]
-name = "logos-codegen"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
-dependencies = [
- "fnv",
- "proc-macro2",
- "quote",
- "regex-automata",
- "regex-syntax",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "logos-derive"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
-dependencies = [
- "logos-codegen",
-]
 
 [[package]]
 name = "lru"
@@ -5179,30 +5174,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
  "bytes",
  "chrono",
- "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-util",
  "http",
- "http-body-util",
- "httparse",
  "humantime",
- "hyper",
  "itertools 0.14.0",
- "md-5 0.10.6",
  "parking_lot",
  "percent-encoding",
- "quick-xml 0.39.4",
- "rand 0.10.1",
- "reqwest 0.12.28",
- "ring",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5820,9 +5801,9 @@ dependencies = [
  "log",
  "nix 0.26.4",
  "once_cell",
- "prost",
+ "prost 0.12.6",
  "prost-build",
- "prost-derive",
+ "prost-derive 0.12.6",
  "sha2 0.10.9",
  "smallvec",
  "spin 0.10.0",
@@ -5936,7 +5917,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
@@ -5953,8 +5944,8 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "regex",
  "syn 2.0.117",
  "tempfile",
@@ -5974,12 +5965,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost",
+ "prost 0.12.6",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -6025,16 +6038,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.39.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
-dependencies = [
- "memchr",
- "serde",
 ]
 
 [[package]]
@@ -6438,7 +6441,6 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -7905,9 +7907,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb"
-version = "3.3.0-beta.3"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5050f1cdaf068fccef830f7bb80a9dd79f23c071331ab00428936b924747b6ea"
+checksum = "01fef5cc04dd6cb042391d48c0f78a586c56042e999f8cb17f0b97b0a147e2c0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -7925,18 +7927,13 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "surrealdb-engine-api",
- "surrealdb-engine-local",
- "surrealdb-iam",
- "surrealdb-kvs",
- "surrealdb-rpc",
+ "surrealdb-core 3.2.4",
  "surrealdb-types",
  "surrealdb-types-derive",
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tokio-tungstenite-wasm",
  "tokio-util",
- "tonic",
  "tracing",
  "url",
  "uuid",
@@ -7947,74 +7944,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "surrealdb-catalog"
-version = "3.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8a905b94eee033a021f918f3a9a3ba3c367f6d23fa7d7995c0a67fd93f2c2f"
-dependencies = [
- "ahash 0.8.12",
- "anyhow",
- "chrono",
- "md-5 0.10.6",
- "revision 0.30.0",
- "serde",
- "sha2 0.10.9",
- "storekey 0.11.0",
- "surrealdb-collections",
- "surrealdb-common",
- "surrealdb-expr",
- "surrealdb-iam",
- "surrealdb-kvs",
- "surrealdb-sql",
- "surrealdb-strand",
- "surrealdb-syn",
- "surrealdb-types",
- "thiserror 2.0.18",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "surrealdb-cnf"
-version = "3.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b572e1e1086b00aa9f6b51313ffc60f812acf77c13995bb7aa08cd4cb8a0a43d"
-dependencies = [
- "num-traits",
- "path-clean",
- "surrealdb-common",
- "surrealdb-parse-common",
- "tracing",
-]
-
-[[package]]
 name = "surrealdb-collections"
-version = "3.3.0-beta.3"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a9fbf8cf66deac85604942d841a39803c853955925aae1d57fdf646ee53b7e"
+checksum = "ca3472955f9692427583e78476d5b03c6f750bf11dc8a04383e0d365d7bd5d99"
 dependencies = [
  "revision 0.30.0",
  "storekey 0.11.0",
-]
-
-[[package]]
-name = "surrealdb-common"
-version = "3.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "798232be02e321616d3246035fb9c6d670c352acea4381b2b67750d820e5e74d"
-dependencies = [
- "chrono",
- "futures",
- "hashbrown 0.16.1",
- "parking_lot",
- "phf 0.13.1",
- "rust_decimal",
- "surrealdb-types",
- "sysinfo 0.37.2",
- "thiserror 2.0.18",
- "tokio",
- "unicase",
- "wasmtimer 0.4.3",
 ]
 
 [[package]]
@@ -8112,39 +8048,58 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-core"
-version = "3.3.0-beta.3"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e17d94f447dc357cc6bbb3e1eebfb6214c5329549aa61794a1c9e4dd9b48af6"
+checksum = "8cd76c36f8b545a9371eec050bb2ae83750a6f60bae8c6d92d06956943348f4c"
 dependencies = [
+ "addr",
+ "affinitypool 0.7.0",
  "ahash 0.8.12",
+ "ammonia",
  "anyhow",
- "arc-swap",
  "argon2",
  "async-channel",
+ "async-stream",
  "base64 0.22.1",
  "bcrypt 0.18.0",
+ "blake3",
  "bytes",
  "chrono",
  "ciborium",
  "dashmap 6.2.1",
+ "deunicode",
+ "diskann",
+ "diskann-utils",
+ "diskann-vector",
+ "dmp",
  "ext-sort",
+ "fastnum",
+ "fst",
  "futures",
+ "fuzzy-matcher",
  "geo 0.32.0",
  "geo-types",
  "getrandom 0.3.4",
+ "half",
  "headers",
  "hex",
  "http",
+ "humantime",
  "ipnet",
  "jsonwebtoken 10.4.0",
+ "lexicmp 0.2.0",
  "md-5 0.10.6",
  "memchr",
  "mime",
+ "ndarray 0.17.2",
+ "ndarray-stats 0.7.0",
+ "num-traits",
  "num_cpus",
  "object_store 0.13.2",
  "parking_lot",
  "path-clean",
  "pbkdf2",
+ "phf 0.13.1",
  "pin-project-lite",
  "quick_cache 0.6.22",
  "rand 0.9.4",
@@ -8155,6 +8110,7 @@ dependencies = [
  "revision 0.30.0",
  "ring",
  "roaring 0.11.4",
+ "rust-stemmers",
  "rust_decimal",
  "scrypt",
  "semver",
@@ -8163,313 +8119,29 @@ dependencies = [
  "sha1",
  "sha2 0.10.9",
  "storekey 0.11.0",
+ "strsim",
  "subtle",
- "surrealdb-catalog",
- "surrealdb-cnf",
  "surrealdb-collections",
- "surrealdb-common",
- "surrealdb-datastore",
- "surrealdb-expr",
- "surrealdb-iam",
- "surrealdb-idx",
- "surrealdb-kvs",
- "surrealdb-kvs-any",
- "surrealdb-observe",
- "surrealdb-rpc",
- "surrealdb-runtime",
- "surrealdb-sql",
+ "surrealdb-protocol",
+ "surrealdb-rocksdb",
  "surrealdb-strand",
- "surrealdb-syn",
  "surrealdb-types",
+ "surrealkv 0.21.4",
+ "surrealmx 0.22.0",
  "sysinfo 0.37.2",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
+ "ulid",
+ "unicase",
  "url",
  "uuid",
- "wasm-bindgen-futures",
- "wasmtimer 0.4.3",
- "web-time",
-]
-
-[[package]]
-name = "surrealdb-datastore"
-version = "3.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dadd311115f3dc19a5fdb30693b60dea046c4eb27b8c7f4ce380db187b33c1f"
-dependencies = [
- "anyhow",
- "blake3",
- "bytes",
- "chrono",
- "parking_lot",
- "quick_cache 0.6.22",
- "rand 0.9.4",
- "revision 0.30.0",
- "roaring 0.11.4",
- "semver",
- "serde",
- "storekey 0.11.0",
- "surrealdb-catalog",
- "surrealdb-cnf",
- "surrealdb-collections",
- "surrealdb-common",
- "surrealdb-expr",
- "surrealdb-iam",
- "surrealdb-keyspace-macro",
- "surrealdb-kvs",
- "surrealdb-observe",
- "surrealdb-rpc",
- "surrealdb-strand",
- "surrealdb-types",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
- "uuid",
- "web-time",
-]
-
-[[package]]
-name = "surrealdb-engine-api"
-version = "3.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db11b9d7f9545ebb9e6f74683efcd3919d63f19a4a3f5210b6ed79ffbc9398c2"
-dependencies = [
- "async-channel",
- "surrealdb-rpc",
- "surrealdb-types",
- "tokio",
- "uuid",
-]
-
-[[package]]
-name = "surrealdb-engine-local"
-version = "3.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59d72a2bab1783046b7ade6cbb9313ce69a6d996856e4bffc4c699332341673d"
-dependencies = [
- "anyhow",
- "async-channel",
- "futures",
- "surrealdb-cnf",
- "surrealdb-core 3.3.0-beta.3",
- "surrealdb-datastore",
- "surrealdb-engine-api",
- "surrealdb-iam",
- "surrealdb-kvs",
- "surrealdb-rpc",
- "surrealdb-types",
- "tokio",
- "tokio-util",
- "tracing",
- "uuid",
- "wasm-bindgen-futures",
- "wasmtimer 0.4.3",
-]
-
-[[package]]
-name = "surrealdb-expr"
-version = "3.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb78c38d50f2c9fb9e70d3c36175fafcb353d53e37de2f474a9ce37fe1003a72"
-dependencies = [
- "anyhow",
- "bytes",
- "chrono",
- "dmp",
- "fastnum",
- "geo 0.32.0",
- "geo-types",
- "half",
- "hex",
- "http",
- "jsonwebtoken 10.4.0",
- "lexicmp 0.2.0",
- "quick_cache 0.6.22",
- "rand 0.9.4",
- "reblessive",
- "regex",
- "revision 0.30.0",
- "rust_decimal",
- "serde",
- "serde_json",
- "storekey 0.11.0",
- "surrealdb-cnf",
- "surrealdb-collections",
- "surrealdb-common",
- "surrealdb-iam",
- "surrealdb-kvs",
- "surrealdb-sql",
- "surrealdb-strand",
- "surrealdb-syn",
- "surrealdb-types",
- "thiserror 2.0.18",
- "tracing",
- "ulid",
- "uuid",
-]
-
-[[package]]
-name = "surrealdb-iam"
-version = "3.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686e7845e61176696fe66b6bd5406a08d75a6c8abc687fe7a198b3507fa334c9"
-dependencies = [
- "anyhow",
- "argon2",
- "base64 0.22.1",
- "hmac 0.12.1",
- "pbkdf2",
- "rand_core 0.6.4",
- "revision 0.30.0",
- "serde",
- "sha2 0.10.9",
- "stringprep",
- "subtle",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "surrealdb-idx"
-version = "3.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9896715c164f28e094cd13959100bd3c73ec0c7db871416b12cc3d62036712f6"
-dependencies = [
- "ahash 0.8.12",
- "anyhow",
- "bytes",
- "dashmap 6.2.1",
- "deunicode",
- "diskann",
- "diskann-utils",
- "diskann-vector",
- "fst",
- "half",
- "ndarray 0.17.2",
- "ndarray-stats 0.7.0",
- "parking_lot",
- "quick_cache 0.6.22",
- "rand 0.9.4",
- "reblessive",
- "roaring 0.11.4",
- "rust-stemmers",
- "storekey 0.11.0",
- "surrealdb-catalog",
- "surrealdb-cnf",
- "surrealdb-common",
- "surrealdb-datastore",
- "surrealdb-expr",
- "surrealdb-kvs",
- "surrealdb-runtime",
- "surrealdb-strand",
- "surrealdb-types",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "uuid",
  "vart 0.9.3",
+ "wasm-bindgen-futures",
+ "wasmtimer 0.4.3",
  "web-time",
-]
-
-[[package]]
-name = "surrealdb-keyspace-macro"
-version = "3.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2560b41072360fc86125218c939ba336ad67255d71bb1aa54edec90e9d7c6825"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "surrealdb-kvs"
-version = "3.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9fe1568dadb47339b704ff60d39f3630db6c47145a2619c085a7b245c0d31f"
-dependencies = [
- "affinitypool 0.8.0",
- "anyhow",
- "chrono",
- "num_cpus",
- "revision 0.30.0",
- "roaring 0.11.4",
- "surrealdb-cnf",
- "surrealdb-common",
- "surrealdb-types",
- "thiserror 2.0.18",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "surrealdb-kvs-any"
-version = "3.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db79a007b98f562376ac0153a4c5626e3a589208fdb7eeba64f0000505644488"
-dependencies = [
- "surrealdb-cnf",
- "surrealdb-kvs",
- "surrealdb-kvs-mem",
- "surrealdb-kvs-rocksdb",
- "surrealdb-kvs-surrealkv",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "surrealdb-kvs-mem"
-version = "3.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ddd30699c4001f3837eebadac02094742d4b203cf36c7763d0571d5fdd41bed"
-dependencies = [
- "affinitypool 0.8.0",
- "chrono",
- "surrealdb-cnf",
- "surrealdb-kvs",
- "surrealmx 0.24.0",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "surrealdb-kvs-rocksdb"
-version = "3.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b99f58caa5c45b726e1ccdf5fffd80c03e6caf98a03dcdc08570e90ca576533"
-dependencies = [
- "affinitypool 0.8.0",
- "futures",
- "num_cpus",
- "parking_lot",
- "surrealdb-cnf",
- "surrealdb-common",
- "surrealdb-kvs",
- "surrealdb-rocksdb",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "surrealdb-kvs-surrealkv"
-version = "3.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb733b085b9c30ee18b8a1b911b0089b255eeafff46f119ae1329d38aefe7e62"
-dependencies = [
- "affinitypool 0.8.0",
- "chrono",
- "parking_lot",
- "surrealdb-cnf",
- "surrealdb-common",
- "surrealdb-kvs",
- "surrealkv 0.21.4",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -8488,44 +8160,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "surrealdb-observe"
-version = "3.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f84dec988fac06d788857cf01198fca44ffb2071ee483737eaf14f3c18725c"
-dependencies = [
- "surrealdb-iam",
- "surrealdb-rpc",
- "surrealdb-types",
- "uuid",
-]
-
-[[package]]
-name = "surrealdb-parse-common"
-version = "3.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44e6eb52a9a799833075674272f51cf747d8780a26ae718d8ad57b8eee62b3a"
-dependencies = [
- "chrono",
- "logos",
- "uuid",
-]
-
-[[package]]
 name = "surrealdb-protocol"
-version = "0.13.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53501c853fe88d5ead8e50612d310b43389f3c66fda7ef323a1af6c393809c6"
+checksum = "3f4e06f586c9179a02349b88b0c18e3a0850c55431aa513e0cd66529c00da1af"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
  "chrono",
  "flatbuffers",
+ "futures",
  "geo 0.32.0",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "rust_decimal",
  "semver",
  "serde",
  "serde_json",
+ "tonic",
+ "tonic-prost",
  "uuid",
 ]
 
@@ -8540,95 +8194,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "surrealdb-rpc"
-version = "3.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c6258773eff54ec7b1303e526f5717e96a1b28a310111573a0427048e807d4"
-dependencies = [
- "anyhow",
- "humantime",
- "ipnet",
- "revision 0.30.0",
- "serde",
- "surrealdb-cnf",
- "surrealdb-common",
- "surrealdb-iam",
- "surrealdb-types",
- "thiserror 2.0.18",
- "tracing",
- "url",
- "uuid",
- "web-time",
-]
-
-[[package]]
-name = "surrealdb-runtime"
-version = "3.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17af38b22610ae3f8eec2c9f6a6b3c9db8ec320c6981495e44f09fe7b7b2f54d"
-dependencies = [
- "addr",
- "ammonia",
- "anyhow",
- "argon2",
- "bcrypt 0.18.0",
- "blake3",
- "chrono",
- "deunicode",
- "fuzzy-matcher",
- "geo 0.32.0",
- "md-5 0.10.6",
- "pbkdf2",
- "rand 0.9.4",
- "rand_core 0.6.4",
- "reblessive",
- "regex",
- "rust_decimal",
- "scrypt",
- "semver",
- "sha1",
- "sha2 0.10.9",
- "strsim",
- "surrealdb-cnf",
- "surrealdb-common",
- "surrealdb-expr",
- "surrealdb-strand",
- "surrealdb-syn",
- "surrealdb-types",
- "ulid",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "surrealdb-sql"
-version = "3.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8365d2def9396edd54c7b6a51a3d7d6ec21f37028129db4baad661fc3348eddf"
-dependencies = [
- "bytes",
- "chrono",
- "geo 0.32.0",
- "getrandom 0.3.4",
- "hex",
- "phf 0.13.1",
- "rand 0.9.4",
- "regex",
- "rust_decimal",
- "serde",
- "surrealdb-common",
- "surrealdb-iam",
- "surrealdb-strand",
- "surrealdb-types",
- "unicase",
- "uuid",
-]
-
-[[package]]
 name = "surrealdb-strand"
-version = "3.3.0-beta.3"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f15ab11aca263b8ab3c547787fa903cc33f8cc099f55cdfb70a2f267c0ae87d"
+checksum = "a86f53e307b6b8275b15eaff2b718add63605cb804395d156589770c3bf38e56"
 dependencies = [
  "revision 0.30.0",
  "serde",
@@ -8636,35 +8205,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "surrealdb-syn"
-version = "3.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c00a905bae5db9b012761c78cc0f92f3c3dccea656d9b8ae86a145711d05ea2"
-dependencies = [
- "bytes",
- "chrono",
- "geo 0.32.0",
- "phf 0.13.1",
- "reblessive",
- "regex",
- "rust_decimal",
- "surrealdb-cnf",
- "surrealdb-common",
- "surrealdb-iam",
- "surrealdb-sql",
- "surrealdb-strand",
- "surrealdb-types",
- "thiserror 2.0.18",
- "tracing",
- "unicase",
- "uuid",
-]
-
-[[package]]
 name = "surrealdb-types"
-version = "3.3.0-beta.3"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c47492779f4600a1086cd25a8d83b00ee89550b1421f8b0208e0812cc89ca7"
+checksum = "e0d70c7f4dbf1198521282a171a03f2f77f38a1225a149f7c0175e758f773b8a"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -8673,8 +8217,6 @@ dependencies = [
  "chrono",
  "flatbuffers",
  "geo 0.32.0",
- "getrandom 0.2.17",
- "getrandom 0.3.4",
  "hex",
  "http",
  "papaya",
@@ -8685,7 +8227,6 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "surrealdb-parse-common",
  "surrealdb-protocol",
  "surrealdb-types-derive",
  "tracing",
@@ -8696,9 +8237,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types-derive"
-version = "3.3.0-beta.3"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "072225776f0f25568eb95a2fabb7652ad13647522d4551f93b72738d1ffe73b5"
+checksum = "dc11310bfc0ae3e546cd14788f8d36e7616dbe41fa68b4b265b29fea34a7d7e1"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -8778,9 +8319,9 @@ dependencies = [
 
 [[package]]
 name = "surrealmx"
-version = "0.24.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6ea4bb6532095046e99d2820185dee700c5bd7e6d919d3331c2537bcd8f91b"
+checksum = "9e8a87f050a4860832ccf4a53e43ea264e98d27618983602b5c575e6df296054"
 dependencies = [
  "arc-swap",
  "bincode 2.0.1",
@@ -9366,13 +8907,22 @@ dependencies = [
  "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost 0.14.4",
+ "tonic",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "affinitypool"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a46f56d354df11b6bcd8ca4f84fa03ac816cc41c72568a1b337d8f7e5af90e"
+dependencies = [
+ "arc-swap",
+ "async-task",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "libc",
+ "num_cpus",
+ "parking_lot",
+ "thiserror 2.0.18",
+ "winapi",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1592,10 +1609,10 @@ dependencies = [
  "serial_test",
  "slatedb",
  "surrealdb 2.6.5",
- "surrealdb 3.0.5",
+ "surrealdb 3.2.4",
  "surrealdb-rocksdb",
  "surrealkv 0.21.2",
- "surrealmx",
+ "surrealmx 0.18.0",
  "sysinfo 0.37.2",
  "tokio",
  "tokio-postgres",
@@ -1987,6 +2004,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "diskann"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421c6cf955c6cb1451d36c8a3740ab2a22880265d0fa93d8ea22cbc425c90479"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "diskann-utils",
+ "diskann-vector",
+ "diskann-wide",
+ "futures-util",
+ "half",
+ "hashbrown 0.16.1",
+ "num-traits",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "diskann-utils"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cdf7d491910fbff13338e07460c9197a3c172268cfd4d8f8e69e5cec5a256d9"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "diskann-vector",
+ "diskann-wide",
+ "half",
+ "rand 0.9.4",
+ "rand_distr",
+ "rayon",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "diskann-vector"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de1643bbece645f03527ef120bc7dd5e4e40557980dbe52ee51129adfb58a851"
+dependencies = [
+ "cfg-if",
+ "diskann-wide",
+ "half",
+]
+
+[[package]]
+name = "diskann-wide"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421f02c42e57a2153dc65b66b4b95fe2be56e14bf9f95253b663abcac8521166"
+dependencies = [
+ "cfg-if",
+ "half",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2181,12 +2256,6 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
-name = "endian-type"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
 
 [[package]]
 name = "enum_dispatch"
@@ -2804,12 +2873,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
-
-[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2874,25 +2937,6 @@ dependencies = [
  "float_next_after",
  "geo-types",
  "geographiclib-rs",
- "log",
- "num-traits",
- "robust",
- "rstar 0.12.2",
- "serde",
- "spade",
-]
-
-[[package]]
-name = "geo"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc1a1678e54befc9b4bcab6cd43b8e7f834ae8ea121118b0fd8c42747675b4a"
-dependencies = [
- "earcutr",
- "float_next_after",
- "geo-types",
- "geographiclib-rs",
- "i_overlay",
  "log",
  "num-traits",
  "robust",
@@ -3055,8 +3099,12 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_distr",
  "zerocopy",
 ]
 
@@ -6146,18 +6194,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
 dependencies = [
- "endian-type 0.1.2",
- "nibble_vec",
- "serde",
-]
-
-[[package]]
-name = "radix_trie"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4431027dcd37fc2a73ef740b5f233aa805897935b8bce0195e41bbf9a3289a"
-dependencies = [
- "endian-type 0.2.0",
+ "endian-type",
  "nibble_vec",
  "serde",
 ]
@@ -6237,6 +6274,16 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.4",
+]
 
 [[package]]
 name = "rand_pcg"
@@ -6389,12 +6436,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "relative-path"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6531,15 +6572,15 @@ dependencies = [
 
 [[package]]
 name = "revision"
-version = "0.17.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b66f44139d1fe8e1b6c21bf1a855f12df38517aab94e21cea2a077e9753f216"
+checksum = "13b48b66c1cd4bf814516ea48f727d4b3697e3fa8841be99a7d9cbb8c9ac1666"
 dependencies = [
  "bytes",
  "chrono",
- "geo 0.31.0",
+ "geo 0.32.0",
  "regex",
- "revision-derive 0.17.1",
+ "revision-derive 0.30.0",
  "roaring 0.11.4",
  "rust_decimal",
  "uuid",
@@ -6569,9 +6610,9 @@ dependencies = [
 
 [[package]]
 name = "revision-derive"
-version = "0.17.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696cbf6f9d0bdeb7d75ef3a037c8295ea9fb665c89c6b70c23022f5918713353"
+checksum = "3d266d798eaaa2921e14188dfe998bb7cc0528ec26e894b4be0e35fe2b19c89d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6775,35 +6816,6 @@ dependencies = [
  "num-traits",
  "serde",
  "smallvec",
-]
-
-[[package]]
-name = "rstest"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
-dependencies = [
- "futures-timer",
- "futures-util",
- "rstest_macros",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version",
- "syn 2.0.117",
- "unicode-ident",
 ]
 
 [[package]]
@@ -7915,9 +7927,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb"
-version = "3.0.5"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504a96b55e86ef8653a03b6b97e771f49c954e26bcc0308160b0134d94f334fd"
+checksum = "01fef5cc04dd6cb042391d48c0f78a586c56042e999f8cb17f0b97b0a147e2c0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -7935,7 +7947,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "surrealdb-core 3.0.5",
+ "surrealdb-core 3.2.4",
  "surrealdb-types",
  "surrealdb-types-derive",
  "tokio",
@@ -7949,6 +7961,16 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasmtimer 0.4.3",
  "web-sys",
+]
+
+[[package]]
+name = "surrealdb-collections"
+version = "3.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3472955f9692427583e78476d5b03c6f750bf11dc8a04383e0d365d7bd5d99"
+dependencies = [
+ "revision 0.30.0",
+ "storekey 0.11.0",
 ]
 
 [[package]]
@@ -8004,7 +8026,7 @@ dependencies = [
  "phf 0.11.3",
  "pin-project-lite",
  "quick_cache 0.5.2",
- "radix_trie 0.2.1",
+ "radix_trie",
  "rand 0.8.6",
  "rayon",
  "reblessive",
@@ -8046,19 +8068,18 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-core"
-version = "3.0.5"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e6a7f248c958fd5000c4fab5759503663bf93c622be10a6d7bf7d2d676b8fc"
+checksum = "8cd76c36f8b545a9371eec050bb2ae83750a6f60bae8c6d92d06956943348f4c"
 dependencies = [
  "addr",
- "affinitypool 0.4.0",
+ "affinitypool 0.7.0",
  "ahash 0.8.12",
  "ammonia",
  "anyhow",
  "argon2",
  "async-channel",
  "async-stream",
- "async-trait",
  "base64 0.22.1",
  "bcrypt 0.18.0",
  "blake3",
@@ -8067,6 +8088,9 @@ dependencies = [
  "ciborium",
  "dashmap 6.2.1",
  "deunicode",
+ "diskann",
+ "diskann-utils",
+ "diskann-vector",
  "dmp",
  "ext-sort",
  "fastnum",
@@ -8076,6 +8100,7 @@ dependencies = [
  "geo 0.32.0",
  "geo-types",
  "getrandom 0.3.4",
+ "half",
  "headers",
  "hex",
  "http",
@@ -8084,6 +8109,7 @@ dependencies = [
  "jsonwebtoken 10.4.0",
  "lexicmp 0.2.0",
  "md-5 0.10.6",
+ "memchr",
  "mime",
  "ndarray 0.17.2",
  "ndarray-stats 0.7.0",
@@ -8096,12 +8122,12 @@ dependencies = [
  "phf 0.13.1",
  "pin-project-lite",
  "quick_cache 0.6.22",
- "radix_trie 0.3.0",
- "rand 0.8.6",
+ "rand 0.9.4",
+ "rand_core 0.6.4",
  "rayon",
  "reblessive",
  "regex",
- "revision 0.17.1",
+ "revision 0.30.0",
  "ring",
  "roaring 0.11.4",
  "rust-stemmers",
@@ -8115,11 +8141,13 @@ dependencies = [
  "storekey 0.11.0",
  "strsim",
  "subtle",
+ "surrealdb-collections",
  "surrealdb-protocol",
  "surrealdb-rocksdb",
+ "surrealdb-strand",
  "surrealdb-types",
  "surrealkv 0.21.2",
- "surrealmx",
+ "surrealmx 0.22.0",
  "sysinfo 0.37.2",
  "tempfile",
  "thiserror 2.0.18",
@@ -8153,9 +8181,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-protocol"
-version = "0.8.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb37698e0493bcfac3229ecb6ec6894a3ad705a3a2087b1562eeb881b3db19d4"
+checksum = "3f4e06f586c9179a02349b88b0c18e3a0850c55431aa513e0cd66529c00da1af"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8186,37 +8214,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "surrealdb-types"
-version = "3.0.5"
+name = "surrealdb-strand"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79e71d035367b933cf528c09b7ed186bc17dea58c66a1bca84d22f9abf167db"
+checksum = "a86f53e307b6b8275b15eaff2b718add63605cb804395d156589770c3bf38e56"
+dependencies = [
+ "revision 0.30.0",
+ "serde",
+ "storekey 0.11.0",
+]
+
+[[package]]
+name = "surrealdb-types"
+version = "3.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d70c7f4dbf1198521282a171a03f2f77f38a1225a149f7c0175e758f773b8a"
 dependencies = [
  "anyhow",
+ "async-channel",
  "bytes",
+ "castaway",
  "chrono",
  "flatbuffers",
  "geo 0.32.0",
  "hex",
  "http",
  "papaya",
- "rand 0.8.6",
+ "rand 0.9.4",
  "regex",
- "rstest",
+ "reqwest 0.13.4",
  "rust_decimal",
+ "semver",
  "serde",
  "serde_json",
  "surrealdb-protocol",
  "surrealdb-types-derive",
+ "tracing",
  "ulid",
+ "url",
  "uuid",
 ]
 
 [[package]]
 name = "surrealdb-types-derive"
-version = "3.0.5"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76abdbfc597e062daae5269251e18a84553f9090cfff423591f57c8c6765aa8"
+checksum = "dc11310bfc0ae3e546cd14788f8d36e7616dbe41fa68b4b265b29fea34a7d7e1"
 dependencies = [
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8275,6 +8320,28 @@ name = "surrealmx"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6508449a7d1379a92a51ba49391b48ccab0b60dd11a4277c0dda965d8c99dbff"
+dependencies = [
+ "arc-swap",
+ "bincode 2.0.1",
+ "bytes",
+ "crossbeam-deque",
+ "crossbeam-queue",
+ "crossbeam-skiplist",
+ "lz4",
+ "papaya",
+ "parking_lot",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "surrealmx"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8a87f050a4860832ccf4a53e43ea264e98d27618983602b5c575e6df296054"
 dependencies = [
  "arc-swap",
  "bincode 2.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,19 +61,17 @@ dependencies = [
 
 [[package]]
 name = "affinitypool"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a46f56d354df11b6bcd8ca4f84fa03ac816cc41c72568a1b337d8f7e5af90e"
+checksum = "a487a26c23775316bc010e9425fd7cf046c384ab37efbb2cfd4ba87a58f68c6d"
 dependencies = [
  "arc-swap",
  "async-task",
  "crossbeam-deque",
  "crossbeam-utils",
- "libc",
  "num_cpus",
  "parking_lot",
  "thiserror 2.0.18",
- "winapi",
 ]
 
 [[package]]
@@ -132,14 +130,13 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ammonia"
-version = "4.1.2"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e913097e1a2124b46746c980134e8c954bc17a6a59bb3fde96f088d126dde6"
+checksum = "dc6d763210e2eb7670d1a5183a08bebefa3f97db2a738a684f2ce00bd49f681d"
 dependencies = [
  "cssparser",
  "html5ever",
  "maplit",
- "tendril",
  "url",
 ]
 
@@ -441,28 +438,6 @@ dependencies = [
  "rustix",
  "slab",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1159,7 +1134,7 @@ checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
 dependencies = [
  "parse-zoneinfo",
  "phf 0.11.3",
- "phf_codegen",
+ "phf_codegen 0.11.3",
 ]
 
 [[package]]
@@ -1609,9 +1584,9 @@ dependencies = [
  "serial_test",
  "slatedb",
  "surrealdb 2.6.5",
- "surrealdb 3.2.4",
+ "surrealdb 3.3.0-beta.3",
  "surrealdb-rocksdb",
- "surrealkv 0.21.2",
+ "surrealkv 0.21.4",
  "surrealmx 0.18.0",
  "sysinfo 0.37.2",
  "tokio",
@@ -1661,25 +1636,13 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.35.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
 dependencies = [
- "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.11.3",
  "smallvec",
-]
-
-[[package]]
-name = "cssparser-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
-dependencies = [
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -2005,9 +1968,9 @@ dependencies = [
 
 [[package]]
 name = "diskann"
-version = "0.54.0"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421c6cf955c6cb1451d36c8a3740ab2a22880265d0fa93d8ea22cbc425c90479"
+checksum = "31a7680a192e1abc16cb70415cb6c1aa4c4cf3269294ce2583c5d81763ee9762"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2025,9 +1988,9 @@ dependencies = [
 
 [[package]]
 name = "diskann-utils"
-version = "0.54.0"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cdf7d491910fbff13338e07460c9197a3c172268cfd4d8f8e69e5cec5a256d9"
+checksum = "0e2d755436dbe7141db9d2311ba99e885126003251d9392d5e41768548df777a"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -2042,9 +2005,9 @@ dependencies = [
 
 [[package]]
 name = "diskann-vector"
-version = "0.54.0"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de1643bbece645f03527ef120bc7dd5e4e40557980dbe52ee51129adfb58a851"
+checksum = "bf19284b35e697b4c49e71306425490b526ebe70b5602eb06d19c3013fb5138c"
 dependencies = [
  "cfg-if",
  "diskann-wide",
@@ -2053,9 +2016,9 @@ dependencies = [
 
 [[package]]
 name = "diskann-wide"
-version = "0.54.0"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421f02c42e57a2153dc65b66b4b95fe2be56e14bf9f95253b663abcac8521166"
+checksum = "7d3f814c2b66a98968630b7ad31afbb3c5e62b94b26f80542878eb7440aa8e5d"
 dependencies = [
  "cfg-if",
  "half",
@@ -2779,16 +2742,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
-]
-
-[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2951,7 +2904,6 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3901269ec6d4f6068d3f09e5f02f995bd076398dcd1dfec407cd230b02d11b"
 dependencies = [
- "earcutr",
  "float_next_after",
  "geo-types",
  "geographiclib-rs",
@@ -2963,7 +2915,6 @@ dependencies = [
  "rstar 0.12.2",
  "serde",
  "sif-itree",
- "spade",
 ]
 
 [[package]]
@@ -2974,7 +2925,6 @@ checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
 dependencies = [
  "approx 0.5.1",
  "num-traits",
- "rayon",
  "rstar 0.10.0",
  "rstar 0.11.0",
  "rstar 0.12.2",
@@ -3430,13 +3380,12 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.35.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
 dependencies = [
  "log",
  "markup5ever",
- "match_token",
 ]
 
 [[package]]
@@ -3531,6 +3480,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs 0.8.3",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -3616,7 +3566,6 @@ dependencies = [
  "i_key_sort",
  "i_shape",
  "i_tree",
- "rayon",
 ]
 
 [[package]]
@@ -4135,7 +4084,7 @@ dependencies = [
  "pico-args",
  "regex",
  "regex-syntax",
- "string_cache",
+ "string_cache 0.8.9",
  "term",
  "tiny-keccak",
  "unicode-xid",
@@ -4319,6 +4268,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4420,12 +4401,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
 name = "macro_magic"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4481,24 +4456,13 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markup5ever"
-version = "0.35.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
  "tendril",
  "web_atoms",
-]
-
-[[package]]
-name = "match_token"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -5215,16 +5179,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "bytes",
  "chrono",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-util",
  "http",
+ "http-body-util",
+ "httparse",
  "humantime",
+ "hyper",
  "itertools 0.14.0",
+ "md-5 0.10.6",
  "parking_lot",
  "percent-encoding",
+ "quick-xml 0.39.4",
+ "rand 0.10.1",
+ "reqwest 0.12.28",
+ "ring",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5608,6 +5586,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
 name = "phf_generator"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5832,9 +5820,9 @@ dependencies = [
  "log",
  "nix 0.26.4",
  "once_cell",
- "prost 0.12.6",
+ "prost",
  "prost-build",
- "prost-derive 0.12.6",
+ "prost-derive",
  "sha2 0.10.9",
  "smallvec",
  "spin 0.10.0",
@@ -5948,17 +5936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive 0.12.6",
-]
-
-[[package]]
-name = "prost"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
-dependencies = [
- "bytes",
- "prost-derive 0.14.3",
+ "prost-derive",
 ]
 
 [[package]]
@@ -5975,8 +5953,8 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.12.6",
- "prost-types 0.12.6",
+ "prost",
+ "prost-types",
  "regex",
  "syn 2.0.117",
  "tempfile",
@@ -5996,34 +5974,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-derive"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "prost-types"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost 0.12.6",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
-dependencies = [
- "prost 0.14.3",
+ "prost",
 ]
 
 [[package]]
@@ -6069,6 +6025,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -6472,6 +6438,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -7824,17 +7791,28 @@ dependencies = [
  "parking_lot",
  "phf_shared 0.11.3",
  "precomputed-hash",
- "serde",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
 ]
 
 [[package]]
 name = "string_cache_codegen"
-version = "0.5.4"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
 ]
@@ -7927,9 +7905,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb"
-version = "3.2.4"
+version = "3.3.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fef5cc04dd6cb042391d48c0f78a586c56042e999f8cb17f0b97b0a147e2c0"
+checksum = "5050f1cdaf068fccef830f7bb80a9dd79f23c071331ab00428936b924747b6ea"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -7947,13 +7925,18 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "surrealdb-core 3.2.4",
+ "surrealdb-engine-api",
+ "surrealdb-engine-local",
+ "surrealdb-iam",
+ "surrealdb-kvs",
+ "surrealdb-rpc",
  "surrealdb-types",
  "surrealdb-types-derive",
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tokio-tungstenite-wasm",
  "tokio-util",
+ "tonic",
  "tracing",
  "url",
  "uuid",
@@ -7964,13 +7947,74 @@ dependencies = [
 ]
 
 [[package]]
-name = "surrealdb-collections"
-version = "3.2.4"
+name = "surrealdb-catalog"
+version = "3.3.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3472955f9692427583e78476d5b03c6f750bf11dc8a04383e0d365d7bd5d99"
+checksum = "be8a905b94eee033a021f918f3a9a3ba3c367f6d23fa7d7995c0a67fd93f2c2f"
+dependencies = [
+ "ahash 0.8.12",
+ "anyhow",
+ "chrono",
+ "md-5 0.10.6",
+ "revision 0.30.0",
+ "serde",
+ "sha2 0.10.9",
+ "storekey 0.11.0",
+ "surrealdb-collections",
+ "surrealdb-common",
+ "surrealdb-expr",
+ "surrealdb-iam",
+ "surrealdb-kvs",
+ "surrealdb-sql",
+ "surrealdb-strand",
+ "surrealdb-syn",
+ "surrealdb-types",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "surrealdb-cnf"
+version = "3.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b572e1e1086b00aa9f6b51313ffc60f812acf77c13995bb7aa08cd4cb8a0a43d"
+dependencies = [
+ "num-traits",
+ "path-clean",
+ "surrealdb-common",
+ "surrealdb-parse-common",
+ "tracing",
+]
+
+[[package]]
+name = "surrealdb-collections"
+version = "3.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a9fbf8cf66deac85604942d841a39803c853955925aae1d57fdf646ee53b7e"
 dependencies = [
  "revision 0.30.0",
  "storekey 0.11.0",
+]
+
+[[package]]
+name = "surrealdb-common"
+version = "3.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "798232be02e321616d3246035fb9c6d670c352acea4381b2b67750d820e5e74d"
+dependencies = [
+ "chrono",
+ "futures",
+ "hashbrown 0.16.1",
+ "parking_lot",
+ "phf 0.13.1",
+ "rust_decimal",
+ "surrealdb-types",
+ "sysinfo 0.37.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "unicase",
+ "wasmtimer 0.4.3",
 ]
 
 [[package]]
@@ -8068,58 +8112,39 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-core"
-version = "3.2.4"
+version = "3.3.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd76c36f8b545a9371eec050bb2ae83750a6f60bae8c6d92d06956943348f4c"
+checksum = "1e17d94f447dc357cc6bbb3e1eebfb6214c5329549aa61794a1c9e4dd9b48af6"
 dependencies = [
- "addr",
- "affinitypool 0.7.0",
  "ahash 0.8.12",
- "ammonia",
  "anyhow",
+ "arc-swap",
  "argon2",
  "async-channel",
- "async-stream",
  "base64 0.22.1",
  "bcrypt 0.18.0",
- "blake3",
  "bytes",
  "chrono",
  "ciborium",
  "dashmap 6.2.1",
- "deunicode",
- "diskann",
- "diskann-utils",
- "diskann-vector",
- "dmp",
  "ext-sort",
- "fastnum",
- "fst",
  "futures",
- "fuzzy-matcher",
  "geo 0.32.0",
  "geo-types",
  "getrandom 0.3.4",
- "half",
  "headers",
  "hex",
  "http",
- "humantime",
  "ipnet",
  "jsonwebtoken 10.4.0",
- "lexicmp 0.2.0",
  "md-5 0.10.6",
  "memchr",
  "mime",
- "ndarray 0.17.2",
- "ndarray-stats 0.7.0",
- "num-traits",
  "num_cpus",
  "object_store 0.13.2",
  "parking_lot",
  "path-clean",
  "pbkdf2",
- "phf 0.13.1",
  "pin-project-lite",
  "quick_cache 0.6.22",
  "rand 0.9.4",
@@ -8130,7 +8155,6 @@ dependencies = [
  "revision 0.30.0",
  "ring",
  "roaring 0.11.4",
- "rust-stemmers",
  "rust_decimal",
  "scrypt",
  "semver",
@@ -8139,29 +8163,313 @@ dependencies = [
  "sha1",
  "sha2 0.10.9",
  "storekey 0.11.0",
- "strsim",
  "subtle",
+ "surrealdb-catalog",
+ "surrealdb-cnf",
  "surrealdb-collections",
- "surrealdb-protocol",
- "surrealdb-rocksdb",
+ "surrealdb-common",
+ "surrealdb-datastore",
+ "surrealdb-expr",
+ "surrealdb-iam",
+ "surrealdb-idx",
+ "surrealdb-kvs",
+ "surrealdb-kvs-any",
+ "surrealdb-observe",
+ "surrealdb-rpc",
+ "surrealdb-runtime",
+ "surrealdb-sql",
  "surrealdb-strand",
+ "surrealdb-syn",
  "surrealdb-types",
- "surrealkv 0.21.2",
- "surrealmx 0.22.0",
  "sysinfo 0.37.2",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
- "ulid",
- "unicase",
  "url",
  "uuid",
- "vart 0.9.3",
  "wasm-bindgen-futures",
  "wasmtimer 0.4.3",
  "web-time",
+]
+
+[[package]]
+name = "surrealdb-datastore"
+version = "3.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dadd311115f3dc19a5fdb30693b60dea046c4eb27b8c7f4ce380db187b33c1f"
+dependencies = [
+ "anyhow",
+ "blake3",
+ "bytes",
+ "chrono",
+ "parking_lot",
+ "quick_cache 0.6.22",
+ "rand 0.9.4",
+ "revision 0.30.0",
+ "roaring 0.11.4",
+ "semver",
+ "serde",
+ "storekey 0.11.0",
+ "surrealdb-catalog",
+ "surrealdb-cnf",
+ "surrealdb-collections",
+ "surrealdb-common",
+ "surrealdb-expr",
+ "surrealdb-iam",
+ "surrealdb-keyspace-macro",
+ "surrealdb-kvs",
+ "surrealdb-observe",
+ "surrealdb-rpc",
+ "surrealdb-strand",
+ "surrealdb-types",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "web-time",
+]
+
+[[package]]
+name = "surrealdb-engine-api"
+version = "3.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db11b9d7f9545ebb9e6f74683efcd3919d63f19a4a3f5210b6ed79ffbc9398c2"
+dependencies = [
+ "async-channel",
+ "surrealdb-rpc",
+ "surrealdb-types",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "surrealdb-engine-local"
+version = "3.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59d72a2bab1783046b7ade6cbb9313ce69a6d996856e4bffc4c699332341673d"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "futures",
+ "surrealdb-cnf",
+ "surrealdb-core 3.3.0-beta.3",
+ "surrealdb-datastore",
+ "surrealdb-engine-api",
+ "surrealdb-iam",
+ "surrealdb-kvs",
+ "surrealdb-rpc",
+ "surrealdb-types",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "wasm-bindgen-futures",
+ "wasmtimer 0.4.3",
+]
+
+[[package]]
+name = "surrealdb-expr"
+version = "3.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb78c38d50f2c9fb9e70d3c36175fafcb353d53e37de2f474a9ce37fe1003a72"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "chrono",
+ "dmp",
+ "fastnum",
+ "geo 0.32.0",
+ "geo-types",
+ "half",
+ "hex",
+ "http",
+ "jsonwebtoken 10.4.0",
+ "lexicmp 0.2.0",
+ "quick_cache 0.6.22",
+ "rand 0.9.4",
+ "reblessive",
+ "regex",
+ "revision 0.30.0",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "storekey 0.11.0",
+ "surrealdb-cnf",
+ "surrealdb-collections",
+ "surrealdb-common",
+ "surrealdb-iam",
+ "surrealdb-kvs",
+ "surrealdb-sql",
+ "surrealdb-strand",
+ "surrealdb-syn",
+ "surrealdb-types",
+ "thiserror 2.0.18",
+ "tracing",
+ "ulid",
+ "uuid",
+]
+
+[[package]]
+name = "surrealdb-iam"
+version = "3.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686e7845e61176696fe66b6bd5406a08d75a6c8abc687fe7a198b3507fa334c9"
+dependencies = [
+ "anyhow",
+ "argon2",
+ "base64 0.22.1",
+ "hmac 0.12.1",
+ "pbkdf2",
+ "rand_core 0.6.4",
+ "revision 0.30.0",
+ "serde",
+ "sha2 0.10.9",
+ "stringprep",
+ "subtle",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "surrealdb-idx"
+version = "3.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9896715c164f28e094cd13959100bd3c73ec0c7db871416b12cc3d62036712f6"
+dependencies = [
+ "ahash 0.8.12",
+ "anyhow",
+ "bytes",
+ "dashmap 6.2.1",
+ "deunicode",
+ "diskann",
+ "diskann-utils",
+ "diskann-vector",
+ "fst",
+ "half",
+ "ndarray 0.17.2",
+ "ndarray-stats 0.7.0",
+ "parking_lot",
+ "quick_cache 0.6.22",
+ "rand 0.9.4",
+ "reblessive",
+ "roaring 0.11.4",
+ "rust-stemmers",
+ "storekey 0.11.0",
+ "surrealdb-catalog",
+ "surrealdb-cnf",
+ "surrealdb-common",
+ "surrealdb-datastore",
+ "surrealdb-expr",
+ "surrealdb-kvs",
+ "surrealdb-runtime",
+ "surrealdb-strand",
+ "surrealdb-types",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+ "vart 0.9.3",
+ "web-time",
+]
+
+[[package]]
+name = "surrealdb-keyspace-macro"
+version = "3.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2560b41072360fc86125218c939ba336ad67255d71bb1aa54edec90e9d7c6825"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "surrealdb-kvs"
+version = "3.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9fe1568dadb47339b704ff60d39f3630db6c47145a2619c085a7b245c0d31f"
+dependencies = [
+ "affinitypool 0.8.0",
+ "anyhow",
+ "chrono",
+ "num_cpus",
+ "revision 0.30.0",
+ "roaring 0.11.4",
+ "surrealdb-cnf",
+ "surrealdb-common",
+ "surrealdb-types",
+ "thiserror 2.0.18",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "surrealdb-kvs-any"
+version = "3.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db79a007b98f562376ac0153a4c5626e3a589208fdb7eeba64f0000505644488"
+dependencies = [
+ "surrealdb-cnf",
+ "surrealdb-kvs",
+ "surrealdb-kvs-mem",
+ "surrealdb-kvs-rocksdb",
+ "surrealdb-kvs-surrealkv",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "surrealdb-kvs-mem"
+version = "3.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ddd30699c4001f3837eebadac02094742d4b203cf36c7763d0571d5fdd41bed"
+dependencies = [
+ "affinitypool 0.8.0",
+ "chrono",
+ "surrealdb-cnf",
+ "surrealdb-kvs",
+ "surrealmx 0.24.0",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "surrealdb-kvs-rocksdb"
+version = "3.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b99f58caa5c45b726e1ccdf5fffd80c03e6caf98a03dcdc08570e90ca576533"
+dependencies = [
+ "affinitypool 0.8.0",
+ "futures",
+ "num_cpus",
+ "parking_lot",
+ "surrealdb-cnf",
+ "surrealdb-common",
+ "surrealdb-kvs",
+ "surrealdb-rocksdb",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "surrealdb-kvs-surrealkv"
+version = "3.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb733b085b9c30ee18b8a1b911b0089b255eeafff46f119ae1329d38aefe7e62"
+dependencies = [
+ "affinitypool 0.8.0",
+ "chrono",
+ "parking_lot",
+ "surrealdb-cnf",
+ "surrealdb-common",
+ "surrealdb-kvs",
+ "surrealkv 0.21.4",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -8180,26 +8488,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "surrealdb-protocol"
-version = "0.10.2"
+name = "surrealdb-observe"
+version = "3.3.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4e06f586c9179a02349b88b0c18e3a0850c55431aa513e0cd66529c00da1af"
+checksum = "e0f84dec988fac06d788857cf01198fca44ffb2071ee483737eaf14f3c18725c"
+dependencies = [
+ "surrealdb-iam",
+ "surrealdb-rpc",
+ "surrealdb-types",
+ "uuid",
+]
+
+[[package]]
+name = "surrealdb-parse-common"
+version = "3.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44e6eb52a9a799833075674272f51cf747d8780a26ae718d8ad57b8eee62b3a"
+dependencies = [
+ "chrono",
+ "logos",
+ "uuid",
+]
+
+[[package]]
+name = "surrealdb-protocol"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53501c853fe88d5ead8e50612d310b43389f3c66fda7ef323a1af6c393809c6"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
  "chrono",
  "flatbuffers",
- "futures",
  "geo 0.32.0",
- "prost 0.14.3",
- "prost-types 0.14.3",
  "rust_decimal",
  "semver",
  "serde",
  "serde_json",
- "tonic",
- "tonic-prost",
  "uuid",
 ]
 
@@ -8214,10 +8540,95 @@ dependencies = [
 ]
 
 [[package]]
-name = "surrealdb-strand"
-version = "3.2.4"
+name = "surrealdb-rpc"
+version = "3.3.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a86f53e307b6b8275b15eaff2b718add63605cb804395d156589770c3bf38e56"
+checksum = "92c6258773eff54ec7b1303e526f5717e96a1b28a310111573a0427048e807d4"
+dependencies = [
+ "anyhow",
+ "humantime",
+ "ipnet",
+ "revision 0.30.0",
+ "serde",
+ "surrealdb-cnf",
+ "surrealdb-common",
+ "surrealdb-iam",
+ "surrealdb-types",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "uuid",
+ "web-time",
+]
+
+[[package]]
+name = "surrealdb-runtime"
+version = "3.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17af38b22610ae3f8eec2c9f6a6b3c9db8ec320c6981495e44f09fe7b7b2f54d"
+dependencies = [
+ "addr",
+ "ammonia",
+ "anyhow",
+ "argon2",
+ "bcrypt 0.18.0",
+ "blake3",
+ "chrono",
+ "deunicode",
+ "fuzzy-matcher",
+ "geo 0.32.0",
+ "md-5 0.10.6",
+ "pbkdf2",
+ "rand 0.9.4",
+ "rand_core 0.6.4",
+ "reblessive",
+ "regex",
+ "rust_decimal",
+ "scrypt",
+ "semver",
+ "sha1",
+ "sha2 0.10.9",
+ "strsim",
+ "surrealdb-cnf",
+ "surrealdb-common",
+ "surrealdb-expr",
+ "surrealdb-strand",
+ "surrealdb-syn",
+ "surrealdb-types",
+ "ulid",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "surrealdb-sql"
+version = "3.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8365d2def9396edd54c7b6a51a3d7d6ec21f37028129db4baad661fc3348eddf"
+dependencies = [
+ "bytes",
+ "chrono",
+ "geo 0.32.0",
+ "getrandom 0.3.4",
+ "hex",
+ "phf 0.13.1",
+ "rand 0.9.4",
+ "regex",
+ "rust_decimal",
+ "serde",
+ "surrealdb-common",
+ "surrealdb-iam",
+ "surrealdb-strand",
+ "surrealdb-types",
+ "unicase",
+ "uuid",
+]
+
+[[package]]
+name = "surrealdb-strand"
+version = "3.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f15ab11aca263b8ab3c547787fa903cc33f8cc099f55cdfb70a2f267c0ae87d"
 dependencies = [
  "revision 0.30.0",
  "serde",
@@ -8225,10 +8636,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "surrealdb-types"
-version = "3.2.4"
+name = "surrealdb-syn"
+version = "3.3.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d70c7f4dbf1198521282a171a03f2f77f38a1225a149f7c0175e758f773b8a"
+checksum = "8c00a905bae5db9b012761c78cc0f92f3c3dccea656d9b8ae86a145711d05ea2"
+dependencies = [
+ "bytes",
+ "chrono",
+ "geo 0.32.0",
+ "phf 0.13.1",
+ "reblessive",
+ "regex",
+ "rust_decimal",
+ "surrealdb-cnf",
+ "surrealdb-common",
+ "surrealdb-iam",
+ "surrealdb-sql",
+ "surrealdb-strand",
+ "surrealdb-types",
+ "thiserror 2.0.18",
+ "tracing",
+ "unicase",
+ "uuid",
+]
+
+[[package]]
+name = "surrealdb-types"
+version = "3.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6c47492779f4600a1086cd25a8d83b00ee89550b1421f8b0208e0812cc89ca7"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -8237,6 +8673,8 @@ dependencies = [
  "chrono",
  "flatbuffers",
  "geo 0.32.0",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "hex",
  "http",
  "papaya",
@@ -8247,6 +8685,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "surrealdb-parse-common",
  "surrealdb-protocol",
  "surrealdb-types-derive",
  "tracing",
@@ -8257,9 +8696,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types-derive"
-version = "3.2.4"
+version = "3.3.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc11310bfc0ae3e546cd14788f8d36e7616dbe41fa68b4b265b29fea34a7d7e1"
+checksum = "072225776f0f25568eb95a2fabb7652ad13647522d4551f93b72738d1ffe73b5"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -8288,9 +8727,9 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.21.2"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0672cbbe282723a62ccee14b95232ca0b4c9bf44ea22fb520c43e7c517fb8ec"
+checksum = "7e57275d2ec60b2b73294d5b3de12efd9f84ff5ce6f738866a35d52301918ce7"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -8339,9 +8778,9 @@ dependencies = [
 
 [[package]]
 name = "surrealmx"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8a87f050a4860832ccf4a53e43ea264e98d27618983602b5c575e6df296054"
+checksum = "9e6ea4bb6532095046e99d2820185dee700c5bd7e6d919d3331c2537bcd8f91b"
 dependencies = [
  "arc-swap",
  "bincode 2.0.1",
@@ -8530,13 +8969,11 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
- "futf",
- "mac",
- "utf-8",
+ "new_debug_unreachable",
 ]
 
 [[package]]
@@ -8929,22 +9366,13 @@ dependencies = [
  "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tonic-prost"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
-dependencies = [
- "bytes",
- "prost 0.14.3",
- "tonic",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -9578,13 +10006,13 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.1.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+checksum = "ba8b815c1b593dc0baf78dd0f4fc8fdb2de53198fb1163738093e9a311c33fb3"
 dependencies = [
- "phf 0.11.3",
- "phf_codegen",
- "string_cache",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache 0.9.0",
  "string_cache_codegen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 slatedb = { version = "0.15.0", features = ["foyer"], optional = true }
 serde_json = "1.0.150"
 serial_test = "3.4.0"
-surrealdb = { version = "3.0.5", default-features = false, optional = true }
+surrealdb = { version = "3.2.4", default-features = false, optional = true }
 surrealdb2 = { package = "surrealdb", version = "2.6", default-features = false, optional = true }
 surrealkv = { version = "0.21.2", optional = true }
 surrealmx = { version = "0.18.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,13 @@ serde = { version = "1.0.228", features = ["derive"] }
 slatedb = { version = "0.15.0", features = ["foyer"], optional = true }
 serde_json = "1.0.150"
 serial_test = "3.4.0"
+# Track the published version closest to surrealdb's main branch, prereleases
+# included, rather than the latest stable. crud-bench exists to monitor SurrealDB
+# as it is developed, so the embedded engine should sit where the development is
+# — and this matches what server mode already does, which pulls the `nightly`
+# image. Pinning stable also means inheriting whatever a stable release carries:
+# 3.2.4 regressed full-table COUNT scans on embedded RocksDB by ~11x (#286),
+# which 3.3.0-beta.3 does not.
 surrealdb = { version = "3.3.0-beta.3", default-features = false, optional = true }
 surrealdb2 = { package = "surrealdb", version = "2.6", default-features = false, optional = true }
 surrealkv = { version = "0.21.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ serial_test = "3.4.0"
 # image. Pinning stable also means inheriting whatever a stable release carries:
 # 3.2.4 regressed full-table COUNT scans on embedded RocksDB by ~11x (#286),
 # which 3.3.0-beta.3 does not.
-surrealdb = { version = "3.3.0-beta.3", default-features = false, optional = true }
+surrealdb = { version = "3.2.4", default-features = false, optional = true }
 surrealdb2 = { package = "surrealdb", version = "2.6", default-features = false, optional = true }
 surrealkv = { version = "0.21.2", optional = true }
 surrealmx = { version = "0.18.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 slatedb = { version = "0.15.0", features = ["foyer"], optional = true }
 serde_json = "1.0.150"
 serial_test = "3.4.0"
-surrealdb = { version = "3.2.4", default-features = false, optional = true }
+surrealdb = { version = "3.3.0-beta.3", default-features = false, optional = true }
 surrealdb2 = { package = "surrealdb", version = "2.6", default-features = false, optional = true }
 surrealkv = { version = "0.21.2", optional = true }
 surrealmx = { version = "0.18.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -620,6 +620,13 @@ cargo run -r -- -d sqlite -s 100000 -c 12 -t 24 -r
 cargo run -r -- -d surrealdb -s 100000 -c 12 -t 24 -r
 ```
 
+> [!NOTE]
+> The embedded engine tracks the **published version closest to SurrealDB's `main`**, prereleases
+> included, rather than the latest stable release — crud-bench exists to monitor SurrealDB as it is
+> developed, so it should sit where the development is. Server mode already does the same by pulling
+> the `surrealdb/surrealdb:nightly` image. Embedded and server therefore benchmark different builds,
+> and a result should say which it used.
+
 Specify a custom endpoint using `-e` or `--endpoint` to benchmark a custom deployment:
 
 | Endpoint | Meaning |

--- a/README.md
+++ b/README.md
@@ -256,6 +256,9 @@ Each scan object can make use of the following values:
 - `start`: Skips the specified number of rows before starting to return rows.
 - `limit`: Specifies the maximum number of rows to return.
 - `expect`: (optional) Asserts the expected number of rows returned.
+- `clients` / `threads`: (optional) Concurrency for this scan's timed legs, overriding `--clients`
+  and `--threads`. `clients` is capped at the pool `--clients` created. Index DDL is unaffected — it
+  always runs on a single client.
 
 ```json
 [
@@ -358,6 +361,20 @@ KNN operator, Redis passes `EF_RUNTIME` on the query rather than fixing it at `F
 pgvector takes it from the `hnsw.ef_search` session GUC, which is applied to every client before each
 leg — a setting made only on the client that built the index would reach one session out of
 `--clients`.
+
+#### Concurrency
+
+Vector legs default to `clients = 1`, `threads = 1` in `config/vector.toml`, and that default is
+load-bearing. Once an index is warm a KNN query answers in well under a millisecond, so at the
+benchmark's usual concurrency the timed legs measure queueing rather than search: the same query
+measured **0.4 ms at one client and roughly 1500 ms at sixty-four**. Raise the setting to measure
+throughput under load — that is a legitimate thing to want — but do not read the latency columns of
+such a run as search cost.
+
+The first leg timed after an index build is also warmed with untimed queries first. Without that it
+absorbs the whole cost of warming the index, and not by a little: on a 50k-row HNSW the first leg
+measured ~295 ms per query against ~0.5 ms for the identical query in the leg that followed, and it
+was *more accurate* as well — a cold index answers differently, not just slower.
 
 #### Recall
 

--- a/README.md
+++ b/README.md
@@ -306,7 +306,8 @@ block describes one KNN benchmark:
 - `distance`: `cosine` (default), `euclidean`, `inner_product`, or `manhattan`.
 - `index_strategy` (**required**): `{ kind = "bruteforce" }`, `{ kind = "hnsw", m, ef_construction,
   ef_search }`, or `{ kind = "diskann", degree, l_build, alpha, l_search }`. All knobs are required —
-  results without explicit parameters cannot be interpreted.
+  results without explicit parameters cannot be interpreted. The search-time knob (`ef_search`,
+  `l_search`) also accepts a **list**, which is swept: see below.
 - `holdout`: `{ count, seed }` for the query set. Query vectors are generated from `seed` using the
   schema's own vector generator and are **never inserted**, so no query is its own nearest neighbour.
 - `tie_epsilon`: relative tolerance when deciding whether a returned neighbour counts as correct
@@ -336,6 +337,27 @@ harder; rows add candidates that can confuse a graph. Measured against embedded 
 dimensions, neither graph index beats a linear scan below ~100k rows — at 200k, HNSW is 1.7x faster
 than bruteforce and DiskANN 3.4x. Treat 100k as a floor, and 1M as the size worth quoting, which also
 matches the scale of the standard ANN datasets.
+
+#### Parameter sweeps
+
+`ef_search` and `l_search` accept a list as well as a single value:
+
+```toml
+index_strategy = { kind = "hnsw", m = 16, ef_construction = 200, ef_search = [16, 32, 64, 128, 256] }
+```
+
+Each value becomes its own timed leg, all sharing a **single** index build, and each is reported as a
+separate row labelled with the value it used. A lone `ef_search` is one arbitrary point on a curve —
+the comparison worth making is the curve itself, what recall an index reaches at a given latency
+budget — and tracing it this way costs one index build rather than one per point.
+
+Values must be at least `top_k`: a search budget narrower than `k` cannot return `k` neighbours.
+
+Engines apply the budget differently and crud-bench hides the difference. SurrealDB carries it in the
+KNN operator, Redis passes `EF_RUNTIME` on the query rather than fixing it at `FT.CREATE`, and
+pgvector takes it from the `hnsw.ef_search` session GUC, which is applied to every client before each
+leg — a setting made only on the client that built the index would reach one session out of
+`--clients`.
 
 #### Recall
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ Within the JSON structure, the following values are replaced by randomly generat
 - Every `int_enum:A,B,C` will be replaced by a i32 from `A` `B` or `C`.
 - Every `float_enum:A,B,C` will be replaced by a f32 from `A` `B` or `C`.
 - Every `datetime` will be replaced by a datetime (ISO 8601).
+- Every `vector:X` will be replaced by an `X`-dimension vector with uniform components in `[-1, 1]`.
+- Every `vector:X:LO..HI` will be replaced by an `X`-dimension vector with uniform components in `[LO, HI]`.
+- Every `vector:X:clustered:N` will be replaced by an `X`-dimension unit vector drawn from a mixture
+  of `N` clusters. Add `:SIGMA` (default `0.35`) to widen or tighten the clusters.
 
 ```json
 {
@@ -313,6 +317,25 @@ block describes one KNN benchmark:
 > [!NOTE]
 > Engines without vector support skip these runs rather than failing. DiskANN is currently
 > implemented for SurrealDB only.
+
+#### Vector data
+
+Use `vector:<dim>:clustered:<n>` rather than `vector:<dim>` for anything whose recall you intend to
+read. Uniform components leave a corpus with no neighbourhood structure — under distance
+concentration every pair sits at roughly the same distance, so a query's true neighbours are
+conspicuous and any index walks straight to them. Measured over 20k 128-d rows, the nearest neighbour
+sits at 65% of a random pair's distance under `vector:128`, and at 8% under
+`vector:128:clustered:200`. Recall only tells you anything on the second.
+
+Clusters are drawn from the corpus seed, so two seeds give two genuinely different datasets rather
+than one structure populated differently. Query vectors come from the same generator, so they follow
+the corpus distribution by construction.
+
+Corpus size matters more than dimension. Dimension scales cost linearly without making the search
+harder; rows add candidates that can confuse a graph. Measured against embedded SurrealDB at 128
+dimensions, neither graph index beats a linear scan below ~100k rows — at 200k, HNSW is 1.7x faster
+than bruteforce and DiskANN 3.4x. Treat 100k as a floor, and 1M as the size worth quoting, which also
+matches the scale of the standard ANN datasets.
 
 #### Recall
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ and lists those which are planned in the future.
 - [x] Full-text search query, using boolean OR search terms, projecting id field
 - [x] Full-text search query, using boolean OR search terms, counting rows
 
+**Vector search**
+
+- [x] Bruteforce (exact) KNN query
+- [x] HNSW KNN query, with configurable `m` / `ef_construction` / `ef_search`
+- [x] DiskANN KNN query, with configurable `degree` / `l_build` / `alpha` / `l_search`
+- [x] Vector index build timing
+- [x] Recall@k against exact ground truth, scored identically for every engine
+- [ ] Parameter sweeps tracing the recall/latency curve
+- [ ] Index size on disk and resident memory
+- [ ] Filtered KNN (`WHERE … ORDER BY <embedding> LIMIT k`)
+
 **Relationships**
 
 - [ ] Fetching or traversing 1-level, one-to-one relationships or joins
@@ -149,6 +160,8 @@ Options:
       --skip-batches                           Skip all batch benchmarks
       --skip-indexes                           Skip index operations, but still table scan queries
       --emit-phase-markers                     Emit line-oriented phase markers (`… starting`, `Benchmark starting`) for log-based tooling (e.g. `dev.sh` perf windows). Off by default; also on when `CRUD_BENCH_EMIT_PHASE_MARKERS` is `1`, `true`, `yes`, or `on`
+      --corpus-seed <CORPUS_SEED>              Seed for generated row content, overriding `seed` in the benchmark TOML. With a seed the corpus is a pure function of `(seed, sample)`, making the run reproducible and letting vector-search ground truth reconstruct the corpus instead of reading it back
+      --ground-truth-cache <DIR>               Directory holding cached vector-search ground truth [env: CRUD_BENCH_GROUND_TRUTH_CACHE=] [default: .crud-bench-gt]
   -h, --help                                   Print help (see more with '--help')
   ```
 
@@ -276,6 +289,58 @@ Multiple benchmarks that share the same filter, index, and write settings can us
     "with_index": { "fields": ["x"] }
   }
 ]
+```
+
+### Vector search
+
+Vector workloads live in [`config/vector.toml`](config/vector.toml). Each `[scans.runs.vector_query]`
+block describes one KNN benchmark:
+
+- `field` (**required**): the `vector:<dim>` column to search. The index, when the strategy needs
+  one, is derived from this — do not also declare `with_index`.
+- `top_k` (**required**): number of neighbours to return.
+- `distance`: `cosine` (default), `euclidean`, `inner_product`, or `manhattan`.
+- `index_strategy` (**required**): `{ kind = "bruteforce" }`, `{ kind = "hnsw", m, ef_construction,
+  ef_search }`, or `{ kind = "diskann", degree, l_build, alpha, l_search }`. All knobs are required —
+  results without explicit parameters cannot be interpreted.
+- `holdout`: `{ count, seed }` for the query set. Query vectors are generated from `seed` using the
+  schema's own vector generator and are **never inserted**, so no query is its own nearest neighbour.
+- `tie_epsilon`: relative tolerance when deciding whether a returned neighbour counts as correct
+  (default `0.0`, i.e. strict recall@k). Engines compute distances at different precisions, so rows
+  straddling the k-th boundary can swap without any real quality difference; a small tolerance stops
+  that reading as a recall gap.
+
+> [!NOTE]
+> Engines without vector support skip these runs rather than failing. DiskANN is currently
+> implemented for SurrealDB only.
+
+#### Recall
+
+An approximate index has a free parameter — `ef_search`, `l_search` — that trades accuracy for
+latency, so a latency number on its own cannot tell a fast index from an inaccurate one. Every KNN
+run is therefore scored for recall@k, reported as `mean / 5th percentile` in the summary table and in
+full in the JSON and CSV output. The 5th percentile is shown because a mean can look healthy while a
+tail of queries is answered badly.
+
+Ground truth is computed by crud-bench itself and shared by every engine, rather than taken from each
+engine's own bruteforce leg. Scoring an engine against itself measures whether its index agrees with
+its own exact path — useful for tracking regressions, but not a number that can sit beside another
+engine's, because a quirk shared by an engine's exact and approximate paths cancels out and divergent
+metric definitions leave every engine near 1.0 against itself. A useful side effect: each engine's
+own bruteforce leg is scored too, and should read `1.000`. Anything less is a metric divergence or an
+engine bug.
+
+Recall needs a reproducible corpus, so a vector config must set `seed` (or the run must pass
+`--corpus-seed`). Row content then becomes a pure function of the seed and the sample index, which
+also means the same dataset is benchmarked across engines and across runs. Without a seed the KNN
+runs still execute and report latency, and print why recall is unavailable.
+
+The answer key is a pure function of its inputs — both seeds, the sample count, `top_k`, the metric,
+the field, and the value template — so it is computed once, cached under `--ground-truth-cache`
+(default `.crud-bench-gt`, gitignored), and reused by every subsequent engine and run.
+
+```bash
+cargo run -r -- -d surrealdb -s 100000 -c 12 -t 24 --config config/vector.toml
 ```
 
 ## Databases

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ and lists those which are planned in the future.
 - [x] DiskANN KNN query, with configurable `degree` / `l_build` / `alpha` / `l_search`
 - [x] Vector index build timing
 - [x] Recall@k against exact ground truth, scored identically for every engine
-- [ ] Parameter sweeps tracing the recall/latency curve
+- [x] Parameter sweeps tracing the recall/latency curve over a single index build
+- [x] Reproducible corpora, so engines and runs are compared on identical data
 - [ ] Index size on disk and resident memory
 - [ ] Filtered KNN (`WHERE … ORDER BY <embedding> LIMIT k`)
 
@@ -162,6 +163,7 @@ Options:
       --emit-phase-markers                     Emit line-oriented phase markers (`… starting`, `Benchmark starting`) for log-based tooling (e.g. `dev.sh` perf windows). Off by default; also on when `CRUD_BENCH_EMIT_PHASE_MARKERS` is `1`, `true`, `yes`, or `on`
       --corpus-seed <CORPUS_SEED>              Seed for generated row content, overriding `seed` in the benchmark TOML. With a seed the corpus is a pure function of `(seed, sample)`, making the run reproducible and letting vector-search ground truth reconstruct the corpus instead of reading it back
       --ground-truth-cache <DIR>               Directory holding cached vector-search ground truth [env: CRUD_BENCH_GROUND_TRUTH_CACHE=] [default: .crud-bench-gt]
+      --vector-warmup-seconds <SECONDS>        Seconds a vector index may be warmed before a timed leg. Warming stops on its own once latency plateaus; this is a safety cap. Raise it for large corpora [default: 30]
   -h, --help                                   Print help (see more with '--help')
   ```
 
@@ -318,9 +320,19 @@ block describes one KNN benchmark:
   straddling the k-th boundary can swap without any real quality difference; a small tolerance stops
   that reading as a recall gap.
 
-> [!NOTE]
-> Engines without vector support skip these runs rather than failing. DiskANN is currently
-> implemented for SurrealDB only.
+#### Engine support
+
+| engine | bruteforce | HNSW | DiskANN | notes |
+|---|---|---|---|---|
+| SurrealDB (3.x) | ✓ | ✓ | ✓ | `<\|k,ef\|>` operator; DiskANN needs a build that has the DDL |
+| SurrealDB (2.x) | ✓ | ✓ | — | 2.6 has no DiskANN |
+| PostgreSQL | ✓ | ✓ | — | pgvector; DiskANN would need pgvectorscale |
+| Redis Stack | ✓ (FLAT) | ✓ | — | no native L1/Manhattan metric |
+| everything else | — | — | — | the run is skipped, not failed |
+
+Engines without vector support skip these runs rather than failing, so a mixed run reports `-` for
+them rather than aborting. A leg whose strategy needs an index it cannot build is skipped the same
+way.
 
 #### Vector data
 

--- a/compare/index.html
+++ b/compare/index.html
@@ -694,6 +694,8 @@
             <option value="ops">Throughput (OPS)</option>
             <option value="mean">Mean latency (µs)</option>
             <option value="q99">p99 latency (µs)</option>
+            <option value="recall">Recall@k (mean)</option>
+            <option value="recall_p5">Recall@k (5th pct)</option>
           </select>
         </div>
         <div class="control-group">
@@ -762,6 +764,7 @@
   /** @typedef {{
    * mean: number, min?: number, max?: number, q99: number, q95?: number,
    * q75?: number, q50?: number, ops: number,
+   * recall?: { mean: number, p5: number, min: number, queries: number },
    * elapsed?: ElapsedSerde
    * }} OperationResultLike */
 
@@ -973,7 +976,17 @@
     if (metric === "ops") return typeof op.ops === "number" ? op.ops : null;
     if (metric === "mean") return typeof op.mean === "number" ? op.mean : null;
     if (metric === "q99") return typeof op.q99 === "number" ? op.q99 : Number(op.q99);
+    // Recall is present only on vector scans, and only when the run had a
+    // corpus seed to score against. Everything else reports null and renders
+    // as an empty cell rather than a zero, which would read as "recall 0".
+    if (metric === "recall") return typeof op.recall?.mean === "number" ? op.recall.mean : null;
+    if (metric === "recall_p5") return typeof op.recall?.p5 === "number" ? op.recall.p5 : null;
     return null;
+  }
+
+  /** Metrics where a bigger number is a better result. */
+  function higherIsBetter(metric) {
+    return metric === "ops" || metric === "recall" || metric === "recall_p5";
   }
 
   /** Five-number summary for box plot (µs), matches crud-bench `scan_boxplot_json`. */
@@ -1226,7 +1239,14 @@
     trh.appendChild(document.createElement("th")).textContent = "Test";
     okRuns.forEach((r) => {
       const th = document.createElement("th");
-      th.textContent = r.displayLabel + (metric === "ops" ? "\nOPS" : metric === "mean" ? "\nµs mean" : "\nµs p99");
+      const metricLabel = {
+        ops: "\nOPS",
+        mean: "\nµs mean",
+        q99: "\nµs p99",
+        recall: "\nrecall",
+        recall_p5: "\nrecall p5",
+      }[metric] ?? "";
+      th.textContent = r.displayLabel + metricLabel;
       trh.appendChild(th);
       if (r.id !== baseline) {
         const th2 = document.createElement("th");
@@ -1258,7 +1278,9 @@
           if (r.id !== baseline) tr.appendChild(document.createElement("td")).textContent = "-";
           return;
         }
-        td.textContent = metric === "ops" ? Number(v.toFixed(2)) : Number(v.toFixed(2));
+        // Recall lives in [0, 1], where the interesting differences are in the
+        // third decimal; latency and throughput read better at two.
+        td.textContent = Number(v.toFixed(metric.startsWith("recall") ? 4 : 2));
 
         const okey = outlierCellKey(r.id, k);
         if (outliers.outOps.has(okey) || outliers.outLatMean.has(okey) || outliers.outLatP99.has(okey)) td.classList.add("out-cell");
@@ -1278,10 +1300,7 @@
             tdd.textContent = "-";
           } else {
             const pct = ((v - bv) / Math.abs(bv)) * 100;
-            const good =
-              metric === "ops"
-                ? v >= bv
-                : v <= bv;
+            const good = higherIsBetter(metric) ? v >= bv : v <= bv;
             tdd.textContent = (pct >= 0 ? "+" : "") + pct.toFixed(1) + "%";
             tdd.className = good ? "delta-pos" : "delta-neg";
           }
@@ -1871,14 +1890,22 @@
           formatter(val, tooltipOpts) {
             const idx = tooltipOpts.dataPointIndex;
             const full = catKeys[idx] || "";
-            const unit = metric === "ops" ? " ops" : " µs";
+            const unit = metric === "ops" ? " ops" : metric.startsWith("recall") ? "" : " µs";
             const show = val != null && typeof val === "number" ? val + unit : "—";
             return `${show}\n\n${full}`;
           },
         },
       },
       title: {
-        text: `${metric === "ops" ? "Throughput (OPS)" : metric === "mean" ? "Mean latency (µs)" : "p99 latency (µs)"}${capApplied}`,
+        text: `${
+          {
+            ops: "Throughput (OPS)",
+            mean: "Mean latency (µs)",
+            q99: "p99 latency (µs)",
+            recall: "Recall@k (mean)",
+            recall_p5: "Recall@k (5th percentile)",
+          }[metric] ?? metric
+        }${capApplied}`,
         align: "left",
         style: {
           fontSize: "15px",

--- a/compare/index.html
+++ b/compare/index.html
@@ -765,6 +765,7 @@
    * mean: number, min?: number, max?: number, q99: number, q95?: number,
    * q75?: number, q50?: number, ops: number,
    * recall?: { mean: number, p5: number, min: number, queries: number },
+   * label?: string,
    * elapsed?: ElapsedSerde
    * }} OperationResultLike */
 
@@ -847,7 +848,13 @@
     } else {
       mid = `reads - ${indexSlug}`;
     }
-    return `[S]can · ${id} · ${scanName} - ${mid} (${samples})`;
+    // Sweep legs share id, name and index state, differing only by `label`.
+    // Leaving it out makes every leg hash to the same key, so `flattenBenchmark`
+    // keeps only the last one and the rest of the curve is silently dropped.
+    // Mirrors `scan_run_row_label` in src/result.rs.
+    return run.label
+      ? `[S]can · ${id} · ${scanName} · ${run.label} - ${mid} (${samples})`
+      : `[S]can · ${id} · ${scanName} - ${mid} (${samples})`;
   }
 
   /**

--- a/config/ci.toml
+++ b/config/ci.toml
@@ -50,7 +50,7 @@ geography.code = "string:3"
 geography.text = "string:15"
 geography.location = "string_enum:Africa,Antarctica,Asia,Europe,North America,South America,Oceania"
 geography.description = "words:100;hello,world,foo,bar,test,search,data,query,index,document,database,performance"
-embedding = "vector:128"
+embedding = "vector:128:clustered:50"
 
 # ============================================================================
 # count

--- a/config/ci.toml
+++ b/config/ci.toml
@@ -1,3 +1,9 @@
+# Corpus seed. Without one the vector legs run but report no recall, so CI would
+# never exercise the ground-truth and scoring paths at all. Ground truth at this
+# scale costs about 9ms (50 queries over 10k rows), and seeding also makes every
+# CI benchmark reproducible run to run.
+seed = 20260908
+
 # crud-bench benchmark specification (TOML).
 #
 # Three parts: document shape (`[value]`), scan workloads (`[[scans]]`), and batch throughput

--- a/config/vector.toml
+++ b/config/vector.toml
@@ -82,6 +82,13 @@ embedding = "vector:768:clustered:200"
 [[scans]]
 id = "vector_knn"
 iterations = 1000
+# KNN answers in well under a millisecond once the index is warm, so at the
+# default concurrency these legs measure queueing rather than search — the same
+# query timed 0.4ms at one client and roughly 1500ms at sixty-four. Latency is
+# only interpretable at a low setting; raise these to measure throughput under
+# load instead, and read the numbers as such.
+clients = 1
+threads = 1
 
 [[scans.runs]]
 name = "bruteforce knn(10)"

--- a/config/vector.toml
+++ b/config/vector.toml
@@ -20,6 +20,20 @@
 # dataset; the ground-truth cache keys on it, so each seed is computed once.
 seed = 20260908
 
+# The embedding column below uses the clustered generator. Uniform components
+# (`vector:<dim>`) leave a corpus with no neighbourhood structure: in high
+# dimensions every pair sits at roughly the same distance, so a query's true
+# neighbours are conspicuous and every index returns them exactly. Measured on
+# 20k 128-d rows, uniform puts the nearest neighbour at 65% of a random pair's
+# distance; clustered puts it at 8%. Recall only discriminates on the second.
+#
+# 768 dimensions matches common embedding models and keeps a 1M-row corpus at
+# ~3 GB with a ~2 minute one-off ground-truth build. Raise it for a
+# high-dimension variant — 3072 is ~12 GB at 1M rows — but note dimension scales
+# cost linearly without making the search harder; corpus size is the dial that
+# does that. Below ~100k rows a linear scan beats both graph indexes here, so
+# treat 100k as a floor and 1M as the size worth quoting.
+
 # ============================================================================
 # value
 # ============================================================================
@@ -49,7 +63,7 @@ geography.code = "string:3"
 geography.text = "string:15"
 geography.location = "string_enum:Africa,Antarctica,Asia,Europe,North America,South America,Oceania"
 geography.description = "words:100;hello,world,foo,bar,test,search,data,query,index,document,database,performance"
-embedding = "vector:3072"
+embedding = "vector:768:clustered:200"
 
 # ============================================================================
 # vector_knn — Bruteforce / HNSW / DiskANN KNN against a 128-d embedding.

--- a/config/vector.toml
+++ b/config/vector.toml
@@ -5,11 +5,20 @@
 # Engines covered end-to-end: SurrealDB, PostgreSQL (pgvector), Redis Stack.
 # Engines without vector support skip the run via `NOT_SUPPORTED_ERROR`.
 #
-# The query set is built deterministically from the inserted records: at the
-# end of the create phase the framework picks `count` ids using `seed`, reads
-# each row once (outside the timing window), and reuses those embedding
-# vectors across all scan iterations. Only the KNN call itself is timed, so the
-# benchmark's RAM footprint is constant in `count` (independent of `-s N`).
+# `seed` below makes row content a pure function of (seed, sample index), so
+# the corpus is identical across engines and across runs. That is what lets
+# recall be compared between engines at all, and it lets the harness rebuild
+# the corpus locally to compute exact ground truth instead of trusting any one
+# engine's bruteforce leg as the answer key.
+#
+# Query vectors are generated from `holdout.seed` using the same generator as
+# the corpus, and are never inserted, so no query is its own nearest neighbour.
+# Only the KNN call itself is timed, and the benchmark's RAM footprint stays
+# constant in `holdout.count` (independent of `-s N`).
+
+# Corpus seed. Change it to benchmark a different (but still reproducible)
+# dataset; the ground-truth cache keys on it, so each seed is computed once.
+seed = 20260908
 
 # ============================================================================
 # value

--- a/config/vector.toml
+++ b/config/vector.toml
@@ -65,6 +65,11 @@ geography.location = "string_enum:Africa,Antarctica,Asia,Europe,North America,So
 geography.description = "words:100;hello,world,foo,bar,test,search,data,query,index,document,database,performance"
 embedding = "vector:768:clustered:200"
 
+# A search-time knob given as a list is swept: one timed leg per value over a
+# SINGLE index build. A lone `ef_search` is one arbitrary point on a curve; the
+# comparison worth making is the curve — what recall an index reaches at a given
+# latency budget — and tracing it should not cost a rebuild per point.
+#
 # ============================================================================
 # vector_knn — Bruteforce / HNSW / DiskANN KNN against a 128-d embedding.
 #
@@ -89,13 +94,13 @@ index_strategy = { kind = "bruteforce" }
 holdout = { count = 200, seed = 42 }
 
 [[scans.runs]]
-name = "hnsw knn(10) m=16 efc=200 efs=64"
+name = "hnsw knn(10) m=16 efc=200"
 
 [scans.runs.vector_query]
 field = "embedding"
 top_k = 10
 distance = "cosine"
-index_strategy = { kind = "hnsw", m = 16, ef_construction = 200, ef_search = 64 }
+index_strategy = { kind = "hnsw", m = 16, ef_construction = 200, ef_search = [16, 32, 64, 128, 256] }
 holdout = { count = 200, seed = 42 }
 
 [[scans.runs]]
@@ -105,5 +110,5 @@ name = "diskann knn(10) deg=64 L=100 alpha=1.2"
 field = "embedding"
 top_k = 10
 distance = "cosine"
-index_strategy = { kind = "diskann", degree = 64, l_build = 100, alpha = 1.2, l_search = 100 }
+index_strategy = { kind = "diskann", degree = 64, l_build = 100, alpha = 1.2, l_search = [25, 50, 100, 200] }
 holdout = { count = 200, seed = 42 }

--- a/config/vector.toml
+++ b/config/vector.toml
@@ -2,8 +2,10 @@
 # (exact, no auxiliary index), HNSW (graph ANN), and DiskANN (graph ANN with a
 # disk-resident structure) — over a fixed-dimension embedding column.
 #
-# Engines covered end-to-end: SurrealDB, PostgreSQL (pgvector), Redis Stack.
-# Engines without vector support skip the run via `NOT_SUPPORTED_ERROR`.
+# Engines covered end-to-end: SurrealDB 3.x and 2.x, PostgreSQL (pgvector) and
+# Redis Stack. DiskANN is SurrealDB 3.x only; Postgres and Redis skip that leg.
+# Engines without vector support skip the run via `NOT_SUPPORTED_ERROR` rather
+# than failing it, so a mixed run reports `-` for them.
 #
 # `seed` below makes row content a pure function of (seed, sample index), so
 # the corpus is identical across engines and across runs. That is what lets

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -409,6 +409,26 @@ impl Benchmark {
 								search_param_label(&vq.index_strategy)
 							));
 						}
+						// Warm the index before timing. The first leg after a
+						// build otherwise absorbs the cost of faulting the
+						// structure in, which made it read ~1000x slower than
+						// the identical leg that followed it — a sweep would
+						// have reported its first point as its worst whatever
+						// the parameter said.
+						for client in clients.iter() {
+							for w in 0..VECTOR_WARMUP_QUERIES {
+								match client
+									.scan_vector(&leg_scan, query_set.pick(w), &kp, ctx)
+									.await
+								{
+									Ok(_) => {}
+									// An engine that cannot serve this scan
+									// fails the same way in the timed run,
+									// which is where it is reported.
+									Err(_) => break,
+								}
+							}
+						}
 						let result = self
 							.run_operation::<C, D>(
 								&clients,
@@ -1132,6 +1152,12 @@ impl Benchmark {
 		Ok((histogram, tally))
 	}
 }
+
+/// Untimed queries issued per client before a vector leg is timed.
+///
+/// Enough to fault in the index structure and warm the caches the engine keeps
+/// per connection, without materially adding to a run's wall time.
+const VECTOR_WARMUP_QUERIES: u32 = 5;
 
 /// Config name of a strategy's search-time knob, for labelling sweep legs.
 fn search_param_label(strategy: &VectorIndexStrategy) -> &'static str {

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -202,10 +202,14 @@ impl Benchmark {
 		C: BenchmarkClient + Send + Sync,
 	{
 		let started = Instant::now();
+		let ceiling = (self.samples / VECTOR_WARMUP_ROWS_PER_QUERY).max(VECTOR_WARMUP_MIN_QUERIES);
+		// Set when a client stopped on a limit rather than on a settled rate.
+		let mut truncated = false;
 		for client in clients.iter() {
 			let mut previous: Option<Duration> = None;
 			let mut q = 0u32;
-			while started.elapsed() <= self.vector_warmup_budget {
+			let mut plateaued = false;
+			while started.elapsed() <= self.vector_warmup_budget && q < ceiling {
 				// Time a whole window rather than single queries: while an index
 				// is warming its latency is *falling*, and once warm it is flat.
 				// Comparing consecutive windows detects that transition, where
@@ -226,22 +230,27 @@ impl Benchmark {
 					// which is true immediately for an index that was already
 					// warm, so a later sweep leg pays only two windows.
 					if window * 100 >= previous * VECTOR_WARMUP_PLATEAU_PCT {
+						plateaued = true;
 						break;
 					}
 				}
 				previous = Some(window);
 			}
+			if !plateaued {
+				truncated = true;
+			}
 		}
 		let waited = started.elapsed();
-		if waited > self.vector_warmup_budget {
+		if truncated {
 			// A truncated warm-up leaves the index cold, and a cold index is
 			// both slower and — because it answers by a different path — more
 			// accurate. Reporting that silently is how this went unnoticed for
 			// several runs, so say it loudly instead.
 			self.bench_ui.println_muted(&format!(
-				"Warm-up hit its {} budget: the next leg's latency is understated and its \
-				 recall overstated. Raise --vector-warmup-seconds.",
-				format_duration(self.vector_warmup_budget)
+				"Warm-up stopped on a limit after {} without the rate settling: the next leg's \
+				 latency may be understated and its recall overstated. Raise \
+				 --vector-warmup-seconds if this persists.",
+				format_duration(waited)
 			));
 		} else if waited > Duration::from_millis(500) {
 			self.bench_ui
@@ -1272,6 +1281,19 @@ impl Benchmark {
 
 /// Warm-up queries measured together before checking for a plateau.
 const VECTOR_WARMUP_WINDOW: u32 = 25;
+
+/// Floor on the warm-up query ceiling, for small corpora.
+const VECTOR_WARMUP_MIN_QUERIES: u32 = 500;
+
+/// Rows per permitted warm-up query, so the ceiling grows with the index.
+///
+/// The plateau check compares consecutive windows, and on a noisy machine a
+/// window can beat the one before it by chance for a long time — which kept
+/// warm-up running for thousands of queries against a 10k-row index that needed
+/// a few hundred, and blew a CI step's budget. A ceiling bounds that, but a
+/// fixed one under-warms a large index just as silently, so it scales: 500
+/// queries at 10k rows, 4000 at 200k.
+const VECTOR_WARMUP_ROWS_PER_QUERY: u32 = 50;
 
 /// A window this close to the one before it means warming has plateaued.
 /// Expressed as a percentage so the comparison stays in integer arithmetic.

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -4,7 +4,7 @@
 //! [`crate::result::OperationResult`] values for reporting.
 
 use crate::dialect::Dialect;
-use crate::engine::{BenchmarkClient, BenchmarkEngine, ScanContext};
+use crate::engine::{BenchmarkClient, BenchmarkEngine, KnnKey, ScanContext};
 use crate::keyprovider::KeyProvider;
 use crate::result::{
 	BenchmarkMetadata, BenchmarkResult, OperationMetric, OperationResult, ScanResult, ScanRun,
@@ -15,7 +15,7 @@ use crate::terminal::BenchUi;
 use crate::util::format_duration;
 use crate::valueprovider::ColumnType;
 use crate::valueprovider::{ValueProvider, ValueStream};
-use crate::vectorgt::{self, GroundTruth};
+use crate::vectorgt::{self, GroundTruth, RecallTally, VectorAnswer};
 use crate::workloads;
 use crate::{
 	Args, BatchOperation, Batches, Index, Scan, ScanWithWrites, Scans, VectorHoldout,
@@ -66,12 +66,21 @@ pub(crate) struct VectorQuerySet {
 	/// every engine rather than taken from the engine's own exact leg, so the
 	/// recall it scores is comparable across engines.
 	pub(crate) ground_truth: Option<Arc<GroundTruth>>,
+	/// The answer key resolved into this run's key shape, ready to score
+	/// against. Built once per scan so an iteration costs a set lookup.
+	pub(crate) accept: Option<Arc<Vec<VectorAnswer>>>,
 }
 
 impl VectorQuerySet {
 	pub(crate) fn pick(&self, sample: u32) -> &[f32] {
-		let q = &self.queries[(sample as usize) % self.queries.len()];
+		let q = &self.queries[self.query_index(sample)];
 		q.as_slice()
+	}
+
+	/// Index of the query `pick` returns for `sample`; scoring needs it to line
+	/// a result up with its answer.
+	pub(crate) fn query_index(&self, sample: u32) -> usize {
+		(sample as usize) % self.queries.len()
 	}
 }
 
@@ -330,7 +339,7 @@ impl Benchmark {
 					ScanContext::WithoutIndex
 				};
 				let scan_result = if !strategy_needs_index || vec_index_build.is_some() {
-					self.attach_ground_truth(&scan, &vq, &vp, &mut query_set)?;
+					self.attach_ground_truth(&scan, &vq, &vp, &kp, &mut query_set)?;
 					self.run_operation::<C, D>(
 						&clients,
 						BenchmarkOperation::VectorScan(scan.clone(), ctx, query_set.clone()),
@@ -652,6 +661,7 @@ impl Benchmark {
 		Ok(VectorQuerySet {
 			queries: Arc::new(queries),
 			ground_truth: None,
+			accept: None,
 		})
 	}
 
@@ -666,6 +676,7 @@ impl Benchmark {
 		scan: &Scan,
 		vq: &VectorQuerySpec,
 		vp: &ValueProvider,
+		kp: &KeyProvider,
 		query_set: &mut VectorQuerySet,
 	) -> Result<()> {
 		let Some(corpus_seed) = vp.seed() else {
@@ -700,6 +711,8 @@ impl Benchmark {
 				format_duration(started.elapsed())
 			));
 		}
+		query_set.accept =
+			Some(Arc::new(vectorgt::build_answers(&gt, kp, vq.top_k, vq.tie_epsilon)));
 		query_set.ground_truth = Some(Arc::new(gt));
 		Ok(())
 	}
@@ -823,10 +836,12 @@ impl Benchmark {
 		}
 		// Wait for the threads to complete, aborting the remaining tasks on the first failure.
 		let mut global_histogram = Histogram::new(3)?;
+		let mut global_recall = RecallTally::default();
 		while let Some(result) = tasks.join_next().await {
 			match result {
-				Ok(Ok(Some(histogram))) => {
+				Ok(Ok(Some((histogram, recall)))) => {
 					global_histogram.add(histogram)?;
+					global_recall.merge(recall);
 				}
 				Ok(Ok(None)) => {}
 				Ok(Err(e)) => {
@@ -858,7 +873,8 @@ impl Benchmark {
 			bail!("Task failure");
 		}
 		// Histogram + sysinfo snapshots → OperationResult; then print phase timing line
-		let result = OperationResult::new(metric, global_histogram);
+		let result =
+			OperationResult::new(metric, global_histogram).with_recall(global_recall.summarise());
 		let took = result.total_time();
 		match &operation {
 			BenchmarkOperation::Scan(_, ctx) => {
@@ -921,12 +937,13 @@ impl Benchmark {
 		operation: BenchmarkOperation,
 		operation_timeout: Duration,
 		(mut kp, mut vp, progress): (KeyProvider, ValueProvider, Option<Arc<ProgressBar>>),
-	) -> Result<Histogram<u64>>
+	) -> Result<(Histogram<u64>, RecallTally)>
 	where
 		C: BenchmarkClient,
 		D: Dialect,
 	{
 		let mut histogram = Histogram::new(3)?;
+		let mut tally = RecallTally::default();
 		// Check if we have encountered an error
 		while !error.load(Ordering::Relaxed) {
 			// Get the current sample number
@@ -944,6 +961,9 @@ impl Benchmark {
 			// parking the worker task forever; the operation `JoinSet` then
 			// short-circuits with the operation name in the error
 			// chain rather than hanging in `block_on`.
+			// KNN hits, kept so recall can be scored after the latency is
+			// recorded rather than inside the measured window.
+			let mut scored: Option<(usize, Vec<KnnKey>)> = None;
 			let time = Instant::now();
 			tokio::time::timeout(operation_timeout, async {
 				match &operation {
@@ -959,7 +979,9 @@ impl Benchmark {
 					BenchmarkOperation::Scan(s, ctx) => client.scan(s, &kp, *ctx).await,
 					BenchmarkOperation::VectorScan(s, ctx, qs) => {
 						let q = qs.pick(sample);
-						client.scan_vector(s, q, &kp, *ctx).await
+						let hits = client.scan_vector(s, q, &kp, *ctx).await?;
+						scored = Some((qs.query_index(sample), hits));
+						Ok(())
 					}
 					BenchmarkOperation::ScanWithWrites(scan, ctx, spec) => {
 						workloads::run_scan_with_writes(
@@ -1000,8 +1022,18 @@ impl Benchmark {
 				pb.set_position(done);
 			}
 			histogram.record(time.elapsed().as_micros() as u64)?;
+			// Scoring happens strictly after the latency is banked, so recall
+			// never inflates the number it is reported beside.
+			if let Some((query, hits)) = scored
+				&& let BenchmarkOperation::VectorScan(_, _, qs) = &operation
+				&& let Some(answers) = qs.accept.as_ref()
+				&& let Some(answer) = answers.get(query)
+				&& let Some(value) = vectorgt::recall(answer, &hits)
+			{
+				tally.record(value);
+			}
 		}
-		Ok(histogram)
+		Ok((histogram, tally))
 	}
 }
 

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -328,6 +328,22 @@ impl Benchmark {
 					)
 					.await?;
 				if vec_index_build.is_some() {
+					// A vector index reports itself built well before it is
+					// actually serving queries from the graph: newly indexed
+					// vectors sit in a pending queue that KNN answers by
+					// scanning linearly. Waiting here — after the timed build,
+					// before the timed scan — keeps a background drain out of
+					// the build number and a brute-force scan out of the KNN
+					// number.
+					let waited = Instant::now();
+					clients[0].await_index_queryable(&id).await?;
+					let waited = waited.elapsed();
+					if waited > Duration::from_millis(200) {
+						self.bench_ui.println_muted(&format!(
+							"Waited {} for index `{id}` to become queryable",
+							format_duration(waited)
+						));
+					}
 					self.maybe_compact_datastore::<C, E>(&engine).await?;
 				}
 				// Run the scan if either the strategy doesn't require an index

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -371,19 +371,58 @@ impl Benchmark {
 				} else {
 					ScanContext::WithoutIndex
 				};
-				let scan_result = if !strategy_needs_index || vec_index_build.is_some() {
+				// A search-time knob given as a list becomes one timed leg per
+				// value over this *single* index build. A lone `ef_search` is
+				// one arbitrary point on a curve; the comparison worth making
+				// is the curve, and tracing it should not cost a rebuild per
+				// point.
+				let sweep = vq.index_strategy.search_values();
+				let mut sweep_results: Vec<(Option<u32>, Option<OperationResult>)> = Vec::new();
+				if !strategy_needs_index || vec_index_build.is_some() {
 					self.attach_ground_truth(&scan, &vq, &vp, &kp, &mut query_set)?;
-					self.run_operation::<C, D>(
-						&clients,
-						BenchmarkOperation::VectorScan(scan.clone(), ctx, query_set.clone()),
-						kp,
-						vp.clone(),
-						iterations,
-					)
-					.await?
+					// Bruteforce has no search budget, so it runs once with no
+					// value to report.
+					let legs: Vec<Option<u32>> = if sweep.len() > 1 {
+						sweep.iter().map(|v| Some(*v)).collect()
+					} else {
+						vec![None]
+					};
+					for leg in legs {
+						// Pin the spec to this leg's value so adapters only ever
+						// see a resolved strategy.
+						let mut leg_scan = scan.clone();
+						if let (Some(value), Some(lvq)) = (leg, leg_scan.vector_query.as_mut()) {
+							lvq.index_strategy = vq.index_strategy.with_search_value(value);
+						}
+						let leg_vq = leg_scan
+							.vector_query
+							.clone()
+							.expect("vector scan always carries a vector_query");
+						// Engines holding the budget in session state need it on
+						// every client, not just the one that built the index.
+						for client in clients.iter() {
+							client.prepare_vector_search(&leg_vq).await?;
+						}
+						if let Some(value) = leg {
+							self.bench_ui.println_scan_run(&format!(
+								"{name} · {} = {value}",
+								search_param_label(&vq.index_strategy)
+							));
+						}
+						let result = self
+							.run_operation::<C, D>(
+								&clients,
+								BenchmarkOperation::VectorScan(leg_scan, ctx, query_set.clone()),
+								kp,
+								vp.clone(),
+								iterations,
+							)
+							.await?;
+						sweep_results.push((leg, result));
+					}
 				} else {
-					None
-				};
+					sweep_results.push((None, None));
+				}
 				// Drop the index *after* the scan finishes — strictly in this
 				// order so the timed scan sees the index.
 				let vec_index_remove = if vec_index_build.is_some() {
@@ -398,14 +437,25 @@ impl Benchmark {
 				} else {
 					None
 				};
-				runs.push(ScanRun {
-					workload: ScanWorkload::Read,
-					indexed: strategy_needs_index,
-					result: scan_result,
-				});
+				let swept = sweep_results.len() > 1;
+				for (value, result) in sweep_results {
+					runs.push(ScanRun {
+						workload: ScanWorkload::Read,
+						indexed: strategy_needs_index,
+						result,
+						label: value
+							.map(|v| format!("{} = {v}", search_param_label(&vq.index_strategy))),
+					});
+				}
 				ScanResult {
 					id: id.clone(),
-					name,
+					// A swept scan reports several legs under one build, so the
+					// value each leg used has to reach the row label.
+					name: if swept {
+						format!("{name} (sweep)")
+					} else {
+						name
+					},
 					iterations,
 					index_build: vec_index_build,
 					index_remove: vec_index_remove,
@@ -428,6 +478,7 @@ impl Benchmark {
 					workload: ScanWorkload::Read,
 					indexed: false,
 					result: without_index,
+					label: None,
 				});
 				// Optional mixed read+write legs on the heap path (one per `with_writes` entry)
 				for spec in write_specs {
@@ -450,6 +501,7 @@ impl Benchmark {
 						},
 						indexed: false,
 						result: mixed_without_index,
+						label: None,
 					});
 				}
 				// BuildIndex uses a single client to avoid races on DDL
@@ -520,6 +572,7 @@ impl Benchmark {
 						workload: ScanWorkload::Read,
 						indexed: true,
 						result: with_index,
+						label: None,
 					});
 					for (spec, r) in write_specs.iter().zip(indexed_write_results) {
 						runs.push(ScanRun {
@@ -528,6 +581,7 @@ impl Benchmark {
 							},
 							indexed: true,
 							result: r,
+							label: None,
 						});
 					}
 				} else {
@@ -536,6 +590,7 @@ impl Benchmark {
 						workload: ScanWorkload::Read,
 						indexed: true,
 						result: None,
+						label: None,
 					});
 					for spec in write_specs {
 						runs.push(ScanRun {
@@ -544,6 +599,7 @@ impl Benchmark {
 							},
 							indexed: true,
 							result: None,
+							label: None,
 						});
 					}
 				}
@@ -571,6 +627,7 @@ impl Benchmark {
 					workload: ScanWorkload::Read,
 					indexed: false,
 					result: without_index,
+					label: None,
 				});
 				for spec in write_specs {
 					let mixed_without_index = self
@@ -592,6 +649,7 @@ impl Benchmark {
 						},
 						indexed: false,
 						result: mixed_without_index,
+						label: None,
 					});
 				}
 				ScanResult {
@@ -1072,6 +1130,19 @@ impl Benchmark {
 			}
 		}
 		Ok((histogram, tally))
+	}
+}
+
+/// Config name of a strategy's search-time knob, for labelling sweep legs.
+fn search_param_label(strategy: &VectorIndexStrategy) -> &'static str {
+	match strategy {
+		VectorIndexStrategy::Hnsw {
+			..
+		} => "ef_search",
+		VectorIndexStrategy::DiskAnn {
+			..
+		} => "l_search",
+		VectorIndexStrategy::Bruteforce => "search",
 	}
 }
 

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -171,6 +171,72 @@ impl Benchmark {
 		Ok(())
 	}
 
+	/// Issue untimed queries until a freshly built vector index answers at a
+	/// steady rate.
+	///
+	/// The first leg timed after a build otherwise absorbs the whole cost of
+	/// warming the index, and not by a small margin: on a 50k-row HNSW the
+	/// first leg measured ~295ms per query against ~0.5ms for the identical
+	/// query in the leg that followed. Worse, it was *more accurate* — 0.935
+	/// recall against 0.853 for the same `ef_search` run later — so the first
+	/// leg is not merely slow, it answers differently. Reversing a sweep's order
+	/// moved the effect to whichever value ran first, which is what identified
+	/// it.
+	///
+	/// The cost is progressive rather than a single fault, so a fixed handful of
+	/// queries does not clear it. Warming instead runs until queries settle:
+	/// a run of consecutive ones close to the fastest seen, or a wall-clock cap
+	/// so a slow engine cannot stall the benchmark.
+	async fn warm_vector_index<C>(
+		&self,
+		clients: &[Arc<C>],
+		scan: &Scan,
+		query_set: &VectorQuerySet,
+		kp: &KeyProvider,
+		ctx: ScanContext,
+	) -> Result<()>
+	where
+		C: BenchmarkClient + Send + Sync,
+	{
+		let started = Instant::now();
+		for client in clients.iter() {
+			let mut previous: Option<Duration> = None;
+			let mut q = 0u32;
+			while started.elapsed() <= VECTOR_WARMUP_BUDGET {
+				// Time a whole window rather than single queries: while an index
+				// is warming its latency is *falling*, and once warm it is flat.
+				// Comparing consecutive windows detects that transition, where
+				// comparing single queries to the fastest so far does not — a
+				// uniformly slow cold index looks perfectly steady.
+				let window = Instant::now();
+				for _ in 0..VECTOR_WARMUP_WINDOW {
+					// An engine that cannot serve this scan fails the same way
+					// in the timed run, which is where it belongs in the output.
+					if client.scan_vector(scan, query_set.pick(q), kp, ctx).await.is_err() {
+						return Ok(());
+					}
+					q += 1;
+				}
+				let window = window.elapsed();
+				if let Some(previous) = previous {
+					// Stop once a window is no real improvement on the last —
+					// which is true immediately for an index that was already
+					// warm, so a later sweep leg pays only two windows.
+					if window * 100 >= previous * VECTOR_WARMUP_PLATEAU_PCT {
+						break;
+					}
+				}
+				previous = Some(window);
+			}
+		}
+		let waited = started.elapsed();
+		if waited > Duration::from_millis(500) {
+			self.bench_ui
+				.println_muted(&format!("Warmed the vector index in {}", format_duration(waited)));
+		}
+		Ok(())
+	}
+
 	/// Block until `index` is queryable as an index, not merely built.
 	///
 	/// SurrealDB reports `building.status = "ready"` once the initial build
@@ -258,13 +324,21 @@ impl Benchmark {
 				kp,
 				vp.clone(),
 				self.samples,
+				self.threads,
 			)
 			.await?;
 		// Compact the datastore
 		self.maybe_compact_datastore::<C, E>(&engine).await?;
 		// Run the "reads" benchmark
 		let reads = self
-			.run_operation::<C, D>(&clients, BenchmarkOperation::Read, kp, vp.clone(), self.samples)
+			.run_operation::<C, D>(
+				&clients,
+				BenchmarkOperation::Read,
+				kp,
+				vp.clone(),
+				self.samples,
+				self.threads,
+			)
 			.await?;
 		// Compact the datastore
 		self.maybe_compact_datastore::<C, E>(&engine).await?;
@@ -276,6 +350,7 @@ impl Benchmark {
 				kp,
 				vp.clone(),
 				self.samples,
+				self.threads,
 			)
 			.await?;
 		// Compact the datastore
@@ -303,6 +378,26 @@ impl Benchmark {
 			let iterations = scan.iterations.map(|s| s as u32).unwrap_or(self.samples);
 			let write_specs = scan.with_writes.as_slice();
 			let w = write_specs.len();
+			// A scan may run at its own concurrency. A query answering in
+			// well under a millisecond spends its time queueing rather than
+			// searching at the default settings — a KNN leg measured 0.4ms at
+			// one client and roughly 1500ms at sixty-four, which is the queue,
+			// not the index — so its latency only means anything lower down.
+			// Index DDL is unaffected; it always runs on a single client.
+			let leg_clients = match scan.clients {
+				Some(requested) => {
+					let capped = (requested as usize).clamp(1, clients.len());
+					if capped < requested as usize {
+						self.bench_ui.println_muted(&format!(
+							"Scan `{}` asked for {requested} clients; the pool holds {capped}",
+							scan.id
+						));
+					}
+					&clients[..capped]
+				}
+				None => &clients[..],
+			};
+			let leg_threads = scan.threads.unwrap_or(self.threads);
 			let index_spec = scan.with_index.as_ref().filter(|i| !i.skip);
 
 			// Vector-search scans take a dedicated path. Order matters:
@@ -357,6 +452,7 @@ impl Benchmark {
 						kp,
 						vp.clone(),
 						1,
+						leg_threads,
 					)
 					.await?;
 				if vec_index_build.is_some() {
@@ -409,33 +505,16 @@ impl Benchmark {
 								search_param_label(&vq.index_strategy)
 							));
 						}
-						// Warm the index before timing. The first leg after a
-						// build otherwise absorbs the cost of faulting the
-						// structure in, which made it read ~1000x slower than
-						// the identical leg that followed it — a sweep would
-						// have reported its first point as its worst whatever
-						// the parameter said.
-						for client in clients.iter() {
-							for w in 0..VECTOR_WARMUP_QUERIES {
-								match client
-									.scan_vector(&leg_scan, query_set.pick(w), &kp, ctx)
-									.await
-								{
-									Ok(_) => {}
-									// An engine that cannot serve this scan
-									// fails the same way in the timed run,
-									// which is where it is reported.
-									Err(_) => break,
-								}
-							}
-						}
+						self.warm_vector_index(leg_clients, &leg_scan, &query_set, &kp, ctx)
+							.await?;
 						let result = self
 							.run_operation::<C, D>(
-								&clients,
+								leg_clients,
 								BenchmarkOperation::VectorScan(leg_scan, ctx, query_set.clone()),
 								kp,
 								vp.clone(),
 								iterations,
+								leg_threads,
 							)
 							.await?;
 						sweep_results.push((leg, result));
@@ -452,6 +531,7 @@ impl Benchmark {
 						kp,
 						vp.clone(),
 						1,
+						leg_threads,
 					)
 					.await?
 				} else {
@@ -487,11 +567,12 @@ impl Benchmark {
 				// Table-scan / heap query (no physical index)
 				let without_index = self
 					.run_operation::<C, D>(
-						&clients,
+						leg_clients,
 						BenchmarkOperation::Scan(scan.clone(), ScanContext::WithoutIndex),
 						kp,
 						vp.clone(),
 						iterations,
+						leg_threads,
 					)
 					.await?;
 				runs.push(ScanRun {
@@ -504,7 +585,7 @@ impl Benchmark {
 				for spec in write_specs {
 					let mixed_without_index = self
 						.run_operation::<C, D>(
-							&clients,
+							leg_clients,
 							BenchmarkOperation::ScanWithWrites(
 								scan.clone(),
 								ScanContext::WithoutIndex,
@@ -513,6 +594,7 @@ impl Benchmark {
 							kp,
 							vp.clone(),
 							iterations,
+							leg_threads,
 						)
 						.await?;
 					runs.push(ScanRun {
@@ -536,6 +618,7 @@ impl Benchmark {
 						kp,
 						vp.clone(),
 						1,
+						leg_threads,
 					)
 					.await?;
 				let (with_index, index_remove, indexed_write_results) = if index_build.is_some() {
@@ -545,11 +628,12 @@ impl Benchmark {
 					// Same query shape using the new index
 					let with_index = self
 						.run_operation::<C, D>(
-							&clients,
+							leg_clients,
 							BenchmarkOperation::Scan(scan.clone(), ScanContext::WithIndex),
 							kp,
 							vp.clone(),
 							iterations,
+							leg_threads,
 						)
 						.await?;
 					let mut iw = Vec::with_capacity(w);
@@ -560,7 +644,7 @@ impl Benchmark {
 						self.await_index_queryable(&clients[0], &id).await?;
 						iw.push(
 							self.run_operation::<C, D>(
-								&clients,
+								leg_clients,
 								BenchmarkOperation::ScanWithWrites(
 									scan.clone(),
 									ScanContext::WithIndex,
@@ -569,6 +653,7 @@ impl Benchmark {
 								kp,
 								vp.clone(),
 								iterations,
+								leg_threads,
 							)
 							.await?,
 						);
@@ -580,6 +665,7 @@ impl Benchmark {
 							kp,
 							vp.clone(),
 							1,
+							leg_threads,
 						)
 						.await?;
 					(with_index, index_remove, iw)
@@ -636,11 +722,12 @@ impl Benchmark {
 				let mut runs = Vec::with_capacity(1 + w);
 				let without_index = self
 					.run_operation::<C, D>(
-						&clients,
+						leg_clients,
 						BenchmarkOperation::Scan(scan.clone(), ScanContext::WithoutIndex),
 						kp,
 						vp.clone(),
 						iterations,
+						leg_threads,
 					)
 					.await?;
 				runs.push(ScanRun {
@@ -652,7 +739,7 @@ impl Benchmark {
 				for spec in write_specs {
 					let mixed_without_index = self
 						.run_operation::<C, D>(
-							&clients,
+							leg_clients,
 							BenchmarkOperation::ScanWithWrites(
 								scan.clone(),
 								ScanContext::WithoutIndex,
@@ -661,6 +748,7 @@ impl Benchmark {
 							kp,
 							vp.clone(),
 							iterations,
+							leg_threads,
 						)
 						.await?;
 					runs.push(ScanRun {
@@ -694,6 +782,7 @@ impl Benchmark {
 				kp,
 				vp.clone(),
 				self.samples,
+				self.threads,
 			)
 			.await?;
 		// Compact the datastore
@@ -716,8 +805,16 @@ impl Benchmark {
 				crate::BatchOperationType::Delete => BenchmarkOperation::BatchDelete(batch.clone()),
 			};
 			// Execute the batch benchmark
-			let duration =
-				self.run_operation::<C, D>(&clients, operation, kp, vp.clone(), iterations).await?;
+			let duration = self
+				.run_operation::<C, D>(
+					&clients,
+					operation,
+					kp,
+					vp.clone(),
+					iterations,
+					self.threads,
+				)
+				.await?;
 			// Store the batch benchmark result
 			batch_results.push((name, iterations, groups, duration));
 		}
@@ -885,6 +982,7 @@ impl Benchmark {
 		kp: KeyProvider,
 		vp: ValueProvider,
 		samples: u32,
+		threads: u32,
 	) -> Result<Option<OperationResult>>
 	where
 		C: BenchmarkClient + Send + Sync,
@@ -913,7 +1011,7 @@ impl Benchmark {
 		// Loop over the clients
 		for (client, _) in clients.iter().cloned().zip(1..) {
 			// Loop over the threads
-			for _ in 0..self.threads {
+			for _ in 0..threads {
 				let error = error.clone();
 				let skip = skip.clone();
 				let current = current.clone();
@@ -1153,11 +1251,15 @@ impl Benchmark {
 	}
 }
 
-/// Untimed queries issued per client before a vector leg is timed.
-///
-/// Enough to fault in the index structure and warm the caches the engine keeps
-/// per connection, without materially adding to a run's wall time.
-const VECTOR_WARMUP_QUERIES: u32 = 5;
+/// Warm-up queries measured together before checking for a plateau.
+const VECTOR_WARMUP_WINDOW: u32 = 25;
+
+/// A window this close to the one before it means warming has plateaued.
+/// Expressed as a percentage so the comparison stays in integer arithmetic.
+const VECTOR_WARMUP_PLATEAU_PCT: u32 = 90;
+
+/// Cap on warm-up across all clients, so a slow engine cannot stall a run.
+const VECTOR_WARMUP_BUDGET: Duration = Duration::from_secs(120);
 
 /// Config name of a strategy's search-time knob, for labelling sweep legs.
 fn search_param_label(strategy: &VectorIndexStrategy) -> &'static str {

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -171,6 +171,38 @@ impl Benchmark {
 		Ok(())
 	}
 
+	/// Block until `index` is queryable as an index, not merely built.
+	///
+	/// SurrealDB reports `building.status = "ready"` once the initial build
+	/// finishes, but rows indexed afterwards sit in a pending queue that
+	/// queries answer by scanning it linearly, drained by a background task on
+	/// its own interval. A leg timed against an undrained queue measures that
+	/// scan wearing the index's name.
+	///
+	/// Called between timed operations so the wait lands in no measurement, and
+	/// before every indexed leg rather than only after the build: a leg that
+	/// writes leaves a queue behind, and the next leg would otherwise inherit
+	/// it and report a number that depends on what ran before it.
+	///
+	/// Unrelated to `COMPACTION` / `ALTER SYSTEM COMPACT`, which compacts the
+	/// storage keyspace and does nothing for this queue. Engines without such a
+	/// queue no-op.
+	async fn await_index_queryable<C>(&self, client: &Arc<C>, index: &str) -> Result<()>
+	where
+		C: BenchmarkClient + Send + Sync,
+	{
+		let started = Instant::now();
+		client.await_index_queryable(index).await?;
+		let waited = started.elapsed();
+		if waited > Duration::from_millis(200) {
+			self.bench_ui.println_muted(&format!(
+				"Waited {} for index `{index}` to become queryable",
+				format_duration(waited)
+			));
+		}
+		Ok(())
+	}
+
 	/// Sleep a fixed beat to let any server-side phase tail settle (open
 	/// snapshots, draining tasks, deferred cleanup that outlives the
 	/// client's `try_join_all`), then emit the grep-friendly `Server idle`
@@ -328,22 +360,7 @@ impl Benchmark {
 					)
 					.await?;
 				if vec_index_build.is_some() {
-					// A vector index reports itself built well before it is
-					// actually serving queries from the graph: newly indexed
-					// vectors sit in a pending queue that KNN answers by
-					// scanning linearly. Waiting here — after the timed build,
-					// before the timed scan — keeps a background drain out of
-					// the build number and a brute-force scan out of the KNN
-					// number.
-					let waited = Instant::now();
-					clients[0].await_index_queryable(&id).await?;
-					let waited = waited.elapsed();
-					if waited > Duration::from_millis(200) {
-						self.bench_ui.println_muted(&format!(
-							"Waited {} for index `{id}` to become queryable",
-							format_duration(waited)
-						));
-					}
+					self.await_index_queryable(&clients[0], &id).await?;
 					self.maybe_compact_datastore::<C, E>(&engine).await?;
 				}
 				// Run the scan if either the strategy doesn't require an index
@@ -452,6 +469,7 @@ impl Benchmark {
 				let (with_index, index_remove, indexed_write_results) = if index_build.is_some() {
 					// Compact the datastore so the indexed-scan phases benchmark a compacted index.
 					self.maybe_compact_datastore::<C, E>(&engine).await?;
+					self.await_index_queryable(&clients[0], &id).await?;
 					// Same query shape using the new index
 					let with_index = self
 						.run_operation::<C, D>(
@@ -464,6 +482,10 @@ impl Benchmark {
 						.await?;
 					let mut iw = Vec::with_capacity(w);
 					for spec in write_specs {
+						// The previous leg's writes leave a queue behind; drain
+						// it so each leg is timed from the same index state
+						// instead of inheriting whatever ran before it.
+						self.await_index_queryable(&clients[0], &id).await?;
 						iw.push(
 							self.run_operation::<C, D>(
 								&clients,

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -13,9 +13,9 @@ use crate::result::{
 use crate::system::SystemInfo;
 use crate::terminal::BenchUi;
 use crate::util::format_duration;
-use crate::value::BenchValue;
 use crate::valueprovider::ColumnType;
-use crate::valueprovider::ValueProvider;
+use crate::valueprovider::{ValueProvider, ValueStream};
+use crate::vectorgt::{self, GroundTruth};
 use crate::workloads;
 use crate::{
 	Args, BatchOperation, Batches, Index, Scan, ScanWithWrites, Scans, VectorHoldout,
@@ -31,6 +31,7 @@ use tokio::task::JoinSet;
 use tokio::time::Instant;
 
 use std::fmt::{Display, Formatter};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::time::{Duration, SystemTime};
@@ -48,13 +49,23 @@ const QUIESCE_DELAY: Duration = Duration::from_secs(1);
 /// Error string returned by adapters to mark an operation as unsupported (skipped, not fatal).
 pub(crate) const NOT_SUPPORTED_ERROR: &str = "NotSupported";
 
-/// Pre-fetched query set for a vector-search scan. Holds `count` query vectors
-/// sampled deterministically from the inserted records, indexed by sample
-/// number with simple modulo wrap-around. Memory cost is constant in `count`
-/// (independent of the dataset size).
+/// Query set for a vector-search scan, indexed by sample number with simple
+/// modulo wrap-around. Memory cost is constant in `count`, independent of the
+/// dataset size.
+///
+/// Queries are generated from their own seed and never inserted, so they are
+/// disjoint from the corpus by construction: no query is its own nearest
+/// neighbour, which would otherwise hand every index one free hit in each
+/// top-k. Generating them also means no engine read is needed to materialise
+/// the set, so an engine that cannot round-trip a vector column no longer
+/// changes how the queries are built.
 #[derive(Debug, Clone)]
 pub(crate) struct VectorQuerySet {
 	pub(crate) queries: Arc<Vec<Vec<f32>>>,
+	/// Exact answer key for these queries, when one was computed. Shared by
+	/// every engine rather than taken from the engine's own exact leg, so the
+	/// recall it scores is comparable across engines.
+	pub(crate) ground_truth: Option<Arc<GroundTruth>>,
 }
 
 impl VectorQuerySet {
@@ -62,56 +73,6 @@ impl VectorQuerySet {
 		let q = &self.queries[(sample as usize) % self.queries.len()];
 		q.as_slice()
 	}
-}
-
-/// Pull a `FloatVector` out of a row's named column, accepting the packed
-/// [`BenchValue::FloatVector`], a generic `Array<Float>` (SurrealDB), or a
-/// `Bytes` payload of packed little-endian f32s (SQL backends that fall back
-/// to BYTEA/BLOB columns for vectors).
-///
-/// Any other shape — including a missing field — bails with
-/// [`NOT_SUPPORTED_ERROR`] so the scan skips cleanly on backends that don't
-/// round-trip vector payloads in any of these forms.
-fn extract_vector_field(row: &BenchValue, field: &str) -> Result<Vec<f32>> {
-	let Some(v) = row.get_field(field) else {
-		bail!(NOT_SUPPORTED_ERROR);
-	};
-	match v {
-		BenchValue::FloatVector(v) => Ok(v.clone()),
-		BenchValue::Array(a) => {
-			let mut out = Vec::with_capacity(a.len());
-			for elem in a {
-				match elem {
-					BenchValue::Float(f) => out.push(*f as f32),
-					BenchValue::Int(i) => out.push(*i as f32),
-					BenchValue::UInt(u) => out.push(*u as f32),
-					BenchValue::Decimal(d) => {
-						out.push(rust_decimal::prelude::ToPrimitive::to_f32(d).unwrap_or(0.0))
-					}
-					_ => bail!(NOT_SUPPORTED_ERROR),
-				}
-			}
-			Ok(out)
-		}
-		BenchValue::Bytes(b) if b.len() % 4 == 0 => Ok(bytemuck::cast_slice::<u8, f32>(b).to_vec()),
-		_ => bail!(NOT_SUPPORTED_ERROR),
-	}
-}
-
-/// Deterministically pick `count` sample indices from `[0, samples)` using `seed`.
-fn holdout_indices(samples: u32, count: usize, seed: u64) -> Vec<u32> {
-	use rand::RngExt as _;
-	use rand::SeedableRng;
-	use rand::prelude::SmallRng;
-	let total = samples as usize;
-	let count = count.min(total);
-	let mut rng = SmallRng::seed_from_u64(seed);
-	let mut out = Vec::with_capacity(count);
-	for _ in 0..count {
-		let pick = rng.random_range(0u32..samples);
-		out.push(pick);
-	}
-	out
 }
 
 /// Shared benchmark settings and UI, built from CLI [`crate::Args`].
@@ -138,6 +99,11 @@ pub(crate) struct Benchmark {
 	pub(crate) optimised: bool,
 	/// Per-operation timeout
 	pub(crate) operation_timeout: Duration,
+	/// Directory holding cached vector-search ground truth
+	pub(crate) ground_truth_cache: PathBuf,
+	/// JSON form of the configured value template. Ground truth keys its cache
+	/// on it: a schema change alters the corpus even at an unchanged seed.
+	pub(crate) value_template: String,
 	/// Terminal UI (tables, progress bars, phase markers).
 	pub(crate) bench_ui: BenchUi,
 	/// Grep-friendly `… starting` / `Benchmark starting` lines for profiling scripts
@@ -166,7 +132,15 @@ impl Benchmark {
 			operation_timeout: Duration::from_secs(args.operation_timeout),
 			bench_ui: BenchUi::new(args.color),
 			emit_phase_markers,
+			ground_truth_cache: PathBuf::from(&args.ground_truth_cache),
+			value_template: String::new(),
 		}
+	}
+
+	/// Record the value template this run was configured with, which is part of
+	/// the vector ground-truth cache key.
+	pub(crate) fn set_value_template(&mut self, template: String) {
+		self.value_template = template;
 	}
 
 	/// When `COMPACTION` is set in the environment, run the engine-specific
@@ -291,14 +265,18 @@ impl Benchmark {
 			let index_spec = scan.with_index.as_ref().filter(|i| !i.skip);
 
 			// Vector-search scans take a dedicated path. Order matters:
-			//   1. Build the holdout query set (skipped if the engine can't
-			//      surface a readable vector — same skip semantics as fulltext).
+			//   1. Generate the query set from its own seed. These vectors are
+			//      never inserted, so they are disjoint from the corpus and
+			//      need no engine read to materialise.
 			//   2. Always invoke BuildVectorIndex. Engines decide whether the
 			//      chosen strategy needs an actual index (Redis Bruteforce
 			//      builds a FLAT FT index; Surreal/Postgres Bruteforce return
 			//      NotSupported and the scan still runs without one).
-			//   3. Run the timed VectorScan.
-			//   4. RemoveIndex iff Build succeeded — strictly after the scan.
+			//   3. Compute or load the exact answer key, but only once the scan
+			//      is known to run — an unsupported engine skips before paying
+			//      for a corpus sweep.
+			//   4. Run the timed VectorScan.
+			//   5. RemoveIndex iff Build succeeded — strictly after the scan.
 			let result = if let Some(vq) = scan.vector_query.clone() {
 				let dim = vp
 					.columns()
@@ -319,108 +297,77 @@ impl Benchmark {
 					vq.index_strategy,
 					VectorIndexStrategy::Hnsw { .. } | VectorIndexStrategy::DiskAnn { .. }
 				);
-				let query_set = self
-					.build_vector_query_set::<C>(&clients[0], &scan, &vq, kp, self.samples)
-					.await?;
+				let mut query_set = self.build_vector_query_set(&scan, &vq, &vp)?;
 				let mut runs = Vec::with_capacity(1);
-				match query_set {
-					None => {
-						// Engine doesn't surface vector reads — skip the whole scan.
-						runs.push(ScanRun {
-							workload: ScanWorkload::Read,
-							indexed: strategy_needs_index,
-							result: None,
-						});
-						ScanResult {
-							id: id.clone(),
-							name,
-							iterations,
-							index_build: None,
-							index_remove: None,
-							runs,
-						}
-					}
-					Some(query_set) => {
-						// Derive the index spec from `vector_query.field` so
-						// the user only declares the field once. Engines that
-						// don't need an index for the chosen strategy ignore
-						// `idx_spec` and return NotSupported from build.
-						let idx_spec = Index {
-							skip: false,
-							fields: vec![vq.field.clone()],
-							unique: None,
-							index_type: None,
-						};
-						let vec_index_build = self
-							.run_operation::<C, D>(
-								&clients[..1],
-								BenchmarkOperation::BuildVectorIndex(
-									idx_spec,
-									vq.clone(),
-									dim,
-									id.clone(),
-								),
-								kp,
-								vp.clone(),
-								1,
-							)
-							.await?;
-						if vec_index_build.is_some() {
-							self.maybe_compact_datastore::<C, E>(&engine).await?;
-						}
-						// Run the scan if either the strategy doesn't require
-						// an index (so a missing build is fine) or build
-						// actually produced an index. HNSW/DiskANN with no
-						// index = skip.
-						let ctx = if strategy_needs_index {
-							ScanContext::WithIndex
-						} else {
-							ScanContext::WithoutIndex
-						};
-						let scan_result = if !strategy_needs_index || vec_index_build.is_some() {
-							self.run_operation::<C, D>(
-								&clients,
-								BenchmarkOperation::VectorScan(
-									scan.clone(),
-									ctx,
-									query_set.clone(),
-								),
-								kp,
-								vp.clone(),
-								iterations,
-							)
-							.await?
-						} else {
-							None
-						};
-						// Drop the index *after* the scan finishes — strictly
-						// in this order so the timed scan sees the index.
-						let vec_index_remove = if vec_index_build.is_some() {
-							self.run_operation::<C, D>(
-								&clients[..1],
-								BenchmarkOperation::RemoveIndex(id.clone(), name.clone()),
-								kp,
-								vp.clone(),
-								1,
-							)
-							.await?
-						} else {
-							None
-						};
-						runs.push(ScanRun {
-							workload: ScanWorkload::Read,
-							indexed: strategy_needs_index,
-							result: scan_result,
-						});
-						ScanResult {
-							id: id.clone(),
-							name,
-							iterations,
-							index_build: vec_index_build,
-							index_remove: vec_index_remove,
-							runs,
-						}
-					}
+				// Derive the index spec from `vector_query.field` so the user
+				// only declares the field once. Engines that don't need an
+				// index for the chosen strategy ignore `idx_spec` and return
+				// NotSupported from build.
+				let idx_spec = Index {
+					skip: false,
+					fields: vec![vq.field.clone()],
+					unique: None,
+					index_type: None,
+				};
+				let vec_index_build = self
+					.run_operation::<C, D>(
+						&clients[..1],
+						BenchmarkOperation::BuildVectorIndex(idx_spec, vq.clone(), dim, id.clone()),
+						kp,
+						vp.clone(),
+						1,
+					)
+					.await?;
+				if vec_index_build.is_some() {
+					self.maybe_compact_datastore::<C, E>(&engine).await?;
+				}
+				// Run the scan if either the strategy doesn't require an index
+				// (so a missing build is fine) or build actually produced one.
+				// HNSW/DiskANN with no index = skip.
+				let ctx = if strategy_needs_index {
+					ScanContext::WithIndex
+				} else {
+					ScanContext::WithoutIndex
+				};
+				let scan_result = if !strategy_needs_index || vec_index_build.is_some() {
+					self.attach_ground_truth(&scan, &vq, &vp, &mut query_set)?;
+					self.run_operation::<C, D>(
+						&clients,
+						BenchmarkOperation::VectorScan(scan.clone(), ctx, query_set.clone()),
+						kp,
+						vp.clone(),
+						iterations,
+					)
+					.await?
+				} else {
+					None
+				};
+				// Drop the index *after* the scan finishes — strictly in this
+				// order so the timed scan sees the index.
+				let vec_index_remove = if vec_index_build.is_some() {
+					self.run_operation::<C, D>(
+						&clients[..1],
+						BenchmarkOperation::RemoveIndex(id.clone(), name.clone()),
+						kp,
+						vp.clone(),
+						1,
+					)
+					.await?
+				} else {
+					None
+				};
+				runs.push(ScanRun {
+					workload: ScanWorkload::Read,
+					indexed: strategy_needs_index,
+					result: scan_result,
+				});
+				ScanResult {
+					id: id.clone(),
+					name,
+					iterations,
+					index_build: vec_index_build,
+					index_remove: vec_index_remove,
+					runs,
 				}
 			} else if let Some(index_spec) = index_spec {
 				// Indexed scan: heap legs → build index → indexed legs → drop index
@@ -683,59 +630,78 @@ impl Benchmark {
 	/// rather than spawning a fresh one — `wait_for_client` carries a
 	/// per-engine pre-connect sleep (5s on SurrealDB) that compounds across
 	/// the three vector legs.
-	async fn build_vector_query_set<C>(
+	fn build_vector_query_set(
 		&self,
-		client: &Arc<C>,
 		scan: &Scan,
 		vq: &VectorQuerySpec,
-		mut kp: KeyProvider,
-		samples: u32,
-	) -> Result<Option<VectorQuerySet>>
-	where
-		C: BenchmarkClient + Send + Sync,
-	{
+		vp: &ValueProvider,
+	) -> Result<VectorQuerySet> {
 		let VectorHoldout {
 			count,
 			seed,
 		} = vq.holdout.clone();
-		let ids = holdout_indices(samples, count, seed);
-		let mut queries = Vec::with_capacity(ids.len());
-		for n in ids {
-			// Read failures and shape mismatches both mean "this engine can't
-			// give us a usable vector for the holdout". Treat both as skip
-			// signals so an engine without vector support never aborts the
-			// whole benchmark — the scan still records a clean `-` cell,
-			// matching how fulltext skips on engines without fulltext. Log
-			// the underlying cause so CI runs can tell a real engine bug
-			// (worth fixing) apart from an unsupported engine (correct skip).
-			let row = match client.read(n, &mut kp).await {
-				Ok(r) => r,
-				Err(e) => {
-					eprintln!("vector holdout: skipping scan `{}` (read: {e:#})", scan.name);
-					return Ok(None);
-				}
-			};
-			let bv: BenchValue = row.into();
-			match extract_vector_field(&bv, &vq.field) {
-				Ok(v) => queries.push(v),
-				Err(e) => {
-					eprintln!("vector holdout: skipping scan `{}` (extract: {e})", scan.name);
-					return Ok(None);
-				}
-			}
-		}
-		// Belt-and-suspenders for `VectorQuerySet::pick`'s
-		// `sample % queries.len()` — the validator already rejects
-		// `holdout.count == 0`, but anything else that ends up returning
-		// zero queries (e.g. `samples = 0`) skips the scan cleanly here
-		// rather than panicking inside the timed window.
+		let queries = vp
+			.generate_vectors(&vq.field, count, seed)
+			.with_context(|| format!("scan `{}`: building the vector query set", scan.name))?;
+		// `VectorQuerySet::pick` indexes modulo the query count, so an empty set
+		// would panic inside the timed window. The validator already rejects
+		// `holdout.count == 0`; this covers anything else that reaches zero.
 		if queries.is_empty() {
-			eprintln!("vector holdout: skipping scan `{}` (empty query set)", scan.name);
-			return Ok(None);
+			bail!("scan `{}`: vector query set is empty", scan.name);
 		}
-		Ok(Some(VectorQuerySet {
+		Ok(VectorQuerySet {
 			queries: Arc::new(queries),
-		}))
+			ground_truth: None,
+		})
+	}
+
+	/// Attach the exact answer key for a scan's query set, computing it or
+	/// loading it from cache.
+	///
+	/// Deferred until the scan is known to run: an engine without vector
+	/// support skips before this point, and there is no reason to spend a full
+	/// corpus sweep producing a key nothing will score against.
+	fn attach_ground_truth(
+		&self,
+		scan: &Scan,
+		vq: &VectorQuerySpec,
+		vp: &ValueProvider,
+		query_set: &mut VectorQuerySet,
+	) -> Result<()> {
+		let Some(corpus_seed) = vp.seed() else {
+			// Recall needs a reconstructible corpus. Without a seed the scan is
+			// still perfectly valid as a latency measurement, so say what is
+			// missing and carry on rather than failing the run.
+			eprintln!(
+				"vector ground truth: scan `{}` will report latency only — set `seed` in the benchmark TOML or pass --corpus-seed to enable recall",
+				scan.name
+			);
+			return Ok(());
+		};
+		let request = vectorgt::Request {
+			field: vq.field.clone(),
+			samples: self.samples,
+			top_k: vq.top_k,
+			metric: vq.distance,
+			corpus_seed,
+			query_seed: vq.holdout.seed,
+			query_count: query_set.queries.len(),
+			template: self.value_template.clone(),
+		};
+		let started = Instant::now();
+		let (gt, cached) =
+			vectorgt::load_or_compute(&request, vp, &query_set.queries, &self.ground_truth_cache)
+				.with_context(|| format!("scan `{}`: computing vector ground truth", scan.name))?;
+		if !cached {
+			self.bench_ui.println_muted(&format!(
+				"Computed exact ground truth for {} queries over {} rows in {}",
+				query_set.queries.len(),
+				self.samples,
+				format_duration(started.elapsed())
+			));
+		}
+		query_set.ground_truth = Some(Arc::new(gt));
+		Ok(())
 	}
 
 	/// Polls until [`BenchmarkEngine::create_client`] succeeds or [`TIMEOUT`] elapses.
@@ -982,12 +948,12 @@ impl Benchmark {
 			tokio::time::timeout(operation_timeout, async {
 				match &operation {
 					BenchmarkOperation::Create => {
-						let value = vp.generate_value();
+						let value = vp.generate_value_for(ValueStream::Create, sample);
 						client.create(sample, value, &mut kp).await
 					}
 					BenchmarkOperation::Read => client.read(sample, &mut kp).await.map(|_| ()),
 					BenchmarkOperation::Update => {
-						let value = vp.generate_value();
+						let value = vp.generate_value_for(ValueStream::Update, sample);
 						client.update(sample, value, &mut kp).await
 					}
 					BenchmarkOperation::Scan(s, ctx) => client.scan(s, &kp, *ctx).await,

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -505,8 +505,14 @@ impl Benchmark {
 								search_param_label(&vq.index_strategy)
 							));
 						}
-						self.warm_vector_index(leg_clients, &leg_scan, &query_set, &kp, ctx)
-							.await?;
+						// Only an index needs priming. A bruteforce leg has none,
+						// and every warm-up query there is a full linear scan —
+						// which is both pointless and the most expensive query
+						// the benchmark can issue.
+						if strategy_needs_index {
+							self.warm_vector_index(leg_clients, &leg_scan, &query_set, &kp, ctx)
+								.await?;
+						}
 						let result = self
 							.run_operation::<C, D>(
 								leg_clients,
@@ -1259,7 +1265,11 @@ const VECTOR_WARMUP_WINDOW: u32 = 25;
 const VECTOR_WARMUP_PLATEAU_PCT: u32 = 90;
 
 /// Cap on warm-up across all clients, so a slow engine cannot stall a run.
-const VECTOR_WARMUP_BUDGET: Duration = Duration::from_secs(120);
+///
+/// Deliberately short. Warming is an accuracy fix, not a benchmark phase, and a
+/// cap long enough to matter is long enough to blow a CI step's timeout — which
+/// it did at 120s.
+const VECTOR_WARMUP_BUDGET: Duration = Duration::from_secs(30);
 
 /// Config name of a strategy's search-time knob, for labelling sweep legs.
 fn search_param_label(strategy: &VectorIndexStrategy) -> &'static str {

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -110,6 +110,8 @@ pub(crate) struct Benchmark {
 	pub(crate) operation_timeout: Duration,
 	/// Directory holding cached vector-search ground truth
 	pub(crate) ground_truth_cache: PathBuf,
+	/// Safety cap on warming a vector index before a timed leg
+	pub(crate) vector_warmup_budget: Duration,
 	/// JSON form of the configured value template. Ground truth keys its cache
 	/// on it: a schema change alters the corpus even at an unchanged seed.
 	pub(crate) value_template: String,
@@ -142,6 +144,7 @@ impl Benchmark {
 			bench_ui: BenchUi::new(args.color),
 			emit_phase_markers,
 			ground_truth_cache: PathBuf::from(&args.ground_truth_cache),
+			vector_warmup_budget: Duration::from_secs(args.vector_warmup_seconds),
 			value_template: String::new(),
 		}
 	}
@@ -202,7 +205,7 @@ impl Benchmark {
 		for client in clients.iter() {
 			let mut previous: Option<Duration> = None;
 			let mut q = 0u32;
-			while started.elapsed() <= VECTOR_WARMUP_BUDGET {
+			while started.elapsed() <= self.vector_warmup_budget {
 				// Time a whole window rather than single queries: while an index
 				// is warming its latency is *falling*, and once warm it is flat.
 				// Comparing consecutive windows detects that transition, where
@@ -230,7 +233,17 @@ impl Benchmark {
 			}
 		}
 		let waited = started.elapsed();
-		if waited > Duration::from_millis(500) {
+		if waited > self.vector_warmup_budget {
+			// A truncated warm-up leaves the index cold, and a cold index is
+			// both slower and — because it answers by a different path — more
+			// accurate. Reporting that silently is how this went unnoticed for
+			// several runs, so say it loudly instead.
+			self.bench_ui.println_muted(&format!(
+				"Warm-up hit its {} budget: the next leg's latency is understated and its \
+				 recall overstated. Raise --vector-warmup-seconds.",
+				format_duration(self.vector_warmup_budget)
+			));
+		} else if waited > Duration::from_millis(500) {
 			self.bench_ui
 				.println_muted(&format!("Warmed the vector index in {}", format_duration(waited)));
 		}
@@ -1263,13 +1276,6 @@ const VECTOR_WARMUP_WINDOW: u32 = 25;
 /// A window this close to the one before it means warming has plateaued.
 /// Expressed as a percentage so the comparison stays in integer arithmetic.
 const VECTOR_WARMUP_PLATEAU_PCT: u32 = 90;
-
-/// Cap on warm-up across all clients, so a slow engine cannot stall a run.
-///
-/// Deliberately short. Warming is an accuracy fix, not a benchmark phase, and a
-/// cap long enough to matter is long enough to blow a CI step's timeout — which
-/// it did at 120s.
-const VECTOR_WARMUP_BUDGET: Duration = Duration::from_secs(30);
 
 /// Config name of a strategy's search-time knob, for labelling sweep legs.
 fn search_param_label(strategy: &VectorIndexStrategy) -> &'static str {

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -588,6 +588,8 @@ impl Benchmark {
 					index_build: vec_index_build,
 					index_remove: vec_index_remove,
 					runs,
+					clients: leg_clients.len() as u32,
+					threads: leg_threads,
 				}
 			} else if let Some(index_spec) = index_spec {
 				// Indexed scan: heap legs → build index → indexed legs → drop index
@@ -744,6 +746,8 @@ impl Benchmark {
 					index_build,
 					index_remove,
 					runs,
+					clients: leg_clients.len() as u32,
+					threads: leg_threads,
 				}
 			} else {
 				// No index spec (or index skipped): only heap scan + optional write-mix legs
@@ -795,6 +799,8 @@ impl Benchmark {
 					index_build: None,
 					index_remove: None,
 					runs,
+					clients: leg_clients.len() as u32,
+					threads: leg_threads,
 				}
 			};
 			scan_results.push(result);

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,12 @@ pub(crate) struct BenchToml {
 	#[serde(default)]
 	pub(crate) batches: Vec<BatchOperation>,
 	pub(crate) value: Value,
+	/// Corpus seed. When set, generated row content is a pure function of this
+	/// seed and the sample index, so a run is reproducible and the corpus can
+	/// be reconstructed for vector-search ground truth without reading rows
+	/// back. Omitted means the historical behaviour: values drawn from entropy.
+	#[serde(default)]
+	pub(crate) seed: Option<u64>,
 }
 
 pub(crate) fn load_bench_toml(path: &str) -> Result<BenchToml> {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2,7 +2,7 @@ use crate::Benchmark;
 use crate::benchmark::NOT_SUPPORTED_ERROR;
 use crate::keyprovider::{IntegerKeyProvider, KeyProvider, StringKeyProvider};
 use crate::value::BenchValue;
-use crate::valueprovider::Columns;
+use crate::valueprovider::{Columns, ValueStream};
 use crate::{BatchOperation, Index, KeyType, Scan, VectorQuerySpec};
 use anyhow::{Result, bail};
 use std::future::Future;
@@ -279,19 +279,23 @@ pub(crate) trait BenchmarkClient: Sync + Send + 'static {
 		async move {
 			match kp {
 				KeyProvider::OrderedInteger(p) => {
-					let pairs_iter = generate_integer_key_values_iter(n, batch_op, p, vp);
+					let pairs_iter =
+						generate_integer_key_values_iter(n, batch_op, p, vp, ValueStream::Create);
 					self.batch_create_u32(pairs_iter).await
 				}
 				KeyProvider::UnorderedInteger(p) => {
-					let pairs_iter = generate_integer_key_values_iter(n, batch_op, p, vp);
+					let pairs_iter =
+						generate_integer_key_values_iter(n, batch_op, p, vp, ValueStream::Create);
 					self.batch_create_u32(pairs_iter).await
 				}
 				KeyProvider::OrderedString(p) => {
-					let pairs_iter = generate_string_key_values_iter(n, batch_op, p, vp);
+					let pairs_iter =
+						generate_string_key_values_iter(n, batch_op, p, vp, ValueStream::Create);
 					self.batch_create_string(pairs_iter).await
 				}
 				KeyProvider::UnorderedString(p) => {
-					let pairs_iter = generate_string_key_values_iter(n, batch_op, p, vp);
+					let pairs_iter =
+						generate_string_key_values_iter(n, batch_op, p, vp, ValueStream::Create);
 					self.batch_create_string(pairs_iter).await
 				}
 			}
@@ -338,19 +342,23 @@ pub(crate) trait BenchmarkClient: Sync + Send + 'static {
 		async move {
 			match kp {
 				KeyProvider::OrderedInteger(p) => {
-					let pairs_iter = generate_integer_key_values_iter(n, batch_op, p, vp);
+					let pairs_iter =
+						generate_integer_key_values_iter(n, batch_op, p, vp, ValueStream::Update);
 					self.batch_update_u32(pairs_iter).await
 				}
 				KeyProvider::UnorderedInteger(p) => {
-					let pairs_iter = generate_integer_key_values_iter(n, batch_op, p, vp);
+					let pairs_iter =
+						generate_integer_key_values_iter(n, batch_op, p, vp, ValueStream::Update);
 					self.batch_update_u32(pairs_iter).await
 				}
 				KeyProvider::OrderedString(p) => {
-					let pairs_iter = generate_string_key_values_iter(n, batch_op, p, vp);
+					let pairs_iter =
+						generate_string_key_values_iter(n, batch_op, p, vp, ValueStream::Update);
 					self.batch_update_string(pairs_iter).await
 				}
 				KeyProvider::UnorderedString(p) => {
-					let pairs_iter = generate_string_key_values_iter(n, batch_op, p, vp);
+					let pairs_iter =
+						generate_string_key_values_iter(n, batch_op, p, vp, ValueStream::Update);
 					self.batch_update_string(pairs_iter).await
 				}
 			}
@@ -518,6 +526,9 @@ struct IntegerKeyValuesIter<'a> {
 	current: usize,
 	kp: &'a mut dyn IntegerKeyProvider,
 	vp: &'a mut crate::valueprovider::ValueProvider,
+	/// Derivation stream for the payloads, so a seeded run reproduces batch
+	/// content the same way single-row create and update do.
+	stream: ValueStream,
 }
 
 impl<'a> Iterator for IntegerKeyValuesIter<'a> {
@@ -527,7 +538,7 @@ impl<'a> Iterator for IntegerKeyValuesIter<'a> {
 		if self.current < self.batch_size {
 			let sample_idx = self.n * self.batch_size as u32 + self.current as u32;
 			let key = self.kp.key(sample_idx);
-			let value = self.vp.generate_value();
+			let value = self.vp.generate_value_for(self.stream, sample_idx);
 			self.current += 1;
 			Some((key, value))
 		} else {
@@ -550,6 +561,9 @@ struct StringKeyValuesIter<'a> {
 	current: usize,
 	kp: &'a mut dyn StringKeyProvider,
 	vp: &'a mut crate::valueprovider::ValueProvider,
+	/// Derivation stream for the payloads, so a seeded run reproduces batch
+	/// content the same way single-row create and update do.
+	stream: ValueStream,
 }
 
 impl<'a> Iterator for StringKeyValuesIter<'a> {
@@ -559,7 +573,7 @@ impl<'a> Iterator for StringKeyValuesIter<'a> {
 		if self.current < self.batch_size {
 			let sample_idx = self.n * self.batch_size as u32 + self.current as u32;
 			let key = self.kp.key(sample_idx);
-			let value = self.vp.generate_value();
+			let value = self.vp.generate_value_for(self.stream, sample_idx);
 			self.current += 1;
 			Some((key, value))
 		} else {
@@ -609,6 +623,7 @@ fn generate_integer_key_values_iter<'a>(
 	batch_op: &BatchOperation,
 	kp: &'a mut dyn IntegerKeyProvider,
 	vp: &'a mut crate::valueprovider::ValueProvider,
+	stream: ValueStream,
 ) -> IntegerKeyValuesIter<'a> {
 	IntegerKeyValuesIter {
 		n,
@@ -616,6 +631,7 @@ fn generate_integer_key_values_iter<'a>(
 		current: 0,
 		kp,
 		vp,
+		stream,
 	}
 }
 
@@ -625,6 +641,7 @@ fn generate_string_key_values_iter<'a>(
 	batch_op: &BatchOperation,
 	kp: &'a mut dyn StringKeyProvider,
 	vp: &'a mut crate::valueprovider::ValueProvider,
+	stream: ValueStream,
 ) -> StringKeyValuesIter<'a> {
 	StringKeyValuesIter {
 		n,
@@ -632,5 +649,6 @@ fn generate_string_key_values_iter<'a>(
 		current: 0,
 		kp,
 		vp,
+		stream,
 	}
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -301,6 +301,21 @@ pub(crate) trait BenchmarkClient: Sync + Send + 'static {
 		async { bail!(NOT_SUPPORTED_ERROR) }
 	}
 
+	/// Block until an index is fully queryable, not merely built.
+	///
+	/// Some engines report an index ready while newly indexed rows still sit in
+	/// a pending queue that searches answer by scanning it linearly. Timing a
+	/// KNN scan in that state measures a brute-force scan wearing the index's
+	/// name — the latency is wrong and the recall is a perfect 1.0 for the wrong
+	/// reason. Engines that drain such a queue in the background override this
+	/// to wait for it.
+	///
+	/// Called outside the timed build so a background task's polling interval
+	/// does not land in the reported build time. The default is a no-op.
+	fn await_index_queryable(&self, _name: &str) -> impl Future<Output = Result<()>> + Send {
+		async { Ok(()) }
+	}
+
 	/// Perform a batch create operation
 	fn batch_create(
 		&self,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -301,6 +301,21 @@ pub(crate) trait BenchmarkClient: Sync + Send + 'static {
 		async { bail!(NOT_SUPPORTED_ERROR) }
 	}
 
+	/// Apply a scan's search-time parameters to this client, before its leg runs.
+	///
+	/// Engines whose search budget travels in the query itself read it from the
+	/// spec and no-op here. Engines that hold it in session state apply it —
+	/// and must do so on *every* client, since a setting made on the one client
+	/// that built the index reaches only that session.
+	///
+	/// Called outside the timed window, once per client per swept value.
+	fn prepare_vector_search(
+		&self,
+		_vq: &VectorQuerySpec,
+	) -> impl Future<Output = Result<()>> + Send {
+		async { Ok(()) }
+	}
+
 	/// Block until an index is fully queryable, not merely built.
 	///
 	/// Some engines report an index ready while newly indexed rows still sit in

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -8,6 +8,35 @@ use anyhow::{Result, bail};
 use std::future::Future;
 use std::time::Duration;
 
+/// One hit returned by a KNN query, in whatever key shape the run is using.
+///
+/// Recall is scored by identity, so adapters return the row's key rather than a
+/// count. Ground truth stores benchmark sample indices, which
+/// [`crate::keyprovider::KeyProvider`] maps into this same shape for comparison
+/// — that keeps the cached answer key reusable across key types instead of
+/// baking one engine's identifier format into it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum KnnKey {
+	/// Numeric primary key.
+	Integer(u32),
+	/// String or UUID primary key, as the engine rendered it.
+	Text(String),
+}
+
+impl KnnKey {
+	/// Read a hit key out of a materialised row's `id` field, for adapters
+	/// whose KNN projection goes through the usual row decoding.
+	pub(crate) fn from_id_field(row: &BenchValue) -> Result<Self> {
+		match row.get_field("id") {
+			Some(BenchValue::Int(i)) => Ok(KnnKey::Integer(*i as u32)),
+			Some(BenchValue::UInt(u)) => Ok(KnnKey::Integer(*u as u32)),
+			Some(BenchValue::String(s)) => Ok(KnnKey::Text(s.clone())),
+			Some(BenchValue::Uuid(u)) => Ok(KnnKey::Text(u.to_string())),
+			other => bail!("knn hit has an unusable id field: {other:?}"),
+		}
+	}
+}
+
 /// Indicates whether a scan is running with or without an index
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScanContext {
@@ -155,9 +184,9 @@ pub(crate) trait BenchmarkClient: Sync + Send + 'static {
 		query: &[f32],
 		kp: &KeyProvider,
 		ctx: ScanContext,
-	) -> impl Future<Output = Result<()>> + Send {
+	) -> impl Future<Output = Result<Vec<KnnKey>>> + Send {
 		async move {
-			let result = match kp {
+			let hits = match kp {
 				KeyProvider::OrderedInteger(_) | KeyProvider::UnorderedInteger(_) => {
 					self.scan_vector_u32(scan, query, ctx).await?
 				}
@@ -167,12 +196,14 @@ pub(crate) trait BenchmarkClient: Sync + Send + 'static {
 			};
 			if let Some(expect) = scan.expect {
 				assert_eq!(
-					expect, result,
-					"Expected a length of {expect} but found {result} for {}",
+					expect,
+					hits.len(),
+					"Expected a length of {expect} but found {} for {}",
+					hits.len(),
 					scan.name
 				);
 			}
-			Ok(())
+			Ok(hits)
 		}
 	}
 
@@ -226,23 +257,25 @@ pub(crate) trait BenchmarkClient: Sync + Send + 'static {
 		async move { bail!(NOT_SUPPORTED_ERROR) }
 	}
 
-	/// Vector KNN scan with a numeric key — engines override this for vector backends.
+	/// Vector KNN scan with a numeric key, returning the hit keys best-first —
+	/// engines override this for vector backends.
 	fn scan_vector_u32(
 		&self,
 		_scan: &Scan,
 		_query: &[f32],
 		_ctx: ScanContext,
-	) -> impl Future<Output = Result<usize>> + Send {
+	) -> impl Future<Output = Result<Vec<KnnKey>>> + Send {
 		async move { bail!(NOT_SUPPORTED_ERROR) }
 	}
 
-	/// Vector KNN scan with a string key — engines override this for vector backends.
+	/// Vector KNN scan with a string key, returning the hit keys best-first —
+	/// engines override this for vector backends.
 	fn scan_vector_string(
 		&self,
 		_scan: &Scan,
 		_query: &[f32],
 		_ctx: ScanContext,
-	) -> impl Future<Output = Result<usize>> + Send {
+	) -> impl Future<Output = Result<Vec<KnnKey>>> + Send {
 		async move { bail!(NOT_SUPPORTED_ERROR) }
 	}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,6 +181,14 @@ pub(crate) struct Args {
 	#[arg(long)]
 	pub(crate) corpus_seed: Option<u64>,
 
+	/// Seconds a vector index may be warmed before a timed leg, per scan.
+	///
+	/// Warming stops on its own once latency plateaus; this is only a safety
+	/// cap. Raise it for large corpora — a truncated warm-up leaves the index
+	/// cold and understates its speed, and the run says so when it happens.
+	#[arg(long, default_value_t = 30)]
+	pub(crate) vector_warmup_seconds: u64,
+
 	/// Directory holding cached vector-search ground truth. The answer key is a
 	/// pure function of the corpus and query seeds, so it is computed once and
 	/// reused across engines and runs.
@@ -1205,6 +1213,7 @@ mod test {
 		run(Args {
 			corpus_seed: None,
 			ground_truth_cache: ".crud-bench-gt".to_string(),
+			vector_warmup_seconds: 30,
 			image: None,
 			name: None,
 			database,

--- a/src/main.rs
+++ b/src/main.rs
@@ -395,6 +395,28 @@ fn validate_scan_index_ids(scans: &[Scan]) -> Result<()> {
 			if vq.field.trim().is_empty() {
 				bail!("scan `{}`: vector_query.field must be non-empty", scan.name);
 			}
+			// A sweep expands into one timed leg per value, so an empty list
+			// would silently produce no legs at all rather than an error.
+			let sweep = vq.index_strategy.search_values();
+			if !matches!(vq.index_strategy, VectorIndexStrategy::Bruteforce) {
+				if sweep.is_empty() {
+					bail!("scan `{}`: the search parameter list must not be empty", scan.name);
+				}
+				if let Some(bad) = sweep.iter().position(|v| *v == 0) {
+					bail!(
+						"scan `{}`: search parameter values must be > 0 (index {bad} is 0)",
+						scan.name
+					);
+				}
+				if sweep.iter().any(|v| (*v as usize) < vq.top_k) {
+					bail!(
+						"scan `{}`: search parameter values must be >= top_k ({}); a budget \
+						 narrower than k cannot return k neighbours",
+						scan.name,
+						vq.top_k
+					);
+				}
+			}
 			if scan.with_index.is_some() {
 				bail!(
 					"scan `{}`: vector scans must not declare `with_index` — the index (when needed) is derived from `vector_query.field`",
@@ -456,6 +478,31 @@ pub(crate) enum VectorDistance {
 	Manhattan,
 }
 
+/// A search-time knob, given either as one value or as a list to sweep.
+///
+/// A single `ef_search` is one arbitrary point on a curve; the comparison worth
+/// making is the curve itself — what recall an index reaches at a given latency.
+/// A list is expanded into one timed leg per value over a **single** index
+/// build, so tracing the frontier costs one build rather than one per point.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub(crate) enum SearchParam {
+	/// One value: a single timed leg, as before.
+	One(u32),
+	/// Several values: one timed leg each, sharing one index build.
+	Sweep(Vec<u32>),
+}
+
+impl SearchParam {
+	/// The values to sweep, in config order.
+	pub(crate) fn values(&self) -> Vec<u32> {
+		match self {
+			SearchParam::One(v) => vec![*v],
+			SearchParam::Sweep(v) => v.clone(),
+		}
+	}
+}
+
 /// Algorithm choice for a vector-search scan. Carries the algorithm-specific
 /// build/search knobs inline so the config has one place to look for tuning.
 /// All knobs are required — benchmark results without explicit parameters
@@ -469,7 +516,7 @@ pub(crate) enum VectorIndexStrategy {
 	Hnsw {
 		m: u32,
 		ef_construction: u32,
-		ef_search: u32,
+		ef_search: SearchParam,
 	},
 	/// DiskANN (Vamana) graph; engines that have not yet wired it return NotSupported.
 	#[serde(rename = "diskann")]
@@ -477,8 +524,63 @@ pub(crate) enum VectorIndexStrategy {
 		degree: u32,
 		l_build: u32,
 		alpha: f32,
-		l_search: u32,
+		l_search: SearchParam,
 	},
+}
+
+impl VectorIndexStrategy {
+	/// Search-time values this strategy sweeps. Empty for bruteforce, which has
+	/// no search knob to vary.
+	pub(crate) fn search_values(&self) -> Vec<u32> {
+		match self {
+			VectorIndexStrategy::Bruteforce => Vec::new(),
+			VectorIndexStrategy::Hnsw {
+				ef_search,
+				..
+			} => ef_search.values(),
+			VectorIndexStrategy::DiskAnn {
+				l_search,
+				..
+			} => l_search.values(),
+		}
+	}
+
+	/// This strategy pinned to one search value, which is the form an adapter
+	/// sees: sweeps are resolved before the spec reaches an engine.
+	pub(crate) fn with_search_value(&self, value: u32) -> Self {
+		match self {
+			VectorIndexStrategy::Bruteforce => VectorIndexStrategy::Bruteforce,
+			VectorIndexStrategy::Hnsw {
+				m,
+				ef_construction,
+				..
+			} => VectorIndexStrategy::Hnsw {
+				m: *m,
+				ef_construction: *ef_construction,
+				ef_search: SearchParam::One(value),
+			},
+			VectorIndexStrategy::DiskAnn {
+				degree,
+				l_build,
+				alpha,
+				..
+			} => VectorIndexStrategy::DiskAnn {
+				degree: *degree,
+				l_build: *l_build,
+				alpha: *alpha,
+				l_search: SearchParam::One(value),
+			},
+		}
+	}
+
+	/// The single search value for a resolved leg.
+	///
+	/// Adapters only ever see a resolved strategy, so a sweep reaching here is a
+	/// bug in the expansion rather than a config error; fall back to the first
+	/// value rather than panicking mid-benchmark.
+	pub(crate) fn search_value(&self) -> u32 {
+		self.search_values().first().copied().unwrap_or(0)
+	}
 }
 
 /// Query-vector source: vectors generated from `seed` using the schema's own
@@ -933,9 +1035,113 @@ fn run(args: Args) -> Result<()> {
 /// Unit and integration-style tests for scan expansion and CLI wiring.
 mod test {
 	use crate::terminal::ColorChoice;
-	use crate::{Args, Database, KeyType, run};
+	use crate::{
+		Args, Database, KeyType, Scans, VectorIndexStrategy, expand_scan_specs, run,
+		validate_scan_index_ids,
+	};
 	use anyhow::Result;
 	use serial_test::serial;
+
+	fn vector_scan_spec(strategy: &str) -> Result<Scans> {
+		let json = format!(
+			r#"[{{ "id": "v", "name": "v", "iterations": 1,
+			   "vector_query": {{ "field": "e", "top_k": 10, "distance": "cosine",
+			   "index_strategy": {strategy} }} }}]"#
+		);
+		// Mirror `run`: expansion and validation are separate steps, and the
+		// vector checks live in the second.
+		let scans = expand_scan_specs(serde_json::from_str(&json)?)?;
+		validate_scan_index_ids(&scans)?;
+		Ok(scans)
+	}
+
+	/// A scalar keeps its old meaning: one timed leg.
+	#[test]
+	fn search_param_accepts_a_scalar() {
+		let scans = vector_scan_spec(
+			r#"{ "kind": "hnsw", "m": 16, "ef_construction": 200, "ef_search": 64 }"#,
+		)
+		.unwrap();
+		let vq = scans[0].vector_query.as_ref().unwrap();
+		assert_eq!(vq.index_strategy.search_values(), vec![64]);
+		assert_eq!(vq.index_strategy.search_value(), 64);
+	}
+
+	/// A list is the sweep: several legs over one index build.
+	#[test]
+	fn search_param_accepts_a_sweep() {
+		let scans = vector_scan_spec(
+			r#"{ "kind": "hnsw", "m": 16, "ef_construction": 200, "ef_search": [16, 32, 64] }"#,
+		)
+		.unwrap();
+		let vq = scans[0].vector_query.as_ref().unwrap();
+		assert_eq!(vq.index_strategy.search_values(), vec![16, 32, 64]);
+	}
+
+	/// Adapters must only ever see a resolved strategy, and pinning a value must
+	/// leave the build parameters alone — the whole point is one shared build.
+	#[test]
+	fn pinning_a_sweep_value_preserves_build_parameters() {
+		let scans = vector_scan_spec(
+			r#"{ "kind": "hnsw", "m": 16, "ef_construction": 200, "ef_search": [16, 64] }"#,
+		)
+		.unwrap();
+		let strategy = &scans[0].vector_query.as_ref().unwrap().index_strategy;
+		let pinned = strategy.with_search_value(64);
+		assert_eq!(pinned.search_values(), vec![64]);
+		let VectorIndexStrategy::Hnsw {
+			m,
+			ef_construction,
+			..
+		} = pinned
+		else {
+			panic!("expected an HNSW strategy");
+		};
+		assert_eq!((m, ef_construction), (16, 200));
+	}
+
+	#[test]
+	fn diskann_sweeps_l_search() {
+		let scans = vector_scan_spec(
+			r#"{ "kind": "diskann", "degree": 64, "l_build": 100, "alpha": 1.2,
+			   "l_search": [50, 100] }"#,
+		)
+		.unwrap();
+		let vq = scans[0].vector_query.as_ref().unwrap();
+		assert_eq!(vq.index_strategy.search_values(), vec![50, 100]);
+	}
+
+	#[test]
+	fn bruteforce_has_no_search_parameter() {
+		let scans = vector_scan_spec(r#"{ "kind": "bruteforce" }"#).unwrap();
+		let vq = scans[0].vector_query.as_ref().unwrap();
+		assert!(vq.index_strategy.search_values().is_empty());
+	}
+
+	#[test]
+	fn search_param_rejects_unusable_values() {
+		// Empty list: would expand to no legs at all.
+		assert!(
+			vector_scan_spec(
+				r#"{ "kind": "hnsw", "m": 16, "ef_construction": 200, "ef_search": [] }"#
+			)
+			.is_err()
+		);
+		// Zero is not a search budget.
+		assert!(
+			vector_scan_spec(
+				r#"{ "kind": "hnsw", "m": 16, "ef_construction": 200, "ef_search": [64, 0] }"#
+			)
+			.is_err()
+		);
+		// Narrower than k cannot return k neighbours.
+		assert!(
+			vector_scan_spec(
+				r#"{ "kind": "hnsw", "m": 16, "ef_construction": 200, "ef_search": [4] }"#
+			)
+			.is_err()
+		);
+	}
 
 	fn test(database: Database, key: KeyType, random: bool) -> Result<()> {
 		run(Args {

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ mod terminal;
 mod util;
 mod value;
 mod valueprovider;
+mod vectorgt;
 mod workloads;
 
 // Datastore modules
@@ -171,6 +172,20 @@ pub(crate) struct Args {
 	/// Emit debug phase markers for log-based tooling
 	#[arg(long, default_value_t = false)]
 	pub(crate) emit_phase_markers: bool,
+
+	/// Seed for generated row content, overriding `seed` in the benchmark TOML.
+	/// With a seed the corpus is a pure function of `(seed, sample)`, which
+	/// makes a run reproducible and lets vector-search ground truth reconstruct
+	/// the corpus instead of reading it back. Without one, values come from
+	/// entropy as before.
+	#[arg(long)]
+	pub(crate) corpus_seed: Option<u64>,
+
+	/// Directory holding cached vector-search ground truth. The answer key is a
+	/// pure function of the corpus and query seeds, so it is computed once and
+	/// reused across engines and runs.
+	#[arg(long, env = "CRUD_BENCH_GROUND_TRUTH_CACHE", default_value = ".crud-bench-gt")]
+	pub(crate) ground_truth_cache: String,
 }
 
 /// Primary key shape and size for generated record ids.
@@ -466,8 +481,10 @@ pub(crate) enum VectorIndexStrategy {
 	},
 }
 
-/// Query-vector source: a deterministic id sample drawn from the inserted
-/// records. The id range and seed make the same query set reproducible
+/// Query-vector source: vectors generated from `seed` using the schema's own
+/// vector generator, so they follow the corpus distribution but are never
+/// inserted. Keeping them out of the corpus means no query is its own nearest
+/// neighbour. The count and seed make the same query set reproducible
 /// across runs and engines.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub(crate) struct VectorHoldout {
@@ -754,7 +771,14 @@ fn run(args: Args) -> Result<()> {
 	let kp = KeyProvider::new(args.key, args.random);
 	let bench_toml = load_bench_toml(&args.config)?;
 	let value_json = serde_json::to_string(&bench_toml.value)?;
-	let vp = ValueProvider::new(&value_json)?;
+	// A CLI seed overrides the config's, so a sweep can vary the corpus without
+	// editing the workload file.
+	let corpus_seed = args.corpus_seed.or(bench_toml.seed);
+	let vp = match corpus_seed {
+		Some(seed) => ValueProvider::new(&value_json)?.with_seed(seed),
+		None => ValueProvider::new(&value_json)?,
+	};
+	benchmark.set_value_template(value_json.clone());
 	let mut batches = bench_toml.batches;
 	if args.skip_batches {
 		batches.clear();
@@ -904,6 +928,8 @@ mod test {
 
 	fn test(database: Database, key: KeyType, random: bool) -> Result<()> {
 		run(Args {
+			corpus_seed: None,
+			ground_truth_cache: ".crud-bench-gt".to_string(),
 			image: None,
 			name: None,
 			database,

--- a/src/main.rs
+++ b/src/main.rs
@@ -943,7 +943,11 @@ fn run(args: Args) -> Result<()> {
 		sync: args.sync,
 		persisted: args.persisted,
 		optimised: args.optimised,
+		// Filled in below, once the benchmark TOML has been read: the seed may
+		// come from the config as well as the CLI.
+		corpus_seed: None,
 	};
+	let mut metadata = metadata;
 	// Get database display name
 	let name = args.database.name().to_string();
 	// Build the key provider
@@ -953,6 +957,7 @@ fn run(args: Args) -> Result<()> {
 	// A CLI seed overrides the config's, so a sweep can vary the corpus without
 	// editing the workload file.
 	let corpus_seed = args.corpus_seed.or(bench_toml.seed);
+	metadata.corpus_seed = corpus_seed;
 	let vp = match corpus_seed {
 		Some(seed) => ValueProvider::new(&value_json)?.with_seed(seed),
 		None => ValueProvider::new(&value_json)?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -525,6 +525,17 @@ pub(crate) struct VectorQuerySpec {
 	/// Holdout sampling for the query set. Defaults to a 1000-id deterministic holdout.
 	#[serde(default)]
 	pub(crate) holdout: VectorHoldout,
+	/// Relative tolerance when deciding whether a returned neighbour counts as
+	/// correct: a hit is accepted when its true distance is within this
+	/// fraction of the k-th true distance.
+	///
+	/// Engines compute distances at different precisions, so rows straddling
+	/// the k-th boundary can swap without any real quality difference. The
+	/// default of 0.0 is strict recall@k; raise it to stop that showing up as
+	/// a recall gap that is not really there. Scoring-time only — changing it
+	/// never invalidates a cached answer key.
+	#[serde(default)]
+	pub(crate) tie_epsilon: f64,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -228,6 +228,20 @@ pub(crate) struct ScanRun {
 pub(crate) struct ScanSpec {
 	/// Stable identifier for grouping, results, and index job names when `with_index` is set.
 	id: String,
+	/// Concurrent clients for this scan's timed legs, capped at `--clients`.
+	/// Defaults to `--clients`.
+	///
+	/// A query that answers in well under a millisecond spends its time
+	/// queueing rather than working at the default concurrency — a KNN scan
+	/// measured 0.4ms at one client and ~1500ms at sixty-four, which is the
+	/// queue, not the index. Latency for such a scan only means something at a
+	/// low setting.
+	#[serde(default)]
+	pub(crate) clients: Option<u32>,
+	/// Threads per client for this scan's timed legs. Defaults to `--threads`.
+	#[serde(default)]
+	pub(crate) threads: Option<u32>,
+
 	/// Display name for a single-run scan; omit when using `runs` instead (mutually exclusive).
 	name: Option<String>,
 	/// Multiple named projections sharing the same parameters; omit when using `name` instead.
@@ -262,6 +276,8 @@ impl ScanSpec {
 	fn into_scans(self, spec_group: u32) -> Result<Vec<Scan>> {
 		let ScanSpec {
 			id,
+			clients,
+			threads,
 			name,
 			runs,
 			iterations,
@@ -296,6 +312,8 @@ impl ScanSpec {
 				}
 				Ok(vec![Scan {
 					id: id.clone(),
+					clients,
+					threads,
 					spec_group,
 					multi_run_spec: false,
 					name: n,
@@ -323,6 +341,8 @@ impl ScanSpec {
 					let run_vq = run.vector_query.or_else(|| vector_query.clone());
 					out.push(Scan {
 						id: id.clone(),
+						clients,
+						threads,
 						spec_group,
 						multi_run_spec,
 						name: run.name,
@@ -645,6 +665,20 @@ pub(crate) struct VectorQuerySpec {
 pub(crate) struct Scan {
 	/// Stable id from the scan spec (grouping, results, index names when indexed).
 	pub(crate) id: String,
+	/// Concurrent clients for this scan's timed legs, capped at `--clients`.
+	/// Defaults to `--clients`.
+	///
+	/// A query that answers in well under a millisecond spends its time
+	/// queueing rather than working at the default concurrency — a KNN scan
+	/// measured 0.4ms at one client and ~1500ms at sixty-four, which is the
+	/// queue, not the index. Latency for such a scan only means something at a
+	/// low setting.
+	#[serde(default)]
+	pub(crate) clients: Option<u32>,
+	/// Threads per client for this scan's timed legs. Defaults to `--threads`.
+	#[serde(default)]
+	pub(crate) threads: Option<u32>,
+
 	/// Which top-level scan JSON object this row came from (CLI grouping only).
 	#[serde(skip)]
 	pub(crate) spec_group: u32,
@@ -1141,6 +1175,30 @@ mod test {
 			)
 			.is_err()
 		);
+	}
+
+	/// The override has to survive `runs` expansion, or a multi-run scan would
+	/// silently fall back to the CLI concurrency on every leg but the first.
+	#[test]
+	fn scan_concurrency_override_expands_to_every_run() {
+		let json = r#"[{ "id": "s", "clients": 1, "threads": 2,
+		   "runs": [{ "name": "a" }, { "name": "b" }] }]"#;
+		let scans = expand_scan_specs(serde_json::from_str(json).unwrap()).unwrap();
+		assert_eq!(scans.len(), 2);
+		for scan in &scans {
+			assert_eq!(scan.clients, Some(1));
+			assert_eq!(scan.threads, Some(2));
+		}
+	}
+
+	/// Omitting it means "use the CLI settings", which is what every existing
+	/// config does.
+	#[test]
+	fn scan_concurrency_override_defaults_to_unset() {
+		let json = r#"[{ "id": "s", "name": "a" }]"#;
+		let scans = expand_scan_specs(serde_json::from_str(json).unwrap()).unwrap();
+		assert_eq!(scans[0].clients, None);
+		assert_eq!(scans[0].threads, None);
 	}
 
 	fn test(database: Database, key: KeyType, random: bool) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -247,6 +247,8 @@ pub(crate) struct ScanSpec {
 	#[serde(default)]
 	pub(crate) clients: Option<u32>,
 	/// Threads per client for this scan's timed legs. Defaults to `--threads`.
+	/// Must be at least 1: zero spawns no workers, and the phase would still
+	/// report a result for iterations that never ran.
 	#[serde(default)]
 	pub(crate) threads: Option<u32>,
 
@@ -396,6 +398,16 @@ fn is_fieldless_index_type(kind: Option<&str>) -> bool {
 /// otherwise the per-backend DDL builders emit broken `FIELDS ` clauses and fail at runtime.
 fn validate_scan_index_ids(scans: &[Scan]) -> Result<()> {
 	for scan in scans {
+		// Zero workers spawns no tasks, but the phase still builds an
+		// `OperationResult` from the requested iteration count — zero latency
+		// and unbounded throughput for work that never happened. `clients` is
+		// additionally clamped to the pool at run time; neither may be zero.
+		if scan.threads == Some(0) {
+			bail!("scan `{}`: threads must be >= 1", scan.name);
+		}
+		if scan.clients == Some(0) {
+			bail!("scan `{}`: clients must be >= 1", scan.name);
+		}
 		if let Some(ref idx) = scan.with_index
 			&& !idx.skip
 		{
@@ -422,6 +434,16 @@ fn validate_scan_index_ids(scans: &[Scan]) -> Result<()> {
 			}
 			if vq.field.trim().is_empty() {
 				bail!("scan `{}`: vector_query.field must be non-empty", scan.name);
+			}
+			// The answer key stores a fixed depth beyond `top_k`, so a tolerance
+			// wider than that depth can admit would score legitimately-returned
+			// boundary neighbours as misses.
+			if !(0.0..=crate::vectorgt::MAX_TIE_EPSILON).contains(&vq.tie_epsilon) {
+				bail!(
+					"scan `{}`: vector_query.tie_epsilon must be between 0.0 and {}",
+					scan.name,
+					crate::vectorgt::MAX_TIE_EPSILON
+				);
 			}
 			// A sweep expands into one timed leg per value, so an empty list
 			// would silently produce no legs at all rather than an error.
@@ -684,6 +706,8 @@ pub(crate) struct Scan {
 	#[serde(default)]
 	pub(crate) clients: Option<u32>,
 	/// Threads per client for this scan's timed legs. Defaults to `--threads`.
+	/// Must be at least 1: zero spawns no workers, and the phase would still
+	/// report a result for iterations that never ran.
 	#[serde(default)]
 	pub(crate) threads: Option<u32>,
 
@@ -1201,6 +1225,18 @@ mod test {
 
 	/// Omitting it means "use the CLI settings", which is what every existing
 	/// config does.
+	/// Zero workers would report a result for iterations that never ran.
+	#[test]
+	fn scan_concurrency_override_rejects_zero() {
+		for bad in [
+			r#"[{ "id": "s", "name": "a", "threads": 0 }]"#,
+			r#"[{ "id": "s", "name": "a", "clients": 0 }]"#,
+		] {
+			let scans = expand_scan_specs(serde_json::from_str(bad).unwrap()).unwrap();
+			assert!(validate_scan_index_ids(&scans).is_err(), "should have rejected {bad}");
+		}
+	}
+
 	#[test]
 	fn scan_concurrency_override_defaults_to_unset() {
 		let json = r#"[{ "id": "s", "name": "a" }]"#;

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -2,7 +2,7 @@
 
 use crate::dialect::{AnsiSqlDialect, Dialect, PostgresDialect};
 use crate::docker::DockerParams;
-use crate::engine::{BenchmarkClient, BenchmarkEngine, ScanContext};
+use crate::engine::{BenchmarkClient, BenchmarkEngine, KnnKey, ScanContext};
 use crate::memory::Config;
 use crate::util::sql::bench_to_postgres_param;
 use crate::value::BenchValue;
@@ -360,7 +360,7 @@ impl BenchmarkClient for PostgresClient {
 		scan: &Scan,
 		query: &[f32],
 		_ctx: ScanContext,
-	) -> Result<usize> {
+	) -> Result<Vec<KnnKey>> {
 		self.knn_scan(scan, query).await
 	}
 
@@ -369,7 +369,7 @@ impl BenchmarkClient for PostgresClient {
 		scan: &Scan,
 		query: &[f32],
 		_ctx: ScanContext,
-	) -> Result<usize> {
+	) -> Result<Vec<KnnKey>> {
 		self.knn_scan(scan, query).await
 	}
 
@@ -597,7 +597,7 @@ impl PostgresClient {
 		}
 	}
 
-	async fn knn_scan(&self, scan: &Scan, query: &[f32]) -> Result<usize> {
+	async fn knn_scan(&self, scan: &Scan, query: &[f32]) -> Result<Vec<KnnKey>> {
 		let vq = scan
 			.vector_query
 			.as_ref()
@@ -608,12 +608,14 @@ impl PostgresClient {
 		let stm = format!("SELECT id FROM record ORDER BY {field} {op} $1 LIMIT {k}");
 		let q = pgvector::Vector::from(query.to_vec());
 		let res = self.client.query(&stm, &[&q]).await?;
-		let mut count = 0;
+		let mut hits = Vec::with_capacity(res.len());
 		for v in res {
-			black_box(self.consume(v, false).unwrap());
-			count += 1;
+			// Materialise the row as any other scan would, then keep its key:
+			// recall is scored by identity, so the ids have to come back.
+			let row = self.consume(v, false)?;
+			hits.push(black_box(KnnKey::from_id_field(&row)?));
 		}
-		Ok(count)
+		Ok(hits)
 	}
 
 	async fn batch_create<T>(&self, key_vals: Vec<(T, BenchValue)>) -> Result<()>

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -343,14 +343,22 @@ impl BenchmarkClient for PostgresClient {
 			} => bail!(crate::benchmark::NOT_SUPPORTED_ERROR),
 		};
 		self.client.execute(&stmt, &[]).await?;
-		// Set ef_search for HNSW (per-session GUC).
-		if let VectorIndexStrategy::Hnsw {
-			ef_search,
-			..
-		} = vq.index_strategy
-		{
-			let s = format!("SET hnsw.ef_search = {ef_search}");
-			self.client.execute(&s, &[]).await?;
+		// `hnsw.ef_search` is deliberately not set here. It is a per-session
+		// GUC, and this runs on one client while the scan runs on all of them,
+		// so setting it here reaches one session in `--clients`. It is applied
+		// per leg through `prepare_vector_search` instead, which also lets a
+		// sweep vary it over a single index build.
+		Ok(())
+	}
+
+	/// pgvector takes the HNSW search budget from the `hnsw.ef_search` GUC,
+	/// which is per session. Applying it here puts it on every client's own
+	/// connection before the leg runs, and lets a sweep change it between legs
+	/// without rebuilding the index.
+	async fn prepare_vector_search(&self, vq: &VectorQuerySpec) -> Result<()> {
+		if matches!(vq.index_strategy, VectorIndexStrategy::Hnsw { .. }) {
+			let ef_search = vq.index_strategy.search_value();
+			self.client.execute(&format!("SET hnsw.ef_search = {ef_search}"), &[]).await?;
 		}
 		Ok(())
 	}

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -2,7 +2,7 @@
 
 use crate::benchmark::NOT_SUPPORTED_ERROR;
 use crate::docker::DockerParams;
-use crate::engine::{BenchmarkClient, BenchmarkEngine, ScanContext};
+use crate::engine::{BenchmarkClient, BenchmarkEngine, KnnKey, ScanContext};
 use crate::value::BenchValue;
 use crate::valueprovider::{ColumnType, Columns};
 use crate::{
@@ -253,8 +253,15 @@ impl BenchmarkClient for RedisClient {
 		scan: &Scan,
 		query: &[f32],
 		_ctx: ScanContext,
-	) -> Result<usize> {
-		self.knn_scan(scan, query).await
+	) -> Result<Vec<KnnKey>> {
+		let hits = self.knn_scan(scan, query).await?;
+		hits.into_iter()
+			.map(|k| {
+				k.parse::<u32>()
+					.map(KnnKey::Integer)
+					.map_err(|e| anyhow!("redis: knn hit {k:?} is not a numeric key: {e}"))
+			})
+			.collect()
 	}
 
 	async fn scan_vector_string(
@@ -262,8 +269,8 @@ impl BenchmarkClient for RedisClient {
 		scan: &Scan,
 		query: &[f32],
 		_ctx: ScanContext,
-	) -> Result<usize> {
-		self.knn_scan(scan, query).await
+	) -> Result<Vec<KnnKey>> {
+		Ok(self.knn_scan(scan, query).await?.into_iter().map(KnnKey::Text).collect())
 	}
 
 	async fn batch_create_u32(
@@ -442,7 +449,8 @@ impl RedisClient {
 		Ok(())
 	}
 
-	async fn knn_scan(&self, scan: &Scan, query: &[f32]) -> Result<usize> {
+	/// Run the KNN query and return the raw document keys, best-first.
+	async fn knn_scan(&self, scan: &Scan, query: &[f32]) -> Result<Vec<String>> {
 		let vq = scan
 			.vector_query
 			.as_ref()
@@ -466,14 +474,29 @@ impl RedisClient {
 			.arg(0)
 			.query_async(&mut *conn)
 			.await?;
-		// FT.SEARCH returns `[total, key1, key2, ...]` (with RETURN 0). Use the
-		// reported `total` capped at `k` for the row-count return.
+		// FT.SEARCH returns `[total, key1, key2, ...]` (with RETURN 0). The keys
+		// after the count are the hits, in rank order; recall scores by
+		// identity so they are what we return.
 		if let redis::Value::Array(items) = &res
-			&& let Some(redis::Value::Int(total)) = items.first()
+			&& matches!(items.first(), Some(redis::Value::Int(_)))
 		{
-			return Ok((*total as usize).min(k));
+			let mut hits = Vec::with_capacity(k);
+			for item in items.iter().skip(1) {
+				let raw = match item {
+					redis::Value::BulkString(b) => String::from_utf8_lossy(b).into_owned(),
+					redis::Value::SimpleString(t) => t.clone(),
+					// Anything else at this position is a field payload, not a
+					// document key — `RETURN 0` should prevent it.
+					_ => continue,
+				};
+				// Documents live in the `vec:{key}` mirror the CRUD paths
+				// dual-write, so strip that prefix back off.
+				hits.push(raw.strip_prefix("vec:").unwrap_or(&raw).to_string());
+			}
+			hits.truncate(k);
+			return Ok(hits);
 		}
-		Ok(k)
+		bail!("knn scan: unexpected FT.SEARCH response shape: {res:?}")
 	}
 
 	async fn scan_bytes(&self, scan: &Scan) -> Result<usize> {

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -201,12 +201,11 @@ impl BenchmarkClient for RedisClient {
 			VectorIndexStrategy::Hnsw {
 				m,
 				ef_construction,
-				ef_search,
 				..
 			} => (
 				"HNSW",
 				vec![
-					"12".into(),
+					"10".into(),
 					"TYPE".into(),
 					"FLOAT32".into(),
 					"DIM".into(),
@@ -217,8 +216,10 @@ impl BenchmarkClient for RedisClient {
 					m.to_string(),
 					"EF_CONSTRUCTION".into(),
 					ef_construction.to_string(),
-					"EF_RUNTIME".into(),
-					ef_search.to_string(),
+					// EF_RUNTIME is deliberately not set here: as an index
+					// attribute it would pin the search budget to the build, so
+					// a sweep would need one index per point. The KNN query
+					// carries it instead.
 				],
 			),
 			VectorIndexStrategy::DiskAnn {
@@ -460,7 +461,15 @@ impl RedisClient {
 		let mut conn = self.conn_record.lock().await;
 		let res: redis::Value = redis::cmd("FT.SEARCH")
 			.arg(&scan.id)
-			.arg(format!("*=>[KNN {k} @v $q AS score]"))
+			.arg(match vq.index_strategy {
+				// Bruteforce is a FLAT index — an exact scan with no search
+				// budget to set.
+				VectorIndexStrategy::Bruteforce => format!("*=>[KNN {k} @v $q AS score]"),
+				_ => {
+					let ef = vq.index_strategy.search_value();
+					format!("*=>[KNN {k} @v $q EF_RUNTIME {ef} AS score]")
+				}
+			})
 			.arg("PARAMS")
 			.arg(2)
 			.arg("q")

--- a/src/result.rs
+++ b/src/result.rs
@@ -101,6 +101,10 @@ pub(crate) struct ScanRun {
 	/// Latency histogram + resource stats; [`None`] when the backend skipped the leg.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub result: Option<OperationResult>,
+	/// Distinguishes legs of a parameter sweep, e.g. `ef_search = 64`. `None`
+	/// for a scan that ran once, which is every non-swept leg.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub label: Option<String>,
 }
 
 /// Normalised `with_writes.ratio` for labels and serialised results.
@@ -121,12 +125,19 @@ pub(crate) fn scan_run_row_label(id: &str, name: &str, iterations: u32, run: &Sc
 			write_ratio_percent: p,
 		} => format!("reads+writes ({p}%) - {index_slug}"),
 	};
-	format!("[S]can · {id} · {name} - {mid} ({iterations})")
+	match &run.label {
+		Some(label) => format!("[S]can · {id} · {name} · {label} - {mid} ({iterations})"),
+		None => format!("[S]can · {id} · {name} - {mid} ({iterations})"),
+	}
 }
 
 impl ScanRun {
 	/// Short label for charts (query text + leg description).
 	pub(crate) fn chart_label(&self, query: &str) -> String {
+		let query = match &self.label {
+			Some(label) => &format!("{query} · {label}"),
+			None => query,
+		};
 		let index_slug = if self.indexed {
 			"indexed"
 		} else {

--- a/src/result.rs
+++ b/src/result.rs
@@ -40,6 +40,14 @@ pub(crate) struct BenchmarkMetadata {
 	pub(crate) persisted: bool,
 	/// Tuned server settings vs defaults where supported.
 	pub(crate) optimised: bool,
+	/// Corpus seed the run generated its rows from, when one was set.
+	///
+	/// Without it a stored result cannot say which dataset produced it, which
+	/// defeats the point of seeding: two results are only comparable if they
+	/// were measured against the same corpus, and vector ground truth is keyed
+	/// on this value.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub(crate) corpus_seed: Option<u64>,
 }
 
 /// Full benchmark output: timings per phase plus one representative generated [`BenchValue`].

--- a/src/result.rs
+++ b/src/result.rs
@@ -167,6 +167,17 @@ pub(crate) struct ScanResult {
 	pub(crate) index_remove: Option<OperationResult>,
 	/// Timed scan legs in benchmark order (baseline → optional write-mix → indexed variants).
 	pub(crate) runs: Vec<ScanRun>,
+	/// Clients this scan's timed legs actually ran at, after any per-scan
+	/// override and the cap at the pool size.
+	///
+	/// The run's metadata records the CLI settings, which a scan may override —
+	/// `config/vector.toml` runs its legs at 1x1 by default. Without this, a
+	/// scan run at 1x1 is indistinguishable in the results from one run at
+	/// 12x24, and those measure very different things: the same KNN query timed
+	/// 0.4ms at one client and roughly 1500ms at sixty-four.
+	pub(crate) clients: u32,
+	/// Threads per client this scan's timed legs actually ran at.
+	pub(crate) threads: u32,
 }
 
 /// Column titles for the ASCII summary table ([`BenchmarkResult`]'s [`Display`] impl).

--- a/src/result.rs
+++ b/src/result.rs
@@ -3,6 +3,7 @@
 use crate::system::SystemInfo;
 use crate::util::format_duration;
 use crate::value::BenchValue;
+use crate::vectorgt::RecallSummary;
 use bytesize::ByteSize;
 use comfy_table::modifiers::UTF8_ROUND_CORNERS;
 use comfy_table::presets::UTF8_FULL;
@@ -158,7 +159,7 @@ pub(crate) struct ScanResult {
 }
 
 /// Column titles for the ASCII summary table ([`BenchmarkResult`]'s [`Display`] impl).
-const HEADERS: [&str; 12] = [
+const HEADERS: [&str; 13] = [
 	"Test",
 	"Total time",
 	"Mean",
@@ -166,6 +167,7 @@ const HEADERS: [&str; 12] = [
 	"99th",
 	"95th",
 	"Min",
+	"Recall",
 	"OPS",
 	"CPU",
 	"Memory",
@@ -174,7 +176,7 @@ const HEADERS: [&str; 12] = [
 ];
 
 /// Extended columns for CSV export (extra quantiles + load averages).
-const CSV_HEADERS: [&str; 22] = [
+const CSV_HEADERS: [&str; 25] = [
 	"Test",
 	"Total time",
 	"Mean",
@@ -187,6 +189,9 @@ const CSV_HEADERS: [&str; 22] = [
 	"1st",
 	"Min",
 	"IQR",
+	"Recall_mean",
+	"Recall_p5",
+	"Recall_min",
 	"OPS",
 	"CPU_avg",
 	"CPU_min",
@@ -200,9 +205,9 @@ const CSV_HEADERS: [&str; 22] = [
 ];
 
 /// Placeholder cells when a phase was skipped or unsupported.
-const SKIP: [&str; 11] = ["-"; 11];
+const SKIP: [&str; 12] = ["-"; 12];
 /// Placeholder row for wide CSV rows.
-const CSV_SKIP: [&str; 21] = ["-"; 21];
+const CSV_SKIP: [&str; 24] = ["-"; 24];
 
 /// ASCII summary table matching [`HEADERS`] (used by CLI stdout).
 impl Display for BenchmarkResult {
@@ -621,6 +626,11 @@ pub(crate) struct OperationResult {
 	elapsed: Duration,
 	/// Number of logical iterations aggregated into `histogram`.
 	samples: u32,
+	/// Recall@k for a vector scan, scored against harness-computed ground
+	/// truth. `None` for every non-vector operation, and for a vector scan run
+	/// without a corpus seed (no reproducible corpus, so no answer key).
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub(crate) recall: Option<RecallSummary>,
 	/// Snapshot CPU at end of phase (normalised by core count).
 	cpu_usage: f32,
 	/// Min / max / avg from polled samples when available.
@@ -642,6 +652,25 @@ pub(crate) struct OperationResult {
 }
 
 impl OperationResult {
+	/// Recall cell for the summary table: mean and 5th percentile, or `-` for
+	/// anything that is not a scored vector scan.
+	///
+	/// Both figures are shown because the mean alone hides the shape — an index
+	/// can average well and still answer a tail of queries badly, which is the
+	/// characteristic failure of a graph index on data it indexed poorly.
+	fn recall_display(&self) -> String {
+		match self.recall {
+			Some(r) => format!("{:.3} / {:.2}", r.mean, r.p5),
+			None => "-".to_string(),
+		}
+	}
+
+	/// Attach recall figures scored for a vector scan.
+	pub(crate) fn with_recall(mut self, recall: Option<RecallSummary>) -> Self {
+		self.recall = recall;
+		self
+	}
+
 	/// Finalises histogram + [`OperationMetric`] snapshots into serialisable stats.
 	pub(crate) fn new(mut metric: OperationMetric, histogram: Histogram<u64>) -> Self {
 		let elapsed = metric.start_time.elapsed();
@@ -706,6 +735,8 @@ impl OperationResult {
 
 		Self {
 			samples: metric.samples,
+			// Set by `with_recall` for vector scans only.
+			recall: None,
 			mean: histogram.mean(),
 			min: histogram.min(),
 			max: histogram.max(),
@@ -760,6 +791,7 @@ impl OperationResult {
 			format!("{:.2} ms", self.q99 as f64 / 1000.0),
 			format!("{:.2} ms", self.q95 as f64 / 1000.0),
 			format!("{:.2} ms", self.min as f64 / 1000.0),
+			self.recall_display(),
 			format!("{:.2}", self.ops),
 			cpu_display,
 			memory_display,
@@ -813,6 +845,9 @@ impl OperationResult {
 			format!("{:.2} ms", self.q01 as f64 / 1000.0),
 			format!("{:.2} ms", self.min as f64 / 1000.0),
 			format!("{:.2} ms", self.iqr as f64 / 1000.0),
+			self.recall.map_or_else(|| "-".to_string(), |r| format!("{:.4}", r.mean)),
+			self.recall.map_or_else(|| "-".to_string(), |r| format!("{:.4}", r.p5)),
+			self.recall.map_or_else(|| "-".to_string(), |r| format!("{:.4}", r.min)),
 			format!("{:.2}", self.ops),
 			format!("{:.2}", cpu_avg),
 			format!("{:.2}", cpu_min),

--- a/src/surrealdb.rs
+++ b/src/surrealdb.rs
@@ -1035,15 +1035,15 @@ impl SurrealDBClient {
 				)
 			}
 			VectorIndexStrategy::Hnsw {
-				ef_search,
 				..
 			} => {
+				let ef_search = vq.index_strategy.search_value();
 				format!("SELECT id FROM record WHERE {field} <|{k},{ef_search}|> $q")
 			}
 			VectorIndexStrategy::DiskAnn {
-				l_search,
 				..
 			} => {
+				let l_search = vq.index_strategy.search_value();
 				format!("SELECT id FROM record WHERE {field} <|{k},{l_search}|> $q")
 			}
 		};

--- a/src/surrealdb.rs
+++ b/src/surrealdb.rs
@@ -15,7 +15,7 @@ use anyhow::{Result, bail};
 use log::{error, warn};
 use std::env;
 use std::hint::black_box;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use surrealdb::Surreal;
 use surrealdb::engine::any::{Any, connect};
 use surrealdb::opt::auth::Root;
@@ -121,6 +121,11 @@ fn surreal_distance_function(d: VectorDistance) -> &'static str {
 		VectorDistance::Manhattan => "vector::distance::manhattan",
 	}
 }
+
+/// How long to wait for a vector index's pending queue to drain before giving
+/// up. The background task runs every `index_compaction_interval` (5s by
+/// default), so this allows for a slow drain without hanging a run forever.
+const VECTOR_COMPACTION_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Pull the record key out of one `SELECT id` KNN row.
 fn surreal_knn_key(row: &Value) -> Result<KnnKey> {
@@ -812,6 +817,50 @@ impl BenchmarkClient for SurrealDBClient {
 			sleep(Duration::from_millis(500)).await;
 		}
 		Ok(())
+	}
+
+	/// Wait for the HNSW / DiskANN pending queue to drain.
+	///
+	/// `INFO FOR INDEX` reports `building.status = "ready"` as soon as the
+	/// initial build finishes, but newly indexed vectors sit in a pending queue
+	/// that KNN searches answer by scanning linearly. A background task drains
+	/// it every `index_compaction_interval` (5s by default), and only then does
+	/// the graph actually serve the query. Scanning before that measures a
+	/// brute-force scan wearing the index's name: the latency is wrong, and
+	/// recall comes back a perfect 1.0 for the wrong reason.
+	///
+	/// `building.pending` carries the queue depth, so poll until it clears.
+	/// Note this is unrelated to `ALTER SYSTEM COMPACT` (see [`Self::compact`]),
+	/// which compacts the RocksDB keyspace and does nothing for this queue.
+	async fn await_index_queryable(&self, name: &str) -> Result<()> {
+		let started = Instant::now();
+		loop {
+			let q = format!("INFO FOR INDEX {name} ON record");
+			let r: surrealdb::types::Value = self
+				.db
+				.query(&q)
+				.await
+				.map_err(log_sql_err(&q))?
+				.take(0)
+				.map_err(log_sql_err(&q))?;
+			let building = r.get("building");
+			// Absent means the engine does not track a queue for this index
+			// kind, which is the same as an empty one.
+			let pending = match building.get("pending") {
+				Value::Number(n) => n.to_int().unwrap_or(0),
+				_ => 0,
+			};
+			if pending == 0 {
+				return Ok(());
+			}
+			if started.elapsed() > VECTOR_COMPACTION_TIMEOUT {
+				bail!(
+					"index {name}: {pending} entries still pending after {:?}; 					 a KNN scan now would measure a brute-force scan over the queue",
+					started.elapsed()
+				);
+			}
+			sleep(Duration::from_millis(250)).await;
+		}
 	}
 
 	async fn scan_vector_u32(

--- a/src/surrealdb.rs
+++ b/src/surrealdb.rs
@@ -122,10 +122,10 @@ fn surreal_distance_function(d: VectorDistance) -> &'static str {
 	}
 }
 
-/// How long to wait for a vector index's pending queue to drain before giving
-/// up. The background task runs every `index_compaction_interval` (5s by
-/// default), so this allows for a slow drain without hanging a run forever.
-const VECTOR_COMPACTION_TIMEOUT: Duration = Duration::from_secs(300);
+/// How long to wait for an index's pending queue to drain before giving up. The
+/// background task runs every `index_compaction_interval` (5s by default), so
+/// this allows for a slow drain without hanging a run forever.
+const INDEX_COMPACTION_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Pull the record key out of one `SELECT id` KNN row.
 fn surreal_knn_key(row: &Value) -> Result<KnnKey> {
@@ -819,15 +819,16 @@ impl BenchmarkClient for SurrealDBClient {
 		Ok(())
 	}
 
-	/// Wait for the HNSW / DiskANN pending queue to drain.
+	/// Wait for an index's pending queue to drain.
 	///
 	/// `INFO FOR INDEX` reports `building.status = "ready"` as soon as the
-	/// initial build finishes, but newly indexed vectors sit in a pending queue
-	/// that KNN searches answer by scanning linearly. A background task drains
-	/// it every `index_compaction_interval` (5s by default), and only then does
-	/// the graph actually serve the query. Scanning before that measures a
-	/// brute-force scan wearing the index's name: the latency is wrong, and
-	/// recall comes back a perfect 1.0 for the wrong reason.
+	/// initial build finishes, but rows indexed after that sit in a pending
+	/// queue that queries answer by scanning it linearly. A background task
+	/// drains it every `index_compaction_interval` (5s by default), and only
+	/// then does the index itself serve the query. In SurrealDB 3.x this
+	/// applies to fulltext, count and HNSW indexes alike; for a KNN scan it is
+	/// especially misleading, since a queue scan is exact and so reports a
+	/// perfect recall of 1.0 for entirely the wrong reason.
 	///
 	/// `building.pending` carries the queue depth, so poll until it clears.
 	/// Note this is unrelated to `ALTER SYSTEM COMPACT` (see [`Self::compact`]),
@@ -843,17 +844,23 @@ impl BenchmarkClient for SurrealDBClient {
 				.map_err(log_sql_err(&q))?
 				.take(0)
 				.map_err(log_sql_err(&q))?;
+			let j = r.to_sql();
 			let building = r.get("building");
+			let status = building.get("status").as_string().expect(&j);
 			// Absent means the engine does not track a queue for this index
 			// kind, which is the same as an empty one.
 			let pending = match building.get("pending") {
 				Value::Number(n) => n.to_int().unwrap_or(0),
 				_ => 0,
 			};
-			if pending == 0 {
-				return Ok(());
+			// `pending` sits at 0 while the initial build is still running, so
+			// it only means "drained" once the build itself reports ready.
+			match status.as_str() {
+				"ready" if pending == 0 => return Ok(()),
+				"ready" | "indexing" | "cleaning" | "started" => {}
+				_ => bail!("Unexpected index status: {j}"),
 			}
-			if started.elapsed() > VECTOR_COMPACTION_TIMEOUT {
+			if started.elapsed() > INDEX_COMPACTION_TIMEOUT {
 				bail!(
 					"index {name}: {pending} entries still pending after {:?}; 					 a KNN scan now would measure a brute-force scan over the queue",
 					started.elapsed()

--- a/src/surrealdb.rs
+++ b/src/surrealdb.rs
@@ -3,7 +3,7 @@
 use crate::benchmark::NOT_SUPPORTED_ERROR;
 use crate::dialect::SurrealDBDialect;
 use crate::docker::DockerParams;
-use crate::engine::{BenchmarkClient, BenchmarkEngine, ScanContext};
+use crate::engine::{BenchmarkClient, BenchmarkEngine, KnnKey, ScanContext};
 use crate::memory::Config as MemoryConfig;
 use crate::value::BenchValue;
 use crate::valueprovider::Columns;
@@ -120,6 +120,19 @@ fn surreal_distance_function(d: VectorDistance) -> &'static str {
 		VectorDistance::InnerProduct => "vector::dot",
 		VectorDistance::Manhattan => "vector::distance::manhattan",
 	}
+}
+
+/// Pull the record key out of one `SELECT id` KNN row.
+fn surreal_knn_key(row: &Value) -> Result<KnnKey> {
+	let Value::RecordId(rid) = row.get("id") else {
+		bail!("knn scan: row is missing a record id: {}", row.to_sql());
+	};
+	Ok(match &rid.key {
+		RecordIdKey::Number(n) => KnnKey::Integer(*n as u32),
+		RecordIdKey::String(t) => KnnKey::Text(t.clone()),
+		RecordIdKey::Uuid(u) => KnnKey::Text(u.to_string()),
+		other => bail!("knn scan: unsupported record key: {other:?}"),
+	})
 }
 
 /// ORDER BY direction so the nearest neighbours sort to the top of the result set.
@@ -806,7 +819,7 @@ impl BenchmarkClient for SurrealDBClient {
 		scan: &Scan,
 		query: &[f32],
 		_ctx: ScanContext,
-	) -> Result<usize> {
+	) -> Result<Vec<KnnKey>> {
 		self.knn_scan(scan, query).await
 	}
 
@@ -815,7 +828,7 @@ impl BenchmarkClient for SurrealDBClient {
 		scan: &Scan,
 		query: &[f32],
 		_ctx: ScanContext,
-	) -> Result<usize> {
+	) -> Result<Vec<KnnKey>> {
 		self.knn_scan(scan, query).await
 	}
 
@@ -948,7 +961,7 @@ impl SurrealDBClient {
 		.await
 	}
 
-	async fn knn_scan(&self, scan: &Scan, query: &[f32]) -> Result<usize> {
+	async fn knn_scan(&self, scan: &Scan, query: &[f32]) -> Result<Vec<KnnKey>> {
 		let vq = scan.vector_query.as_ref().ok_or_else(|| {
 			anyhow::anyhow!("knn_scan called without a vector_query on scan `{}`", scan.name)
 		})?;
@@ -1005,7 +1018,10 @@ impl SurrealDBClient {
 		let Some(arr) = res.as_array() else {
 			bail!("knn scan: unexpected response shape: {}", res.to_sql());
 		};
-		Ok(arr.len())
+		// Recall is scored by identity, so return the record keys rather than a
+		// count. `SELECT id` yields the record id; the table half is constant
+		// so only the key half is kept.
+		arr.iter().map(surreal_knn_key).collect()
 	}
 
 	async fn scan(&self, scan: &Scan, ctx: ScanContext) -> Result<usize> {

--- a/src/surrealdb2.rs
+++ b/src/surrealdb2.rs
@@ -829,13 +829,17 @@ impl SurrealDB2Client {
 				)
 			}
 			VectorIndexStrategy::Hnsw {
-				ef_search,
 				..
-			} => format!("SELECT id FROM record WHERE {field} <|{k},{ef_search}|> $q"),
+			} => {
+				let ef_search = vq.index_strategy.search_value();
+				format!("SELECT id FROM record WHERE {field} <|{k},{ef_search}|> $q")
+			}
 			VectorIndexStrategy::DiskAnn {
-				l_search,
 				..
-			} => format!("SELECT id FROM record WHERE {field} <|{k},{l_search}|> $q"),
+			} => {
+				let l_search = vq.index_strategy.search_value();
+				format!("SELECT id FROM record WHERE {field} <|{k},{l_search}|> $q")
+			}
 		};
 		let q_value = Value::Array(Array::from(
 			query.iter().map(|f| Value::Number(Number::Float(*f as f64))).collect::<Vec<_>>(),

--- a/src/surrealdb2.rs
+++ b/src/surrealdb2.rs
@@ -13,7 +13,7 @@
 use crate::benchmark::NOT_SUPPORTED_ERROR;
 use crate::dialect::SurrealDBDialect;
 use crate::docker::DockerParams;
-use crate::engine::{BenchmarkClient, BenchmarkEngine, ScanContext};
+use crate::engine::{BenchmarkClient, BenchmarkEngine, KnnKey, ScanContext};
 use crate::memory::Config as MemoryConfig;
 use crate::value::BenchValue;
 use crate::valueprovider::Columns;
@@ -118,6 +118,22 @@ fn surreal_distance_function(d: VectorDistance) -> &'static str {
 		VectorDistance::InnerProduct => "vector::dot",
 		VectorDistance::Manhattan => "vector::distance::manhattan",
 	}
+}
+
+/// Pull the record key out of one `SELECT id` KNN row.
+fn surreal_knn_key(row: &Value) -> Result<KnnKey> {
+	let Value::Object(obj) = row else {
+		bail!("knn scan: row is not an object: {row}");
+	};
+	let Some(Value::Thing(thing)) = obj.get("id") else {
+		bail!("knn scan: row is missing a record id: {row}");
+	};
+	Ok(match &thing.id {
+		Id::Number(n) => KnnKey::Integer(*n as u32),
+		Id::String(t) => KnnKey::Text(t.clone()),
+		Id::Uuid(u) => KnnKey::Text(u.to_string()),
+		other => bail!("knn scan: unsupported record key: {other:?}"),
+	})
 }
 
 fn surreal_distance_order(d: VectorDistance) -> &'static str {
@@ -643,7 +659,7 @@ impl BenchmarkClient for SurrealDB2Client {
 		scan: &Scan,
 		query: &[f32],
 		_ctx: ScanContext,
-	) -> Result<usize> {
+	) -> Result<Vec<KnnKey>> {
 		self.knn_scan(scan, query).await
 	}
 
@@ -652,7 +668,7 @@ impl BenchmarkClient for SurrealDB2Client {
 		scan: &Scan,
 		query: &[f32],
 		_ctx: ScanContext,
-	) -> Result<usize> {
+	) -> Result<Vec<KnnKey>> {
 		self.knn_scan(scan, query).await
 	}
 
@@ -798,7 +814,7 @@ impl SurrealDB2Client {
 		.await
 	}
 
-	async fn knn_scan(&self, scan: &Scan, query: &[f32]) -> Result<usize> {
+	async fn knn_scan(&self, scan: &Scan, query: &[f32]) -> Result<Vec<KnnKey>> {
 		let vq = scan.vector_query.as_ref().ok_or_else(|| {
 			anyhow::anyhow!("knn_scan called without a vector_query on scan `{}`", scan.name)
 		})?;
@@ -827,7 +843,9 @@ impl SurrealDB2Client {
 		let mut resp = self.db.query(&sql).bind(("q", q_value)).await.map_err(log_sql_err(&sql))?;
 		let res: surrealdb::Value = resp.take(0).map_err(log_sql_err(&sql))?;
 		match res.into_inner() {
-			Value::Array(a) => Ok(a.0.len()),
+			// Recall is scored by identity, so return the record keys rather
+			// than a count.
+			Value::Array(a) => a.0.iter().map(surreal_knn_key).collect(),
 			other => bail!("knn scan: unexpected response shape: {}", other),
 		}
 	}

--- a/src/valueprovider.rs
+++ b/src/valueprovider.rs
@@ -156,7 +156,7 @@ impl ValueProvider {
 			let mut rng = SmallRng::seed_from_u64(sample_seed(seed, ValueStream::Query, i as u32));
 			match generator.generate(&mut rng) {
 				BenchValue::FloatVector(v) => out.push(v),
-				other => bail!("field {field:?} generated {other:?}, expected a vector"),
+				_ => bail!("field {field:?} did not generate a vector"),
 			}
 		}
 		Ok(out)
@@ -872,12 +872,12 @@ mod test {
 			let tmpl = format!(r#"{{ "v": "vector:64:clustered:4:{sigma}" }}"#);
 			let mut vp = ValueProvider::new(&tmpl).unwrap().with_seed(9);
 			let vs: Vec<Vec<f32>> = (0..200u32)
-				.map(|i| match vp.generate_value_for(ValueStream::Create, i) {
-					BenchValue::Object(o) => match &o[0].1 {
-						BenchValue::FloatVector(v) => v.clone(),
-						other => panic!("expected a vector, got {other:?}"),
-					},
-					other => panic!("expected an object, got {other:?}"),
+				.map(|i| {
+					vp.generate_value_for(ValueStream::Create, i)
+						.get_field("v")
+						.and_then(|v| v.as_float_vector())
+						.expect("template declares `v` as a vector column")
+						.to_vec()
 				})
 				.collect();
 			// Mean pairwise cosine distance over a fixed sample of pairs.

--- a/src/valueprovider.rs
+++ b/src/valueprovider.rs
@@ -11,6 +11,7 @@ use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::ops::Range;
 use std::str::FromStr;
+use std::sync::Arc;
 use uuid::Uuid;
 
 /// Which derivation stream a generated payload belongs to.
@@ -95,8 +96,13 @@ impl ValueProvider {
 	}
 
 	/// Attach a corpus seed, making [`Self::generate_value_for`] deterministic.
+	///
+	/// Cluster centres are re-drawn from the seed as well, so two seeds give two
+	/// genuinely different datasets rather than the same clusters populated
+	/// differently.
 	pub(crate) fn with_seed(mut self, seed: u64) -> Self {
 		self.seed = Some(seed);
+		self.generator.reseed_clusters(seed);
 		self
 	}
 
@@ -167,6 +173,9 @@ impl ValueProvider {
 		match generator {
 			ValueGenerator::Vector {
 				..
+			}
+			| ValueGenerator::ClusteredVector {
+				..
 			} => Ok(generator),
 			other => bail!("field {field:?} is {other:?}, not a `vector:<dim>` column"),
 		}
@@ -214,6 +223,69 @@ enum ValueGenerator {
 		lo: f32,
 		hi: f32,
 	},
+	/// Fixed-dimension f32 vector drawn from a mixture of clusters on the unit
+	/// sphere: pick a centroid, add Gaussian noise, renormalise.
+	///
+	/// Uniform components (see [`ValueGenerator::Vector`]) give a corpus with no
+	/// neighbourhood structure — in high dimensions every pair sits at roughly
+	/// the same distance, so a query's true neighbours are conspicuous and any
+	/// graph walks straight to them. Recall then reads 1.0 for every index and
+	/// discriminates nothing. Clusters put many plausible near-neighbours at
+	/// similar distances, which is what an approximate index actually has to
+	/// get right, and what real embeddings look like.
+	ClusteredVector {
+		dim: usize,
+		/// Shared cluster centres. Every row must land in the same structure
+		/// regardless of which client generated it, so these are fixed for the
+		/// provider rather than drawn per row.
+		centroids: Arc<Vec<Vec<f32>>>,
+		/// Noise length relative to a unit centroid.
+		sigma: f32,
+	},
+}
+
+/// Cluster spread when `vector:<dim>:clustered:<n>` omits it.
+///
+/// At 0.35 a point sits well inside its own cluster while the cluster still has
+/// real internal spread, so a query has many same-cluster candidates to confuse
+/// an index without the clusters bleeding into one another.
+const DEFAULT_CLUSTER_SIGMA: f32 = 0.35;
+
+/// Seed for cluster centres before a corpus seed is attached.
+const DEFAULT_CENTROID_SEED: u64 = 0x5EED_C0DE_CE47_401D;
+
+/// Draw `clusters` unit-length centres, deterministically from `seed`.
+///
+/// Gaussian components normalised to length 1 give directions spread evenly over
+/// the sphere; sampling components uniformly would bunch them toward the corners
+/// of the cube instead.
+fn cluster_centroids(dim: usize, clusters: usize, seed: u64) -> Vec<Vec<f32>> {
+	let mut rng = SmallRng::seed_from_u64(seed);
+	(0..clusters)
+		.map(|_| {
+			let mut v: Vec<f32> = (0..dim).map(|_| standard_normal(&mut rng)).collect();
+			normalise(&mut v);
+			v
+		})
+		.collect()
+}
+
+/// One draw from N(0, 1) by the Box-Muller transform.
+fn standard_normal(rng: &mut SmallRng) -> f32 {
+	// `u1` must exclude 0 or `ln` diverges.
+	let u1: f32 = RandGen::random_range(rng, f32::EPSILON..1.0);
+	let u2: f32 = RandGen::random_range(rng, 0.0..1.0);
+	(-2.0 * u1.ln()).sqrt() * (std::f32::consts::TAU * u2).cos()
+}
+
+/// Scale a vector to unit length, leaving an all-zero vector untouched.
+fn normalise(v: &mut [f32]) {
+	let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+	if norm > 0.0 {
+		for x in v.iter_mut() {
+			*x /= norm;
+		}
+	}
 }
 
 const CHARSET: &[u8; 62] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
@@ -286,6 +358,35 @@ fn bytes_range(rng: &mut SmallRng, range: Range<usize>) -> Vec<u8> {
 }
 
 impl ValueGenerator {
+	/// Re-draw cluster centres from the corpus seed, in place, throughout the
+	/// template tree.
+	fn reseed_clusters(&mut self, seed: u64) {
+		match self {
+			ValueGenerator::ClusteredVector {
+				dim,
+				centroids,
+				..
+			} => {
+				// Salted so the centres are not the same draw as sample 0 of any
+				// stream, which would correlate the structure with a row.
+				let clusters = centroids.len();
+				*centroids =
+					Arc::new(cluster_centroids(*dim, clusters, seed ^ DEFAULT_CENTROID_SEED));
+			}
+			ValueGenerator::Array(items) => {
+				for g in items {
+					g.reseed_clusters(seed);
+				}
+			}
+			ValueGenerator::Object(fields) => {
+				for (_, g) in fields {
+					g.reseed_clusters(seed);
+				}
+			}
+			_ => {}
+		}
+	}
+
 	fn new(value: Value) -> Result<Self> {
 		match value {
 			Value::Null => bail!("Unsupported type: Null"),
@@ -338,7 +439,8 @@ impl ValueGenerator {
 		} else if let Some(i) = s.strip_prefix("bytes:") {
 			Self::Bytes(Length::new(i)?)
 		} else if let Some(rest) = s.strip_prefix("vector:") {
-			// `vector:<dim>` (uniform [-1, 1]) or `vector:<dim>:<lo>..<hi>`.
+			// `vector:<dim>` (uniform [-1, 1]), `vector:<dim>:<lo>..<hi>`, or
+			// `vector:<dim>:clustered:<clusters>[:<sigma>]`.
 			let (dim_str, range) = match rest.split_once(':') {
 				Some((d, r)) => (d, Some(r)),
 				None => (rest, None),
@@ -348,6 +450,34 @@ impl ValueGenerator {
 				.map_err(|e| anyhow!("invalid vector dimension {dim_str:?}: {e}"))?;
 			if dim == 0 {
 				bail!("vector dimension must be > 0");
+			}
+			if let Some(spec) = range.and_then(|r| r.strip_prefix("clustered:")) {
+				let (clusters_str, sigma_str) = match spec.split_once(':') {
+					Some((c, g)) => (c, Some(g)),
+					None => (spec, None),
+				};
+				let clusters: usize = clusters_str
+					.parse()
+					.map_err(|e| anyhow!("invalid cluster count {clusters_str:?}: {e}"))?;
+				if clusters == 0 {
+					bail!("vector cluster count must be > 0");
+				}
+				// Scaled by 1/sqrt(dim) so the default means the same spread at
+				// any dimension: the noise vector's length is `sigma` relative
+				// to a unit-length centroid, rather than growing with `dim`.
+				let sigma: f32 = match sigma_str {
+					Some(g) => g.parse().map_err(|e| anyhow!("invalid cluster sigma: {e}"))?,
+					None => DEFAULT_CLUSTER_SIGMA,
+				};
+				// Also rejects NaN, which would silently poison every centroid.
+				if !sigma.is_finite() || sigma <= 0.0 {
+					bail!("vector cluster sigma must be a finite value > 0");
+				}
+				return Ok(Self::ClusteredVector {
+					dim,
+					sigma,
+					centroids: Arc::new(cluster_centroids(dim, clusters, DEFAULT_CENTROID_SEED)),
+				});
 			}
 			let (lo, hi) = if let Some(r) = range {
 				let parts: Vec<&str> = r.split("..").collect();
@@ -555,6 +685,23 @@ impl ValueGenerator {
 				}
 				BenchValue::FloatVector(buf)
 			}
+			ValueGenerator::ClusteredVector {
+				dim,
+				centroids,
+				sigma,
+			} => {
+				let centroid = &centroids[rng.random_range(0..centroids.len())];
+				// `sigma / sqrt(dim)` per component makes the noise vector's
+				// length `sigma` overall, so the spread means the same thing at
+				// any dimension.
+				let scale = *sigma / (*dim as f32).sqrt();
+				let mut buf: Vec<f32> =
+					centroid.iter().map(|c| c + scale * standard_normal(rng)).collect();
+				// Real embeddings are commonly unit-normalised, and it keeps
+				// cosine and inner-product rankings consistent with each other.
+				normalise(&mut buf);
+				BenchValue::FloatVector(buf)
+			}
 		}
 	}
 }
@@ -666,6 +813,10 @@ impl ColumnType {
 			ValueGenerator::Vector {
 				dim,
 				..
+			}
+			| ValueGenerator::ClusteredVector {
+				dim,
+				..
 			} => ColumnType::FloatVector(*dim),
 		};
 		Ok(r)
@@ -676,6 +827,84 @@ impl ColumnType {
 mod test {
 	use super::*;
 	use tokio::task;
+
+	fn vector_of(template: &str, seed: u64, sample: u32) -> Vec<f32> {
+		ValueProvider::new(template)
+			.unwrap()
+			.with_seed(seed)
+			.generate_value_for(ValueStream::Create, sample)
+			.get_field("v")
+			.and_then(|v| v.as_float_vector())
+			.unwrap()
+			.to_vec()
+	}
+
+	#[test]
+	fn clustered_vectors_are_unit_length() {
+		let v = vector_of(r#"{ "v": "vector:32:clustered:8" }"#, 1, 0);
+		assert_eq!(v.len(), 32);
+		let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+		assert!((norm - 1.0).abs() < 1e-4, "norm was {norm}");
+	}
+
+	/// The corpus has to be reconstructible for ground truth, which means the
+	/// cluster draw must be part of that determinism, not an extra source of
+	/// randomness on top of it.
+	#[test]
+	fn clustered_vectors_are_deterministic() {
+		let tmpl = r#"{ "v": "vector:32:clustered:8" }"#;
+		assert_eq!(vector_of(tmpl, 1, 7), vector_of(tmpl, 1, 7));
+		assert_ne!(vector_of(tmpl, 1, 7), vector_of(tmpl, 1, 8));
+	}
+
+	/// Two corpus seeds should give two different datasets, cluster centres
+	/// included — otherwise every seed reuses one structure.
+	#[test]
+	fn cluster_centres_follow_the_corpus_seed() {
+		let tmpl = r#"{ "v": "vector:32:clustered:4" }"#;
+		assert_ne!(vector_of(tmpl, 1, 0), vector_of(tmpl, 2, 0));
+	}
+
+	/// Tighter clusters must actually be tighter, or `sigma` means nothing.
+	#[test]
+	fn sigma_controls_cluster_spread() {
+		fn spread(sigma: &str) -> f32 {
+			let tmpl = format!(r#"{{ "v": "vector:64:clustered:4:{sigma}" }}"#);
+			let mut vp = ValueProvider::new(&tmpl).unwrap().with_seed(9);
+			let vs: Vec<Vec<f32>> = (0..200u32)
+				.map(|i| match vp.generate_value_for(ValueStream::Create, i) {
+					BenchValue::Object(o) => match &o[0].1 {
+						BenchValue::FloatVector(v) => v.clone(),
+						other => panic!("expected a vector, got {other:?}"),
+					},
+					other => panic!("expected an object, got {other:?}"),
+				})
+				.collect();
+			// Mean pairwise cosine distance over a fixed sample of pairs.
+			let mut total = 0.0;
+			let mut n = 0;
+			for i in 0..vs.len() {
+				for j in (i + 1)..vs.len() {
+					total += 1.0 - vs[i].iter().zip(&vs[j]).map(|(a, b)| a * b).sum::<f32>();
+					n += 1;
+				}
+			}
+			total / n as f32
+		}
+		assert!(spread("0.15") < spread("0.80"), "tighter sigma should cluster more closely");
+	}
+
+	#[test]
+	fn clustered_template_rejects_bad_parameters() {
+		for bad in [
+			r#"{ "v": "vector:8:clustered:0" }"#,
+			r#"{ "v": "vector:8:clustered:4:0" }"#,
+			r#"{ "v": "vector:8:clustered:4:-1" }"#,
+			r#"{ "v": "vector:8:clustered:x" }"#,
+		] {
+			assert!(ValueProvider::new(bad).is_err(), "should have rejected {bad}");
+		}
+	}
 
 	#[tokio::test]
 	async fn check_all_values_are_unique() {

--- a/src/valueprovider.rs
+++ b/src/valueprovider.rs
@@ -3,6 +3,7 @@ use anyhow::{Result, anyhow, bail};
 use chrono::{TimeZone, Utc};
 use log::debug;
 use rand::RngExt as RandGen;
+use rand::SeedableRng;
 use rand::prelude::SmallRng;
 use rust_decimal::Decimal;
 use serde_json::{Map, Number, Value};
@@ -12,14 +13,66 @@ use std::ops::Range;
 use std::str::FromStr;
 use uuid::Uuid;
 
+/// Which derivation stream a generated payload belongs to.
+///
+/// A seeded provider salts each stream differently so they stay independent.
+/// The create and update phases both write every sample, and salting them apart
+/// means updates write genuinely different content rather than rewriting
+/// identical bytes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ValueStream {
+	/// Payloads written by the create phase.
+	Create,
+	/// Payloads written by the update phase. Scans run after the update phase,
+	/// so this is the content a scan actually observes — and therefore the
+	/// stream vector-search ground truth has to be derived from.
+	Update,
+	/// Query vectors for vector search. Never inserted, so a query set drawn
+	/// from this stream is disjoint from the corpus by construction.
+	Query,
+}
+
+impl ValueStream {
+	/// Per-stream salt. Distinct arbitrary constants; the values carry no
+	/// meaning beyond being unrelated to one another and to [`SAMPLE_ODD`].
+	const fn salt(self) -> u64 {
+		match self {
+			ValueStream::Create => 0x243F_6A88_85A3_08D3,
+			ValueStream::Update => 0xB7E1_5162_8AED_2A6B,
+			ValueStream::Query => 0xC13F_A9A9_02A6_328E,
+		}
+	}
+}
+
+/// Odd multiplier spreading consecutive sample indices before mixing.
+const SAMPLE_ODD: u64 = 0x9E37_79B9_7F4A_7C15;
+
+/// Derive the RNG seed for one sample of one stream.
+///
+/// SplitMix64's finalisation step decorrelates neighbouring sample indices, so
+/// sample `n` and sample `n + 1` do not produce visibly related payloads.
+fn sample_seed(seed: u64, stream: ValueStream, n: u32) -> u64 {
+	let mut z = seed ^ stream.salt() ^ (n as u64).wrapping_mul(SAMPLE_ODD);
+	z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+	z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+	z ^ (z >> 31)
+}
+
 /// Generates synthetic [`BenchValue`] payloads from a JSON template authored in
 /// `bench.toml`. The template is parsed once into a [`ValueGenerator`] tree and
 /// each call to [`Self::generate_value`] produces a fresh randomised
 /// [`BenchValue`] following the schema.
+///
+/// A provider carrying a corpus seed (see [`Self::with_seed`]) can additionally
+/// produce the payload for a given sample index as a pure function of that
+/// seed, so the same index yields the same row in every client, every run and
+/// every engine. Vector-search ground truth depends on that property: it lets
+/// the corpus be reconstructed for scoring without reading a single row back.
 pub(crate) struct ValueProvider {
 	generator: ValueGenerator,
 	rng: SmallRng,
 	columns: Columns,
+	seed: Option<u64>,
 }
 
 impl ValueProvider {
@@ -37,7 +90,19 @@ impl ValueProvider {
 			generator,
 			columns,
 			rng: rand::make_rng(),
+			seed: None,
 		})
+	}
+
+	/// Attach a corpus seed, making [`Self::generate_value_for`] deterministic.
+	pub(crate) fn with_seed(mut self, seed: u64) -> Self {
+		self.seed = Some(seed);
+		self
+	}
+
+	/// The corpus seed, when this provider was built with one.
+	pub(crate) fn seed(&self) -> Option<u64> {
+		self.seed
 	}
 
 	/// Returns the schema's columns in their declared order.
@@ -49,6 +114,63 @@ impl ValueProvider {
 	pub(crate) fn generate_value(&mut self) -> BenchValue {
 		self.generator.generate(&mut self.rng)
 	}
+
+	/// Produce the payload for sample `n` of `stream`.
+	///
+	/// With a corpus seed this is a pure function of `(seed, stream, n)`.
+	/// Without one it draws from the provider's own stream and behaves exactly
+	/// like [`Self::generate_value`], which keeps unseeded runs — every
+	/// non-vector config — byte-for-byte unchanged.
+	pub(crate) fn generate_value_for(&mut self, stream: ValueStream, n: u32) -> BenchValue {
+		match self.seed {
+			Some(seed) => {
+				let mut rng = SmallRng::seed_from_u64(sample_seed(seed, stream, n));
+				self.generator.generate(&mut rng)
+			}
+			None => self.generator.generate(&mut self.rng),
+		}
+	}
+
+	/// Generate `count` standalone vectors shaped like the schema's `field`
+	/// column, drawn deterministically from `seed`.
+	///
+	/// Queries come from the same generator as the corpus, so they follow the
+	/// corpus distribution by construction rather than by a parallel
+	/// implementation that could drift from it. Each query is seeded on its own
+	/// index, so raising `count` extends the set instead of reshuffling it.
+	pub(crate) fn generate_vectors(
+		&self,
+		field: &str,
+		count: usize,
+		seed: u64,
+	) -> Result<Vec<Vec<f32>>> {
+		let generator = self.vector_generator(field)?;
+		let mut out = Vec::with_capacity(count);
+		for i in 0..count {
+			let mut rng = SmallRng::seed_from_u64(sample_seed(seed, ValueStream::Query, i as u32));
+			match generator.generate(&mut rng) {
+				BenchValue::FloatVector(v) => out.push(v),
+				other => bail!("field {field:?} generated {other:?}, expected a vector"),
+			}
+		}
+		Ok(out)
+	}
+
+	/// Locate the generator for a top-level `vector:<dim>` column.
+	fn vector_generator(&self, field: &str) -> Result<&ValueGenerator> {
+		let ValueGenerator::Object(fields) = &self.generator else {
+			bail!("value template must be an object");
+		};
+		let Some((_, generator)) = fields.iter().find(|(name, _)| name == field) else {
+			bail!("field {field:?} is not present in the value template");
+		};
+		match generator {
+			ValueGenerator::Vector {
+				..
+			} => Ok(generator),
+			other => bail!("field {field:?} is {other:?}, not a `vector:<dim>` column"),
+		}
+	}
 }
 
 impl Clone for ValueProvider {
@@ -57,6 +179,7 @@ impl Clone for ValueProvider {
 			generator: self.generator.clone(),
 			rng: rand::make_rng(),
 			columns: self.columns.clone(),
+			seed: self.seed,
 		}
 	}
 }

--- a/src/vectorgt.rs
+++ b/src/vectorgt.rs
@@ -50,11 +50,21 @@ pub(crate) struct GroundTruth {
 
 /// How many neighbours to store for a given `top_k`.
 ///
-/// Twice the cut is enough for any realistic tolerance: it is a scoring-time
-/// parameter, so widening the tolerance never invalidates a cached answer key.
+/// `tie_epsilon` is a scoring-time parameter deliberately kept out of the cache
+/// fingerprint, so a stored key has to cover any tolerance a later run might
+/// apply. Twice the cut covers a realistic one; [`MAX_TIE_EPSILON`] bounds the
+/// configuration to what this depth can actually honour.
 fn storage_depth(top_k: usize) -> usize {
 	top_k.saturating_mul(2)
 }
+
+/// Largest tolerance the stored answer key can honour.
+///
+/// The key holds [`storage_depth`] neighbours. A tolerance wide enough to admit
+/// candidates beyond that would silently score a legitimately-returned boundary
+/// neighbour as a miss, because `build_answers` can only accept rows the key
+/// actually stored.
+pub(crate) const MAX_TIE_EPSILON: f64 = 0.5;
 
 /// One query's accepted answers, resolved into the run's key shape.
 ///

--- a/src/vectorgt.rs
+++ b/src/vectorgt.rs
@@ -770,6 +770,48 @@ mod test {
 		assert!((s.mean - 0.5).abs() < 1e-9);
 	}
 
+	/// The clustered generator exists because uniform components give a corpus
+	/// with no neighbourhood structure. Assert the structure is actually there:
+	/// a query's nearest neighbour should sit far closer, relative to a random
+	/// point, than it does under the uniform generator.
+	#[test]
+	fn clustered_data_has_neighbourhood_structure() {
+		fn profile(template: &str) -> (f32, f32) {
+			let vp = ValueProvider::new(template).unwrap().with_seed(42);
+			let mut src = vp.clone();
+			let corpus: Vec<Vec<f32>> = (0..4_000u32)
+				.map(|i| {
+					src.generate_value_for(ValueStream::Update, i)
+						.get_field("embedding")
+						.and_then(|v| v.as_float_vector())
+						.unwrap()
+						.to_vec()
+				})
+				.collect();
+			let queries = vp.generate_vectors("embedding", 10, 7).unwrap();
+			let (mut nearest, mut mean) = (0.0f32, 0.0f32);
+			for q in &queries {
+				let ds: Vec<f32> =
+					corpus.iter().map(|v| distance(VectorDistance::Cosine, q, v)).collect();
+				mean += ds.iter().sum::<f32>() / ds.len() as f32;
+				nearest += ds.iter().copied().fold(f32::INFINITY, f32::min);
+			}
+			let n = queries.len() as f32;
+			(nearest / n, mean / n)
+		}
+
+		let (u_near, u_mean) = profile(r#"{ "embedding": "vector:64" }"#);
+		let (c_near, c_mean) = profile(r#"{ "embedding": "vector:64:clustered:50" }"#);
+
+		// Under uniform components the nearest neighbour is only modestly
+		// closer than an arbitrary point — the distance concentration that
+		// makes every index look perfect.
+		assert!(u_near / u_mean > 0.4, "uniform nn ratio {}", u_near / u_mean);
+		// Clustered draws put the nearest neighbour an order of magnitude
+		// closer, so there is a real neighbourhood for a search to miss.
+		assert!(c_near / c_mean < 0.2, "clustered nn ratio {}", c_near / c_mean);
+	}
+
 	#[test]
 	fn cache_round_trips() {
 		let dir = std::env::temp_dir().join(format!("crud-bench-gt-test-{}", std::process::id()));

--- a/src/vectorgt.rs
+++ b/src/vectorgt.rs
@@ -1,0 +1,508 @@
+//! Exact nearest-neighbour ground truth for the vector-search benchmark.
+//!
+//! Recall is only comparable across engines when every engine is scored against
+//! the same answer key, so the key is computed here rather than taken from any
+//! engine's own exact-search path. An engine scored against itself reports how
+//! well its index agrees with its own bruteforce leg, which is a useful
+//! regression signal but not a figure that can be placed beside another
+//! engine's — a quirk shared by an engine's exact and approximate paths cancels
+//! out, and divergent metric definitions leave every engine at ~1.0 against
+//! itself with nothing to reveal it.
+//!
+//! Both inputs are reproducible: the corpus is a pure function of the corpus
+//! seed and the queries of the query seed. That makes the whole table a pure
+//! function of its [`Request`] fingerprint, so it is computed once and cached
+//! for reuse across every engine and every later run. It also means the corpus
+//! is reconstructed locally for scoring rather than read back out of the
+//! database under test.
+
+use crate::VectorDistance;
+use crate::valueprovider::{ValueProvider, ValueStream};
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use twox_hash::XxHash64;
+
+/// One true neighbour of a query vector.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub(crate) struct Neighbour {
+	/// Sample index of the neighbouring row. This is the benchmark's sample
+	/// number, not the engine's key — [`crate::keyprovider::KeyProvider`] maps
+	/// it to whatever key type the run is using.
+	pub(crate) sample: u32,
+	/// Distance from the query in ranking orientation: lower is always nearer,
+	/// whatever the metric's native convention.
+	pub(crate) distance: f32,
+}
+
+/// The answer key: for each query, its true nearest neighbours, best first.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct GroundTruth {
+	pub(crate) neighbours: Vec<Vec<Neighbour>>,
+}
+
+/// Everything the answer key depends on. Two runs sharing a fingerprint share
+/// their ground truth, which is what makes the cache reusable across engines.
+#[derive(Clone, Debug)]
+pub(crate) struct Request {
+	/// Name of the `vector:<dim>` column being searched.
+	pub(crate) field: String,
+	/// Number of rows in the corpus.
+	pub(crate) samples: u32,
+	/// Neighbours to record per query.
+	pub(crate) top_k: usize,
+	/// Metric the scan ranks by.
+	pub(crate) metric: VectorDistance,
+	/// Seed the corpus was generated from.
+	pub(crate) corpus_seed: u64,
+	/// Seed the query set was generated from.
+	pub(crate) query_seed: u64,
+	/// Number of query vectors.
+	pub(crate) query_count: usize,
+	/// The value template itself: changing the schema changes the corpus, even
+	/// at an unchanged seed.
+	pub(crate) template: String,
+}
+
+impl Request {
+	/// Stable digest of every input, used as the cache file name.
+	fn fingerprint(&self) -> u64 {
+		let Request {
+			field,
+			samples,
+			top_k,
+			metric,
+			corpus_seed,
+			query_seed,
+			query_count,
+			template,
+		} = self;
+		// Field-separated so no two distinct requests can render to the same
+		// string by shifting a boundary.
+		let key = format!(
+			"v1\u{1f}{field}\u{1f}{samples}\u{1f}{top_k}\u{1f}{metric:?}\u{1f}{corpus_seed}\u{1f}{query_seed}\u{1f}{query_count}\u{1f}{template}"
+		);
+		XxHash64::oneshot(0, key.as_bytes())
+	}
+
+	/// Path this request's answer key is cached at.
+	fn cache_path(&self, dir: &Path) -> PathBuf {
+		dir.join(format!("gt-{:016x}.json", self.fingerprint()))
+	}
+}
+
+/// Load the answer key from `cache_dir`, computing and storing it on a miss.
+///
+/// A cache that cannot be read or written is not fatal — the key is recomputed
+/// and the run continues, since the cache is an optimisation rather than a
+/// source of truth.
+pub(crate) fn load_or_compute(
+	request: &Request,
+	vp: &ValueProvider,
+	queries: &[Vec<f32>],
+	cache_dir: &Path,
+) -> Result<(GroundTruth, bool)> {
+	let path = request.cache_path(cache_dir);
+	if let Ok(text) = fs::read_to_string(&path) {
+		match serde_json::from_str::<GroundTruth>(&text) {
+			Ok(gt) if gt.neighbours.len() == queries.len() => return Ok((gt, true)),
+			// A truncated or stale file is simply a miss: recompute over it.
+			_ => {}
+		}
+	}
+	let gt = compute(request, vp, queries)?;
+	if let Err(e) = store(&gt, &path) {
+		eprintln!("vector ground truth: could not cache to {}: {e:#}", path.display());
+	}
+	Ok((gt, false))
+}
+
+fn store(gt: &GroundTruth, path: &Path) -> Result<()> {
+	if let Some(dir) = path.parent() {
+		fs::create_dir_all(dir)
+			.with_context(|| format!("creating ground-truth cache dir {}", dir.display()))?;
+	}
+	let text = serde_json::to_string(gt)?;
+	fs::write(path, text).with_context(|| format!("writing {}", path.display()))?;
+	Ok(())
+}
+
+/// Compute exact top-k for every query by scanning the whole corpus.
+///
+/// The corpus is regenerated in place rather than held in memory: at 1M rows of
+/// 3072 dimensions the full set is over 12 GB, so each worker streams its own
+/// slice and keeps only the running top-k. Workers partition the corpus rather
+/// than the queries, so every worker sees each of its rows exactly once and the
+/// per-query accumulators merge at the end.
+pub(crate) fn compute(
+	request: &Request,
+	vp: &ValueProvider,
+	queries: &[Vec<f32>],
+) -> Result<GroundTruth> {
+	if request.top_k == 0 {
+		bail!("ground truth: top_k must be > 0");
+	}
+	if queries.is_empty() {
+		bail!("ground truth: query set is empty");
+	}
+	if vp.seed().is_none() {
+		bail!(
+			"ground truth needs a reproducible corpus: set `seed` in the benchmark TOML or pass --corpus-seed"
+		);
+	}
+	let dim = queries[0].len();
+	if let Some(bad) = queries.iter().position(|q| q.len() != dim) {
+		bail!("ground truth: query {bad} has {} dimensions, expected {dim}", queries[bad].len());
+	}
+
+	let workers = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1).min(
+		// One worker per row at most; tiny corpora do not need a thread each.
+		(request.samples as usize).max(1),
+	);
+	let chunk = (request.samples as usize).div_ceil(workers.max(1)) as u32;
+
+	let partials: Vec<Vec<TopK>> = std::thread::scope(|scope| -> Result<Vec<Vec<TopK>>> {
+		let mut handles = Vec::with_capacity(workers);
+		for w in 0..workers {
+			let start = (w as u32) * chunk;
+			if start >= request.samples {
+				break;
+			}
+			let end = start.saturating_add(chunk).min(request.samples);
+			let mut worker_vp = vp.clone();
+			let field = request.field.as_str();
+			let (top_k, metric) = (request.top_k, request.metric);
+			handles.push(scope.spawn(move || -> Result<Vec<TopK>> {
+				let mut acc: Vec<TopK> = (0..queries.len()).map(|_| TopK::new(top_k)).collect();
+				for n in start..end {
+					// Scans run after the update phase, so the corpus a scan
+					// observes is the one the update phase left behind.
+					let row = worker_vp.generate_value_for(ValueStream::Update, n);
+					let Some(v) = row.get_field(field).and_then(|v| v.as_float_vector()) else {
+						bail!("ground truth: sample {n} has no vector at field {field:?}");
+					};
+					if v.len() != dim {
+						bail!(
+							"ground truth: sample {n} has {} dimensions, queries have {dim}",
+							v.len()
+						);
+					}
+					for (q, slot) in queries.iter().zip(acc.iter_mut()) {
+						slot.offer(n, distance(metric, q, v));
+					}
+				}
+				Ok(acc)
+			}));
+		}
+		handles.into_iter().map(|h| h.join().expect("ground-truth worker panicked")).collect()
+	})?;
+
+	let mut merged: Vec<TopK> = (0..queries.len()).map(|_| TopK::new(request.top_k)).collect();
+	for partial in &partials {
+		for (slot, part) in merged.iter_mut().zip(partial.iter()) {
+			slot.merge(part);
+		}
+	}
+	Ok(GroundTruth {
+		neighbours: merged.into_iter().map(|t| t.best).collect(),
+	})
+}
+
+/// Distance between two vectors in ranking orientation: lower is always nearer.
+///
+/// Only the ordering matters for recall, so metrics whose native convention is
+/// "higher is nearer" are negated rather than rescaled — the absolute values
+/// stay comparable within a metric without pretending to match any particular
+/// engine's numeric output.
+fn distance(metric: VectorDistance, a: &[f32], b: &[f32]) -> f32 {
+	match metric {
+		VectorDistance::Cosine => {
+			let (mut dot, mut na, mut nb) = (0.0f32, 0.0f32, 0.0f32);
+			for (x, y) in a.iter().zip(b.iter()) {
+				dot += x * y;
+				na += x * x;
+				nb += y * y;
+			}
+			let denom = na.sqrt() * nb.sqrt();
+			// A zero vector has no direction; treat it as maximally distant
+			// rather than producing a NaN that would corrupt the ordering.
+			if denom == 0.0 {
+				2.0
+			} else {
+				1.0 - dot / denom
+			}
+		}
+		VectorDistance::Euclidean => {
+			let mut sum = 0.0f32;
+			for (x, y) in a.iter().zip(b.iter()) {
+				let d = x - y;
+				sum += d * d;
+			}
+			sum.sqrt()
+		}
+		VectorDistance::InnerProduct => {
+			let mut dot = 0.0f32;
+			for (x, y) in a.iter().zip(b.iter()) {
+				dot += x * y;
+			}
+			-dot
+		}
+		VectorDistance::Manhattan => {
+			let mut sum = 0.0f32;
+			for (x, y) in a.iter().zip(b.iter()) {
+				sum += (x - y).abs();
+			}
+			sum
+		}
+	}
+}
+
+/// Bounded best-first accumulator holding at most `k` neighbours sorted by
+/// ascending distance.
+///
+/// The overwhelmingly common case is a row that cannot displace the current
+/// worst, and that costs a single comparison; only an improvement pays for an
+/// insertion.
+struct TopK {
+	k: usize,
+	best: Vec<Neighbour>,
+}
+
+impl TopK {
+	fn new(k: usize) -> Self {
+		Self {
+			k,
+			best: Vec::with_capacity(k),
+		}
+	}
+
+	fn offer(&mut self, sample: u32, distance: f32) {
+		if self.k == 0 {
+			return;
+		}
+		if self.best.len() == self.k {
+			if distance >= self.best[self.k - 1].distance {
+				return;
+			}
+			self.best.pop();
+		}
+		let at = self.best.partition_point(|n| n.distance <= distance);
+		self.best.insert(
+			at,
+			Neighbour {
+				sample,
+				distance,
+			},
+		);
+	}
+
+	fn merge(&mut self, other: &TopK) {
+		for n in &other.best {
+			self.offer(n.sample, n.distance);
+		}
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	const TEMPLATE: &str = r#"{ "name": "string:8", "embedding": "vector:16" }"#;
+
+	fn request(samples: u32, top_k: usize, metric: VectorDistance) -> Request {
+		Request {
+			field: "embedding".to_string(),
+			samples,
+			top_k,
+			metric,
+			corpus_seed: 42,
+			query_seed: 7,
+			query_count: 3,
+			template: TEMPLATE.to_string(),
+		}
+	}
+
+	fn provider() -> ValueProvider {
+		ValueProvider::new(TEMPLATE).unwrap().with_seed(42)
+	}
+
+	/// The whole design rests on the corpus being reconstructible, so assert it
+	/// directly: independent providers must agree sample by sample.
+	#[test]
+	fn seeded_corpus_is_reproducible_across_providers() {
+		let (mut a, mut b) = (provider(), provider().clone());
+		for n in [0u32, 1, 17, 999] {
+			let va = a.generate_value_for(ValueStream::Update, n);
+			let vb = b.generate_value_for(ValueStream::Update, n);
+			assert_eq!(va, vb, "sample {n} differed between providers");
+		}
+	}
+
+	/// Create and update must not collide, or the update phase would rewrite
+	/// identical bytes and ground truth would be ambiguous about which it meant.
+	#[test]
+	fn streams_are_independent() {
+		let mut vp = provider();
+		let create = vp.generate_value_for(ValueStream::Create, 5);
+		let update = vp.generate_value_for(ValueStream::Update, 5);
+		assert_ne!(create, update);
+	}
+
+	/// An unseeded provider keeps its old behaviour, so every non-vector config
+	/// is unaffected by this machinery.
+	#[test]
+	fn unseeded_provider_stays_random() {
+		let mut vp = ValueProvider::new(TEMPLATE).unwrap();
+		let a = vp.generate_value_for(ValueStream::Create, 3);
+		let b = vp.generate_value_for(ValueStream::Create, 3);
+		assert_ne!(a, b, "unseeded provider should not be reproducible");
+	}
+
+	/// Queries are extensible: asking for more must not renumber the ones
+	/// already computed, or a cached answer key would silently mismatch.
+	#[test]
+	fn query_set_extends_rather_than_reshuffles() {
+		let vp = provider();
+		let few = vp.generate_vectors("embedding", 3, 7).unwrap();
+		let many = vp.generate_vectors("embedding", 10, 7).unwrap();
+		assert_eq!(few.as_slice(), &many[..3]);
+	}
+
+	#[test]
+	fn rejects_non_vector_field() {
+		let vp = provider();
+		let err = vp.generate_vectors("name", 1, 7).unwrap_err().to_string();
+		assert!(err.contains("not a `vector:<dim>` column"), "{err}");
+	}
+
+	/// The parallel path partitions the corpus, so it has to agree with a
+	/// single-threaded sweep over the same data.
+	#[test]
+	fn matches_a_naive_sweep() {
+		for metric in [
+			VectorDistance::Cosine,
+			VectorDistance::Euclidean,
+			VectorDistance::InnerProduct,
+			VectorDistance::Manhattan,
+		] {
+			let vp = provider();
+			let samples = 500u32;
+			let top_k = 5;
+			let queries = vp.generate_vectors("embedding", 3, 7).unwrap();
+			let gt = compute(&request(samples, top_k, metric), &vp, &queries).unwrap();
+
+			let mut naive = vp.clone();
+			let corpus: Vec<Vec<f32>> = (0..samples)
+				.map(|n| {
+					naive
+						.generate_value_for(ValueStream::Update, n)
+						.get_field("embedding")
+						.and_then(|v| v.as_float_vector())
+						.map(|v| v.to_vec())
+						.unwrap()
+				})
+				.collect();
+			for (qi, q) in queries.iter().enumerate() {
+				let mut all: Vec<(u32, f32)> = corpus
+					.iter()
+					.enumerate()
+					.map(|(n, v)| (n as u32, distance(metric, q, v)))
+					.collect();
+				all.sort_by(|a, b| a.1.total_cmp(&b.1));
+				let expected: Vec<u32> = all[..top_k].iter().map(|(n, _)| *n).collect();
+				let got: Vec<u32> = gt.neighbours[qi].iter().map(|n| n.sample).collect();
+				assert_eq!(expected, got, "{metric:?} query {qi}");
+			}
+		}
+	}
+
+	/// Neighbours must come back best-first; recall@k and the tie epsilon both
+	/// read positionally.
+	#[test]
+	fn neighbours_are_sorted_best_first() {
+		let vp = provider();
+		let queries = vp.generate_vectors("embedding", 2, 7).unwrap();
+		let gt = compute(&request(300, 8, VectorDistance::Euclidean), &vp, &queries).unwrap();
+		for row in &gt.neighbours {
+			assert_eq!(row.len(), 8);
+			assert!(row.windows(2).all(|w| w[0].distance <= w[1].distance), "{row:?}");
+		}
+	}
+
+	/// A corpus smaller than k must return what exists rather than padding.
+	#[test]
+	fn corpus_smaller_than_k() {
+		let vp = provider();
+		let queries = vp.generate_vectors("embedding", 1, 7).unwrap();
+		let gt = compute(&request(3, 10, VectorDistance::Cosine), &vp, &queries).unwrap();
+		assert_eq!(gt.neighbours[0].len(), 3);
+	}
+
+	/// Changing any input has to change the cache key, or a stale answer key
+	/// would be served for a different corpus.
+	#[test]
+	fn fingerprint_covers_every_input() {
+		let base = request(100, 10, VectorDistance::Cosine);
+		let mut seen = vec![base.fingerprint()];
+		let mut variants = vec![
+			Request {
+				samples: 101,
+				..base.clone()
+			},
+			Request {
+				top_k: 11,
+				..base.clone()
+			},
+			Request {
+				metric: VectorDistance::Euclidean,
+				..base.clone()
+			},
+			Request {
+				corpus_seed: 43,
+				..base.clone()
+			},
+			Request {
+				query_seed: 8,
+				..base.clone()
+			},
+			Request {
+				query_count: 4,
+				..base.clone()
+			},
+			Request {
+				field: "other".to_string(),
+				..base.clone()
+			},
+			Request {
+				template: "{}".to_string(),
+				..base.clone()
+			},
+		];
+		for v in variants.drain(..) {
+			let f = v.fingerprint();
+			assert!(!seen.contains(&f), "fingerprint collision for {v:?}");
+			seen.push(f);
+		}
+	}
+
+	#[test]
+	fn cache_round_trips() {
+		let dir = std::env::temp_dir().join(format!("crud-bench-gt-test-{}", std::process::id()));
+		let _ = fs::remove_dir_all(&dir);
+		let vp = provider();
+		let req = request(200, 4, VectorDistance::Cosine);
+		let queries = vp.generate_vectors("embedding", 3, 7).unwrap();
+
+		let (first, hit) = load_or_compute(&req, &vp, &queries, &dir).unwrap();
+		assert!(!hit, "first call should miss");
+		let (second, hit) = load_or_compute(&req, &vp, &queries, &dir).unwrap();
+		assert!(hit, "second call should hit the cache");
+
+		let ids = |g: &GroundTruth| -> Vec<Vec<u32>> {
+			g.neighbours.iter().map(|r| r.iter().map(|n| n.sample).collect()).collect()
+		};
+		assert_eq!(ids(&first), ids(&second));
+		let _ = fs::remove_dir_all(&dir);
+	}
+}

--- a/src/vectorgt.rs
+++ b/src/vectorgt.rs
@@ -17,9 +17,12 @@
 //! database under test.
 
 use crate::VectorDistance;
+use crate::engine::KnnKey;
+use crate::keyprovider::{IntegerKeyProvider, KeyProvider, StringKeyProvider};
 use crate::valueprovider::{ValueProvider, ValueStream};
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use twox_hash::XxHash64;
@@ -37,9 +40,152 @@ pub(crate) struct Neighbour {
 }
 
 /// The answer key: for each query, its true nearest neighbours, best first.
+///
+/// More than `top_k` neighbours are stored so the tie tolerance has candidates
+/// beyond the cut to admit; the first `top_k` remain the strict answer.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct GroundTruth {
 	pub(crate) neighbours: Vec<Vec<Neighbour>>,
+}
+
+/// How many neighbours to store for a given `top_k`.
+///
+/// Twice the cut is enough for any realistic tolerance: it is a scoring-time
+/// parameter, so widening the tolerance never invalidates a cached answer key.
+fn storage_depth(top_k: usize) -> usize {
+	top_k.saturating_mul(2)
+}
+
+/// One query's accepted answers, resolved into the run's key shape.
+///
+/// Built once per scan rather than per iteration: deriving `top_k` keys from
+/// the [`KeyProvider`] on every KNN call would put avoidable work next to the
+/// timed window.
+#[derive(Clone, Debug)]
+pub(crate) struct VectorAnswer {
+	/// Number of true neighbours that exist, which is `min(top_k, corpus)`.
+	/// Recall divides by this, so a corpus smaller than k is not penalised.
+	truth_len: usize,
+	/// Keys that count as a correct hit, including any admitted by the tie
+	/// tolerance.
+	keys: HashSet<KnnKey>,
+}
+
+/// Resolve the answer key into the run's key shape, applying the tie tolerance.
+///
+/// A hit counts when the engine returned a row inside the true top-k, or one
+/// whose true distance is within `tie_epsilon` (relative) of the k-th true
+/// distance. Engines compute distances at different precisions, so rows
+/// straddling the k-th boundary can swap places without any real quality
+/// difference; without a tolerance that shows up as a recall gap that is not
+/// really there. The default is 0.0 — strict recall@k.
+pub(crate) fn build_answers(
+	gt: &GroundTruth,
+	kp: &KeyProvider,
+	top_k: usize,
+	tie_epsilon: f64,
+) -> Vec<VectorAnswer> {
+	gt.neighbours
+		.iter()
+		.map(|row| {
+			let truth_len = row.len().min(top_k);
+			// Everything at or inside the k-th distance, widened by the
+			// tolerance. `cut` is the k-th distance when one exists.
+			let limit = row.get(truth_len.saturating_sub(1)).map(|n| {
+				let cut = n.distance as f64;
+				// Relative on magnitude, with an absolute floor so a cut at or
+				// near zero still admits its neighbours.
+				cut + tie_epsilon * cut.abs().max(f64::EPSILON)
+			});
+			let keys = row
+				.iter()
+				.enumerate()
+				.filter(|(i, n)| match limit {
+					Some(limit) => *i < truth_len || (n.distance as f64) <= limit,
+					None => false,
+				})
+				.map(|(_, n)| key_for(kp, n.sample))
+				.collect();
+			VectorAnswer {
+				truth_len,
+				keys,
+			}
+		})
+		.collect()
+}
+
+/// Map a benchmark sample index into the run's key shape.
+fn key_for(kp: &KeyProvider, sample: u32) -> KnnKey {
+	// `KeyProvider` is `Copy` and its `key` needs `&mut`, so score against a
+	// local copy rather than threading mutability through the caller.
+	let mut kp = *kp;
+	match &mut kp {
+		KeyProvider::OrderedInteger(p) => KnnKey::Integer(p.key(sample)),
+		KeyProvider::UnorderedInteger(p) => KnnKey::Integer(p.key(sample)),
+		KeyProvider::OrderedString(p) => KnnKey::Text(p.key(sample)),
+		KeyProvider::UnorderedString(p) => KnnKey::Text(p.key(sample)),
+	}
+}
+
+/// Recall of one KNN result: the share of a query's true neighbours the engine
+/// actually returned. `None` when the query has no true neighbours to find.
+pub(crate) fn recall(answer: &VectorAnswer, returned: &[KnnKey]) -> Option<f64> {
+	if answer.truth_len == 0 {
+		return None;
+	}
+	let found = returned.iter().filter(|k| answer.keys.contains(k)).count();
+	Some((found as f64 / answer.truth_len as f64).min(1.0))
+}
+
+/// Per-iteration recall values for one scan, merged across workers.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct RecallTally {
+	values: Vec<f64>,
+}
+
+impl RecallTally {
+	pub(crate) fn record(&mut self, value: f64) {
+		self.values.push(value);
+	}
+
+	pub(crate) fn merge(&mut self, other: RecallTally) {
+		self.values.extend(other.values);
+	}
+
+	/// Collapse into the reported figures.
+	///
+	/// The mean alone hides the shape: an index can average well and still
+	/// answer a tail of queries badly, which is exactly the failure mode a
+	/// graph index has on data it indexed poorly. `p5` and `min` surface it.
+	pub(crate) fn summarise(&self) -> Option<RecallSummary> {
+		if self.values.is_empty() {
+			return None;
+		}
+		let mut sorted = self.values.clone();
+		sorted.sort_by(f64::total_cmp);
+		let mean = sorted.iter().sum::<f64>() / sorted.len() as f64;
+		// Nearest-rank percentile, clamped into range for tiny samples.
+		let idx = ((0.05 * sorted.len() as f64).ceil() as usize).clamp(1, sorted.len()) - 1;
+		Some(RecallSummary {
+			mean,
+			p5: sorted[idx],
+			min: sorted[0],
+			queries: sorted.len(),
+		})
+	}
+}
+
+/// Reported recall figures for one vector scan.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub(crate) struct RecallSummary {
+	/// Mean recall@k across scored iterations.
+	pub(crate) mean: f64,
+	/// 5th-percentile recall — the tail the mean hides.
+	pub(crate) p5: f64,
+	/// Worst single query.
+	pub(crate) min: f64,
+	/// Number of iterations scored.
+	pub(crate) queries: usize,
 }
 
 /// Everything the answer key depends on. Two runs sharing a fingerprint share
@@ -106,7 +252,16 @@ pub(crate) fn load_or_compute(
 	let path = request.cache_path(cache_dir);
 	if let Ok(text) = fs::read_to_string(&path) {
 		match serde_json::from_str::<GroundTruth>(&text) {
-			Ok(gt) if gt.neighbours.len() == queries.len() => return Ok((gt, true)),
+			// Depth as well as width: a key stored before the tie window was
+			// widened would silently score against too few candidates.
+			Ok(gt)
+				if gt.neighbours.len() == queries.len()
+					&& gt.neighbours.iter().all(|n| {
+						n.len() >= storage_depth(request.top_k).min(request.samples as usize)
+					}) =>
+			{
+				return Ok((gt, true));
+			}
 			// A truncated or stale file is simply a miss: recompute over it.
 			_ => {}
 		}
@@ -172,9 +327,9 @@ pub(crate) fn compute(
 			let end = start.saturating_add(chunk).min(request.samples);
 			let mut worker_vp = vp.clone();
 			let field = request.field.as_str();
-			let (top_k, metric) = (request.top_k, request.metric);
+			let (depth, metric) = (storage_depth(request.top_k), request.metric);
 			handles.push(scope.spawn(move || -> Result<Vec<TopK>> {
-				let mut acc: Vec<TopK> = (0..queries.len()).map(|_| TopK::new(top_k)).collect();
+				let mut acc: Vec<TopK> = (0..queries.len()).map(|_| TopK::new(depth)).collect();
 				for n in start..end {
 					// Scans run after the update phase, so the corpus a scan
 					// observes is the one the update phase left behind.
@@ -198,7 +353,8 @@ pub(crate) fn compute(
 		handles.into_iter().map(|h| h.join().expect("ground-truth worker panicked")).collect()
 	})?;
 
-	let mut merged: Vec<TopK> = (0..queries.len()).map(|_| TopK::new(request.top_k)).collect();
+	let mut merged: Vec<TopK> =
+		(0..queries.len()).map(|_| TopK::new(storage_depth(request.top_k))).collect();
 	for partial in &partials {
 		for (slot, part) in merged.iter_mut().zip(partial.iter()) {
 			slot.merge(part);
@@ -410,8 +566,11 @@ mod test {
 					.map(|(n, v)| (n as u32, distance(metric, q, v)))
 					.collect();
 				all.sort_by(|a, b| a.1.total_cmp(&b.1));
+				// The key stores beyond `top_k` for the tie window; the strict
+				// answer is its prefix.
 				let expected: Vec<u32> = all[..top_k].iter().map(|(n, _)| *n).collect();
-				let got: Vec<u32> = gt.neighbours[qi].iter().map(|n| n.sample).collect();
+				let got: Vec<u32> =
+					gt.neighbours[qi].iter().take(top_k).map(|n| n.sample).collect();
 				assert_eq!(expected, got, "{metric:?} query {qi}");
 			}
 		}
@@ -425,7 +584,7 @@ mod test {
 		let queries = vp.generate_vectors("embedding", 2, 7).unwrap();
 		let gt = compute(&request(300, 8, VectorDistance::Euclidean), &vp, &queries).unwrap();
 		for row in &gt.neighbours {
-			assert_eq!(row.len(), 8);
+			assert_eq!(row.len(), storage_depth(8));
 			assert!(row.windows(2).all(|w| w[0].distance <= w[1].distance), "{row:?}");
 		}
 	}
@@ -484,6 +643,131 @@ mod test {
 			assert!(!seen.contains(&f), "fingerprint collision for {v:?}");
 			seen.push(f);
 		}
+	}
+
+	fn answer_key(rows: Vec<Vec<(u32, f32)>>) -> GroundTruth {
+		GroundTruth {
+			neighbours: rows
+				.into_iter()
+				.map(|r| {
+					r.into_iter()
+						.map(|(sample, distance)| Neighbour {
+							sample,
+							distance,
+						})
+						.collect()
+				})
+				.collect(),
+		}
+	}
+
+	fn integer_kp() -> KeyProvider {
+		KeyProvider::new(crate::KeyType::Integer, false)
+	}
+
+	/// Engines return keys, not sample indices, so tests have to address rows
+	/// the same way — the two are not the same number.
+	fn keys(kp: &KeyProvider, samples: &[u32]) -> Vec<KnnKey> {
+		samples.iter().map(|n| key_for(kp, *n)).collect()
+	}
+
+	#[test]
+	fn recall_counts_only_true_neighbours() {
+		let gt = answer_key(vec![vec![(1, 0.1), (2, 0.2), (3, 0.3), (9, 0.9), (8, 1.0), (7, 1.1)]]);
+		let kp = integer_kp();
+		let answers = build_answers(&gt, &kp, 3, 0.0);
+		let hit = |ids: &[u32]| -> Option<f64> { recall(&answers[0], &keys(&kp, ids)) };
+		assert_eq!(hit(&[1, 2, 3]), Some(1.0));
+		assert_eq!(hit(&[1, 2, 99]), Some(2.0 / 3.0));
+		assert_eq!(hit(&[97, 98, 99]), Some(0.0));
+		// Rows outside the true top-k earn nothing, even though the answer key
+		// stores them for the tie window.
+		assert_eq!(hit(&[9, 8, 7]), Some(0.0));
+	}
+
+	/// A near-tie at the k-th place should not read as a quality gap: engines
+	/// compute distances at different precisions and can legitimately swap the
+	/// rows straddling the cut.
+	#[test]
+	fn tie_epsilon_admits_a_boundary_neighbour() {
+		let gt = answer_key(vec![vec![(1, 0.10), (2, 0.20), (3, 0.2001), (4, 0.9)]]);
+		let kp = integer_kp();
+		let returned = keys(&kp, &[1, 3]);
+
+		let strict = build_answers(&gt, &kp, 2, 0.0);
+		assert_eq!(recall(&strict[0], &returned), Some(0.5));
+
+		let tolerant = build_answers(&gt, &kp, 2, 0.01);
+		assert_eq!(recall(&tolerant[0], &returned), Some(1.0));
+
+		// The tolerance must stay narrow: a genuinely distant row is still wrong.
+		assert_eq!(recall(&tolerant[0], &keys(&kp, &[1, 4])), Some(0.5));
+	}
+
+	/// Recall divides by the neighbours that exist, so a corpus smaller than k
+	/// is not scored as a miss.
+	#[test]
+	fn short_answer_key_is_not_penalised() {
+		let gt = answer_key(vec![vec![(1, 0.1), (2, 0.2)]]);
+		let kp = integer_kp();
+		let answers = build_answers(&gt, &kp, 10, 0.0);
+		assert_eq!(recall(&answers[0], &keys(&kp, &[1, 2])), Some(1.0));
+	}
+
+	/// Ground truth stores sample indices; scoring compares engine keys. The
+	/// mapping between them has to be the run's own KeyProvider or every hit
+	/// silently misses.
+	#[test]
+	fn answers_use_the_runs_key_shape() {
+		let gt = answer_key(vec![vec![(0, 0.1), (1, 0.2)]]);
+
+		let mut kp = KeyProvider::new(crate::KeyType::Integer, true);
+		let KeyProvider::UnorderedInteger(p) = &mut kp else {
+			panic!("expected an unordered integer provider");
+		};
+		let expected: Vec<KnnKey> = [0u32, 1].iter().map(|n| KnnKey::Integer(p.key(*n))).collect();
+		let answers = build_answers(&gt, &kp, 2, 0.0);
+		assert_eq!(recall(&answers[0], &expected), Some(1.0));
+
+		let mut string_kp = KeyProvider::new(crate::KeyType::String26, false);
+		let KeyProvider::OrderedString(sp) = &mut string_kp else {
+			panic!("expected an ordered string provider");
+		};
+		let expected: Vec<KnnKey> = [0u32, 1].iter().map(|n| KnnKey::Text(sp.key(*n))).collect();
+		let answers = build_answers(&gt, &string_kp, 2, 0.0);
+		assert_eq!(recall(&answers[0], &expected), Some(1.0));
+	}
+
+	#[test]
+	fn summary_reports_the_tail_not_just_the_mean() {
+		let mut tally = RecallTally::default();
+		for _ in 0..95 {
+			tally.record(1.0);
+		}
+		for _ in 0..5 {
+			tally.record(0.2);
+		}
+		let s = tally.summarise().unwrap();
+		assert_eq!(s.queries, 100);
+		assert!((s.mean - 0.96).abs() < 1e-9, "{}", s.mean);
+		// A mean of 0.96 hides a 5% tail answering at 0.2.
+		assert_eq!(s.p5, 0.2);
+		assert_eq!(s.min, 0.2);
+		assert!(RecallTally::default().summarise().is_none());
+	}
+
+	/// Tallies are merged across workers, so the summary must not depend on
+	/// which worker happened to score which query.
+	#[test]
+	fn tallies_merge_across_workers() {
+		let mut a = RecallTally::default();
+		a.record(1.0);
+		let mut b = RecallTally::default();
+		b.record(0.0);
+		a.merge(b);
+		let s = a.summarise().unwrap();
+		assert_eq!(s.queries, 2);
+		assert!((s.mean - 0.5).abs() < 1e-9);
 	}
 
 	#[test]


### PR DESCRIPTION
Closes the recall half of #284, and fixes #281 along the way.

An approximate index has a free parameter — `ef_search`, `l_search` — that buys latency with accuracy. Turn it down and any index wins any latency comparison. crud-bench measured only latency, so the vector rows could not distinguish a fast index from a broken one. That mattered more than expected: this branch caught a real correctness failure that the latency column alone would have read as the best result in the table.

## What it does

**A shared exact oracle.** Ground truth is computed by the harness and reused by every engine, rather than taken from each engine's own bruteforce leg. Scoring an engine against itself measures whether its index agrees with its own exact path — a useful regression signal, but not a figure that can sit beside another engine's, because a quirk shared by an engine's exact and approximate paths cancels out. A useful side effect: each engine's own bruteforce leg is scored too and should read `1.000`.

**A reproducible corpus.** Row content becomes a pure function of `(seed, stream, sample)`, so the same dataset is benchmarked across engines and across runs, and the corpus can be reconstructed locally for scoring instead of read back out of the database under test. Unseeded runs keep their previous behaviour.

**Queries generated, not read back.** Query vectors come from their own seed through the schema's own generator and are never inserted, so no query is its own nearest neighbour — previously every query matched itself at distance 0.

**Recall reported everywhere latency is** — `mean / 5th percentile` in the table, full figures in CSV, JSON and the comparison viewer. The 5th percentile is there because a mean can look healthy while a tail of queries is answered badly.

**A clustered generator.** `vector:<dim>:clustered:<n>` draws unit vectors from a mixture of clusters. Uniform components leave no neighbourhood structure: over 20k 128-d rows a query's nearest neighbour sits at 65% of a random pair's distance under `vector:128`, and at 8% under `vector:128:clustered:200`. Uniform data was *understating* the indexes — HNSW goes from 1.31x faster than a linear scan to 4.29x once the corpus has structure to descend through.

**Parameter sweeps.** `ef_search = [16, 32, 64, 128, 256]` expands to one timed leg per value over a **single** index build. A lone value is one arbitrary point on a curve; the comparison worth making is the curve.

**Per-scan concurrency.** `clients` and `threads` override the CLI settings for a scan's timed legs. Once warm, a KNN query answers in well under a millisecond, so at the usual concurrency these legs measure queueing rather than search — the same query timed 0.4ms at one client and roughly 1500ms at sixty-four.

## Measurement artifacts found and fixed

Most of this branch is not the recall arithmetic. It is the artifacts that had to be removed before a single number meant what it claimed:

| artifact | effect | fix |
|---|---|---|
| queries drawn from the corpus | every query self-matched at distance 0 | generate them, never insert |
| indexes queryable before compacted | queries answered by scanning a pending queue | wait on `building.pending` |
| cold index on the first timed leg | ~295ms vs ~0.5ms, *and* 0.935 recall vs 0.853 | warm until the rate plateaus |
| queueing at default concurrency | 0.4ms measured as ~1500ms | per-scan concurrency override |
| RediSearch still indexing | recall climbed 0.047 → 1.000 across legs as the indexer caught up; the exact leg scored **0.268** | poll `FT.INFO` until `indexing` clears |
| warm-up declaring victory early | a backlog improving <10% per window read as settled; leg timed against a half-built index | compare across a span of windows, not the last one |
| `samples` silently ignored in two shipped configs | `count_count_idx` ran `--samples` iterations against a `count` leg honouring 1000 | `deny_unknown_fields`; per-run `iterations` supported |

The cold-index one is worth reading twice: a cold index is not merely slower, it answers *differently* — more accurately — so a sweep would report its first point as both its worst latency and its best recall purely from position. Reversing a sweep's order is what identified it.

## What it caught

Scoring recall against an independent oracle immediately found a correctness failure in a candidate dependency. Identical code, identical seed, identical `m=16 ef_construction=200 ef_search=64`, N=5000:

| version | bruteforce | hnsw | diskann |
|---|---|---|---|
| 3.2.4 | 1.000 | **1.000** | 1.000 |
| 3.3.0-beta.3 | 1.000 | **0.002** | 1.000 |
| 3.3.0-beta.4 | 1.000 | **0.998** | 1.000 |

Reproduced at 5k, 10k and 20k. The failing leg runs *fast* — 0.35ms against bruteforce's 100ms — so on latency alone it looks like the best result in the table. This is the failure the recall axis exists to catch, and beta.4 carries the fix.

## Comparisons that were not comparable

The viewer aligned rows across result files on identity alone, so several ways of comparing incomparable numbers were reachable. Each is now reported as a mismatch: differing `corpus_seed`, differing `[value]` template (a new `template_digest` in metadata — the seed alone does not identify a corpus), differing effective per-scan `clients`/`threads`, and a differing `vector_query`, since `top_k`, the metric, the holdout and the tie tolerance each decide what counts as a correct answer.

`build_answers` also refuses to score when the answer key is truncated *and* every stored neighbour falls inside the tie window, rather than counting a legitimately-returned row as a miss. And `uuid` fields now draw from the seeded RNG; `Uuid::new_v4` took its own entropy, so a seeded template containing one — `config/vector.toml` has `request_id` — differed between runs and engines while `corpus_seed` asserted it did not.

## Dependency

Held at **3.2.4**. No newer published version is usable yet, and the recall axis and CI between them ruled out both candidates:

| version | problem |
|---|---|
| 3.3.0-beta.3 | HNSW recall **0.002** against 1.000 elsewhere, on a leg that runs *faster* than a correct one |
| 3.3.0-beta.4 | fixes that, but predates a RocksDB use-after-free: intermittent **segfault** on the string90 benchmark |

beta.4 was published 2026-09-09 22:52; surrealdb-private#1225, *"keep the transaction alive while its snapshot is read"*, merged 2026-09-10 00:13 — about eighty minutes later. A snapshot outliving its transaction is a use-after-free, which matches what CI showed: exit 139, intermittent (the same beta.4 passed one commit and failed the next), only string90 of five key types, not reproducible on macOS, and no `unsafe` anywhere in this diff.

**3.3.0-beta.5** should carry both fixes — recall by inheritance, RocksDB via the backport in surrealdb-private#1269 — and is worth taking in a follow-up once published.

`Cargo.toml` records the tracking policy: follow the published version closest to SurrealDB's `main`, prereleases included, since crud-bench exists to monitor SurrealDB as it is developed — gated on correctness. This also makes embedded and server mode consistent for the first time; server has always pulled the `nightly` image.

### #286's diagnosis was wrong, and its workaround is no longer needed

Measuring beta.4 corrected #286. An A/B on identical config, corpus and machine puts the two unindexed scan legs within 1.2-1.3x — this machine's run-to-run spread — and the *indexed* leg at 21.7x:

| leg | 3.2.4 | beta.4 | ratio |
|---|---|---|---|
| `count_count_idx` no-index | 9.511 ms | 8.011 ms | 1.2x |
| `count_count_idx` **indexed** | **8.231 ms** | **0.380 ms** | **21.7x** |

On 3.2.4 an indexed `COUNT` costs about what the unindexed scan costs, so the index buys nothing. It was never a full-table scan regression, which is what the issue title says. Reported there.

The CI string-key timeouts raised for it are **back to 5 minutes and staying there**, even though 3.2.4 is still pinned. They were raised because `count_count_idx` ran `--samples` (10,000) iterations instead of the configured 1,000 — the `samples` typo fixed in this branch. With that fixed the whole regression costs **0.12s**: on the same machine and corpus, 3.2.4 spends 0.57s across its COUNT legs against beta.4's 0.45s, and the string90 step runs **2m 41s on CI against a 5 minute limit**. A ten minute window for a tenth of a second would stop the timeout catching hangs.

## Verification

98 tests. `cargo fmt --all --check`, `cargo clippy --tests --all-features -- -D warnings`, and the default-features release build all clean. CI now exercises the whole vector path — ground truth, warm-up and recall on all three legs including DiskANN — which it never did before, because `config/ci.toml` had no seed.

A clean `ef_search` sweep, 50k clustered rows, one client:

| ef_search | mean | recall (mean / p5) |
|---|---|---|
| 10 | 0.22 ms | 0.854 / 0.70 |
| 40 | 0.28 ms | 0.996 / 1.00 |
| 200 | 0.52 ms | 1.000 / 1.00 |
| 1000 | 2.24 ms | 1.000 / 1.00 |

Monotonic in both axes, saturating at exact.

## Reviewing

29 commits, in order. Some record failed attempts — the warm-up took three iterations — kept because the reasoning is the useful part. Happy to squash or split; the dependency work, the Redis fix and the warm-up work are each separable from the recall core.

**Where a human read is most worth spending**, in priority order:

1. **`build_answers` in `src/vectorgt.rs`** — decides what counts as a correct answer, including the tie window and the refusal when the answer key is truncated inside it.
2. **`perScanMismatch` in `compare/index.html`** — decides which results may be compared at all.
3. **`warm_vector_index` in `src/benchmark.rs`** — its plateau heuristic is empirical rather than derived (25-query windows, a 10% threshold across a 4-window span, a ceiling of `samples / 50`), tuned against behaviour observed on one machine and most likely to misbehave on hardware I have not tested.

The first two earn that place for a specific reason. They went through four rounds of automated review, and **every finding after the first round was in code written to fix the previous finding**: the tie-window guard was too permissive, then too strict — and the test I wrote for it encoded the wrong behaviour, so it passed while asserting the bug; the concurrency check silently dropped result files that predated its fields; the spec check fired on every single run, including one file on its own. Each fix was plausible and wrong in a way my own tests did not catch.

They are now exercised against real result data rather than reasoned about, and the automated pass is clean. But a clean pass means it stopped finding things, not that the area is settled, and the reviewer of those two files is the first human to read them.

**One caveat on the numbers.** The 1M-scale figures quoted in this description came from a local path dependency on unreleased private `main`, which cannot be committed. Everything at 100k and below reproduces from this branch as it stands.

## Known gap, blocked upstream

`await_index_queryable` still polls `building.pending`, which is the wrong signal: it counts writes arriving *during* a `CONCURRENTLY` build, not work left to materialise. At 1M rows that produced query latencies 100-1000x steady state on an index reporting `ready`, which was briefly misread as an engine defect.

The engine-side fix is a `compacting` field in `INFO FOR INDEX` (surrealdb-private#1221, backported in #1278), but it is not in a published crate yet, so crud-bench cannot reach it. Tracked in #288, to land with the 3.3.0-beta.5 bump.

## Not in this PR

The standard-dataset loader, index footprint, filtered KNN, and adapters for dedicated vector engines — all tracked in #284.


